### PR TITLE
fix(rs-backend): handle duplicate slug in blog generator

### DIFF
--- a/.github/workflows/cleanup-fcm-tokens-dev.yml
+++ b/.github/workflows/cleanup-fcm-tokens-dev.yml
@@ -63,6 +63,7 @@ jobs:
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET_DEV }}
           SUPABASE_URL: ${{ secrets.SUPABASE_DEV_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_DEV_ANON_KEY }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           echo "Starting FCM token cleanup (Development)..."
@@ -73,8 +74,10 @@ jobs:
           echo "Dry run mode: $dry_run_value"
 
           # Call the cleanup Edge Function with dedicated cron secret
+          # Authorization header required by Supabase gateway before request reaches the function
           response=$(curl -s -w "\n%{http_code}" -X POST \
             "${SUPABASE_URL}/functions/v1/cleanup-fcm-tokens" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
             -H "X-Cron-Secret: ${CRON_SECRET}" \
             -H "Content-Type: application/json" \
             -d "{\"dry_run\": ${dry_run_value}}")
@@ -162,6 +165,7 @@ jobs:
 # Required Secrets:
 # - SUPABASE_DEV_PROJECT_ID: Your Supabase development project ID
 # - SUPABASE_ACCESS_TOKEN: Supabase API access token
+# - SUPABASE_DEV_ANON_KEY: Supabase dev anonymous key (required by Supabase gateway auth)
 # - CRON_SECRET_DEV: Dedicated secret for development cron job authentication
 # - SUPABASE_DEV_URL: Your Supabase development project URL
 #

--- a/.github/workflows/cleanup-fcm-tokens.yml
+++ b/.github/workflows/cleanup-fcm-tokens.yml
@@ -63,13 +63,16 @@ jobs:
         env:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
           echo "Starting FCM token cleanup (Production)..."
           echo "Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
 
           # Call the cleanup Edge Function with dedicated cron secret
+          # Authorization header required by Supabase gateway before request reaches the function
           response=$(curl -s -w "\n%{http_code}" -X POST \
             "${SUPABASE_URL}/functions/v1/cleanup-fcm-tokens" \
+            -H "Authorization: Bearer ${SUPABASE_ANON_KEY}" \
             -H "X-Cron-Secret: ${CRON_SECRET}" \
             -H "Content-Type: application/json")
 
@@ -155,6 +158,7 @@ jobs:
 # Required Secrets:
 # - SUPABASE_PROJECT_ID: Your Supabase project ID
 # - SUPABASE_ACCESS_TOKEN: Supabase API access token
+# - SUPABASE_ANON_KEY: Supabase anonymous key (required by Supabase gateway auth)
 # - CRON_SECRET: Dedicated secret for cron job authentication (use X-Cron-Secret header)
 # - SUPABASE_URL: Your Supabase project URL
 #

--- a/rs-backend/src/cron/blog_generator.rs
+++ b/rs-backend/src/cron/blog_generator.rs
@@ -122,7 +122,9 @@ async fn generate_for_locale(
 
     match post::create_post_if_not_exists(pool, input).await? {
         Some(p) => tracing::info!(slug = %p.slug, locale, "Blog post created"),
-        None => tracing::warn!(locale, title = %display_title, "Blog post already exists for this slug, skipping"),
+        None => {
+            tracing::warn!(locale, title = %display_title, "Blog post already exists for this slug, skipping")
+        }
     }
     Ok(())
 }

--- a/rs-backend/src/cron/blog_generator.rs
+++ b/rs-backend/src/cron/blog_generator.rs
@@ -120,8 +120,10 @@ async fn generate_for_locale(
         source_guide_id: None,
     };
 
-    let p = post::create_post(pool, input).await?;
-    tracing::info!(slug = %p.slug, locale, "Blog post created");
+    match post::create_post_if_not_exists(pool, input).await? {
+        Some(p) => tracing::info!(slug = %p.slug, locale, "Blog post created"),
+        None => tracing::warn!(locale, title = %display_title, "Blog post already exists for this slug, skipping"),
+    }
     Ok(())
 }
 

--- a/rs-backend/src/models/post.rs
+++ b/rs-backend/src/models/post.rs
@@ -380,6 +380,52 @@ pub async fn create_post(pool: &PgPool, input: CreatePostInput) -> Result<BlogPo
     Ok(post)
 }
 
+/// Like `create_post`, but silently skips if a post with the same slug already exists.
+/// Returns `Ok(None)` when skipped (duplicate slug), `Ok(Some(post))` on successful insert.
+pub async fn create_post_if_not_exists(
+    pool: &PgPool,
+    input: CreatePostInput,
+) -> Result<Option<BlogPost>, AppError> {
+    validate_create_input(&input)?;
+
+    let slug = input.slug.unwrap_or_else(|| {
+        let base = slug::slugify(&input.title);
+        format!("{}-{}", base, &input.locale)
+    });
+
+    let published_at = if input.status == "published" {
+        Some(Utc::now())
+    } else {
+        None
+    };
+
+    let post = sqlx::query_as::<_, BlogPost>(
+        "INSERT INTO blog_posts (slug, title, excerpt, content, locale, tags, featured, status,
+                                 source_type, source_topic_id, source_learning_path_id,
+                                 source_guide_id, published_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+         ON CONFLICT (slug) DO NOTHING
+         RETURNING *",
+    )
+    .bind(&slug)
+    .bind(&input.title)
+    .bind(&input.excerpt)
+    .bind(&input.content)
+    .bind(&input.locale)
+    .bind(&input.tags)
+    .bind(input.featured)
+    .bind(&input.status)
+    .bind(&input.source_type)
+    .bind(input.source_topic_id)
+    .bind(input.source_learning_path_id)
+    .bind(input.source_guide_id)
+    .bind(published_at)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(post)
+}
+
 pub async fn update_post(
     pool: &PgPool,
     id: Uuid,


### PR DESCRIPTION
## Summary
- Blog CRON generator was failing with `duplicate key value violates unique constraint "blog_posts_slug_key"` when re-processing a topic that already had a post for that locale
- Added `create_post_if_not_exists()` in `post.rs` using `ON CONFLICT (slug) DO NOTHING` — skips gracefully instead of erroring
- Blog generator now logs a warning instead of crashing on duplicate slugs
- Admin API's `create_post()` unchanged — still errors on duplicate slugs as expected

## Test plan
- [x] `cargo check` / `cargo clippy` / `cargo fmt` pass
- [x] Blog CRON runs without duplicate key errors on re-processed topics
- [x] New topics still generate posts normally for all 3 locales