### PR TITLE
fix: whatsnew, Unicode corruption, and language cache

### DIFF
--- a/distribution/whatsnew/whatsnew-en-IN
+++ b/distribution/whatsnew/whatsnew-en-IN
@@ -1,13 +1,11 @@
 🙏 Disciplefy - Beta Update
 
 ✨ What's New:
-• Memory Verses: unlimited verses, scroll to load more
-• Upgrade prompt shown before you start practice (not after)
-• Mastery levels are now easier to achieve
-• Learning path progress tracks actual completions
-
-• Voice Buddy: pause resumes from same position, no restart
-• Voice Buddy: drag the seek slider to jump within a section
-• Learning path guides (recommended mode) now free for all
+• New Epistles learning paths: Philippians, Ephesians, Galatians, 1 & 2 Peter, Corinthians and more
+• Language switch now updates all learning paths instantly
+• Incomplete study guides detected and handled gracefully
+• Token refund on failed or partial study generation
+• Faster study generation with optimized AI prompts
+• Duplicate learning paths merged for cleaner browsing
 
 📖 Keep growing in your faith!

--- a/distribution/whatsnew/whatsnew-en-US
+++ b/distribution/whatsnew/whatsnew-en-US
@@ -1,13 +1,11 @@
 🙏 Disciplefy - Beta Update
 
 ✨ What's New:
-• Memory Verses: unlimited verses, scroll to load more
-• Upgrade prompt shown before you start practice (not after)
-• Mastery levels are now easier to achieve
-• Learning path progress tracks actual completions
-
-• Voice Buddy: pause resumes from same position, no restart
-• Voice Buddy: drag the seek slider to jump within a section
-• Learning path guides (recommended mode) now free for all
+• New Epistles learning paths: Philippians, Ephesians, Galatians, 1 & 2 Peter, Corinthians and more
+• Language switch now updates all learning paths instantly
+• Incomplete study guides detected and handled gracefully
+• Token refund on failed or partial study generation
+• Faster study generation with optimized AI prompts
+• Duplicate learning paths merged for cleaner browsing
 
 📖 Keep growing in your faith!

--- a/distribution/whatsnew/whatsnew-hi-IN
+++ b/distribution/whatsnew/whatsnew-hi-IN
@@ -1,13 +1,10 @@
 🙏 Disciplefy - बीटा अपडेट
 
 ✨ नया क्या है:
-• वचन याद: जितने चाहें वचन जोड़ें, scroll से और लोड करें
-• अभ्यास शुरू करने से पहले अपग्रेड का popup दिखेगा
-• Mastery levels अब आसानी से हासिल करें
-• Learning path progress अब सही completions दिखाता है
-
-• Voice Buddy: pause करने पर वहीं से resume — शुरू से नहीं
-• Voice Buddy: slider खींचकर section में कहीं भी jump करें
-• Learning path guides (recommended mode) अब सभी के लिए free
+• नए पत्रियों के learning paths: फिलिप्पियों, इफिसियों, गलातियों, पतरस और अधिक
+• भाषा बदलने पर सभी learning paths तुरंत अपडेट
+• अधूरी study generation पर tokens वापस
+• बेहतर AI prompts से तेज़ generation
+• डुप्लीकेट learning paths मिलाकर साफ़ browsing
 
 📖 विश्वास में बढ़ते रहें!

--- a/distribution/whatsnew/whatsnew-ml-IN
+++ b/distribution/whatsnew/whatsnew-ml-IN
@@ -1,13 +1,10 @@
 🙏 Disciplefy - ബീറ്റ അപ്‌ഡേറ്റ്
 
 ✨ പുതിയത്:
-• വചന മനഃപാഠം: എത്ര വചനവും ചേർക്കൂ, scroll ചെയ്‌ത് കൂടുതൽ ലോഡ് ചെയ്യൂ
-• പരിശീലനം തുടങ്ങും മുമ്പ് upgrade popup കാണിക്കും
-• Mastery levels ഇനി എളുപ്പത്തിൽ നേടാം
-• Learning path progress ഇനി ശരിയായ completions കാണിക്കും
-
-• Voice Buddy: pause — അതേ സ്ഥാനത്ത് resume
-• Voice Buddy: slider വലിച്ച് section-ൽ jump ചെയ്യൂ
-• Learning path guides (recommended) എല്ലാവർക്കും free
+• പുതിയ ലേഖന learning paths: ഫിലിപ്പിയർ, എഫെസ്യർ, ഗലാത്യർ, പത്രോസ് തുടങ്ങിയവ
+• ഭാഷ മാറ്റുമ്പോൾ learning paths ഉടൻ അപ്‌ഡേറ്റ് ആകും
+• പരാജയപ്പെട്ട study generation-ന് tokens തിരികെ
+• മികച്ച AI prompts വഴി വേഗത്തിൽ generation
+• ഡ്യൂപ്ലിക്കേറ്റ് paths ലയിപ്പിച്ച് ക്ലീൻ browsing
 
 📖 വിശ്വാസ യാത്രയിൽ വളരൂ!


### PR DESCRIPTION
## Summary
- Update whatsnew release notes for epistle learning paths and language cache fixes
- Fix Unicode corruption in epistle translations (already in PR #271)
- Fix language-aware caching for learning paths (already in PR #271)

## Test plan
- [ ] Verify whatsnew text renders correctly in Play Store listing
- [ ] Verify Hindi/Malayalam character counts are under 500