### PR TITLE
fix(backend): drop function before recreating with changed return type

### DIFF
--- a/backend/supabase/migrations/20260410000001_fix_memory_achievements_column_names.sql
+++ b/backend/supabase/migrations/20260410000001_fix_memory_achievements_column_names.sql
@@ -10,6 +10,10 @@
 
 BEGIN;
 
+-- Must DROP first because the existing function has different OUT parameter names
+-- (out_achievement_id, etc.) and PostgreSQL cannot change return type with CREATE OR REPLACE
+DROP FUNCTION IF EXISTS check_memory_achievements(UUID);
+
 CREATE OR REPLACE FUNCTION check_memory_achievements(p_user_id UUID)
 RETURNS TABLE (
     achievement_id TEXT,


### PR DESCRIPTION
## Summary
- Fixes `SQLSTATE 42P13` error during DB migration deployment
- Adds `DROP FUNCTION IF EXISTS check_memory_achievements(UUID)` before `CREATE OR REPLACE` because PostgreSQL cannot change OUT parameter names (from `out_*` prefixed to unprefixed) via `CREATE OR REPLACE`

## Test plan
- [ ] Re-run the deploy workflow and verify migration applies successfully
- [ ] Verify `check_memory_achievements` returns columns without `out_` prefix