### PR TITLE
fix(rs-backend): CRON blog generator slug-check loop to skip done topics

### DIFF
--- a/rs-backend/src/cron/blog_generator.rs
+++ b/rs-backend/src/cron/blog_generator.rs
@@ -10,6 +10,7 @@ use crate::services::{content_formatter, study_api};
 const LOCALES: &[&str] = &["en", "hi", "ml"];
 
 #[derive(Debug, Clone, sqlx::FromRow)]
+#[allow(dead_code)]
 pub struct LearningPathTopic {
     pub id: Uuid,
     /// The recommended_topics.id — used as source_topic_id in blog_posts
@@ -104,7 +105,6 @@ async fn generate_for_locale(
         locale,
     );
 
-    // Always derive the slug from the English title so it stays URL-friendly
     let slug = format!("{}-{}", slug::slugify(&topic.title), locale);
 
     let input = post::CreatePostInput {
@@ -115,7 +115,7 @@ async fn generate_for_locale(
         tags: blog.tags,
         featured: false,
         status: "published".to_string(),
-        slug: Some(slug),
+        slug: Some(slug.clone()),
         source_type: Some("learning_path_topic".to_string()),
         source_topic_id: Some(topic.topic_id),
         source_learning_path_id: Some(topic.path_id),
@@ -125,7 +125,9 @@ async fn generate_for_locale(
     match post::create_post_if_not_exists(pool, input).await? {
         Some(p) => tracing::info!(slug = %p.slug, locale, "Blog post created"),
         None => {
-            tracing::warn!(locale, title = %display_title, "Blog post already exists for this slug, skipping")
+            // Slug conflict — tag existing post so topic is marked done
+            post::tag_existing_post_source(pool, &slug, topic.topic_id, topic.path_id).await?;
+            tracing::info!(locale, slug = %slug, "Slug existed, tagged with source");
         }
     }
     Ok(())
@@ -136,84 +138,100 @@ async fn generate_for_locale(
 pub async fn run_blog_retry(pool: &PgPool, config: &Config, http: &Client) -> Result<(), AppError> {
     tracing::info!("Starting blog retry CRON job");
 
-    let topic = match post::find_next_partially_generated_topic(pool).await? {
-        Some(t) => t,
-        None => {
-            tracing::info!("No partially-generated topics found — nothing to retry");
-            return Ok(());
+    const MAX_SKIP_ATTEMPTS: usize = 10;
+
+    for attempt in 0..MAX_SKIP_ATTEMPTS {
+        let topic = match post::find_next_partially_generated_topic(pool).await? {
+            Some(t) => t,
+            None => {
+                tracing::info!("No partially-generated topics found — nothing to retry");
+                return Ok(());
+            }
+        };
+
+        // Check which locales actually need generation (by slug existence)
+        let mut missing_locales: Vec<&str> = Vec::new();
+        for locale in LOCALES {
+            let slug = format!("{}-{}", slug::slugify(&topic.title), locale);
+            if !post::slug_exists(pool, &slug).await? {
+                missing_locales.push(locale);
+            } else {
+                post::tag_existing_post_source(pool, &slug, topic.topic_id, topic.path_id).await?;
+            }
         }
-    };
 
-    tracing::info!(topic = %topic.title, "Found partially-generated topic, retrying missing locales");
+        if missing_locales.is_empty() {
+            tracing::info!(
+                topic = %topic.title,
+                attempt,
+                "All locale slugs exist (retry), tagged and skipping"
+            );
+            continue;
+        }
 
-    let already_generated = post::get_generated_locales(pool, topic.id).await?;
-    let missing_locales: Vec<&str> = LOCALES
-        .iter()
-        .copied()
-        .filter(|l| !already_generated.contains(&l.to_string()))
-        .collect();
+        tracing::info!(
+            topic = %topic.title,
+            missing = ?missing_locales,
+            "Retrying missing locales in parallel"
+        );
 
-    if missing_locales.is_empty() {
-        tracing::info!(topic = %topic.title, "All locales already generated, skipping");
+        let mut handles = Vec::with_capacity(missing_locales.len());
+
+        for locale in missing_locales {
+            let locale = locale.to_string();
+            let http = http.clone();
+            let config = config.clone();
+            let pool = pool.clone();
+            let topic = topic.clone();
+
+            let handle = tokio::spawn(async move {
+                let result = generate_for_locale(&http, &config, &pool, &topic, &locale).await;
+                (locale, result)
+            });
+            handles.push(handle);
+        }
+
+        let mut generated = 0usize;
+        let mut failed = 0usize;
+
+        for handle in handles {
+            match handle.await {
+                Ok((locale, Ok(()))) => {
+                    tracing::info!(locale, "Locale retried successfully");
+                    generated += 1;
+                }
+                Ok((locale, Err(e))) => {
+                    tracing::error!(locale, "Retry failed: {}", e);
+                    failed += 1;
+                }
+                Err(e) => {
+                    tracing::error!("Retry task panicked: {}", e);
+                    failed += 1;
+                }
+            }
+        }
+
+        tracing::info!(
+            generated,
+            failed,
+            topic = %topic.title,
+            "Blog retry complete"
+        );
+
         return Ok(());
     }
 
-    tracing::info!(
-        topic = %topic.title,
-        missing = ?missing_locales,
-        already_done = ?already_generated,
-        "Retrying missing locales in parallel"
-    );
-
-    let mut handles = Vec::with_capacity(missing_locales.len());
-
-    for locale in missing_locales {
-        let locale = locale.to_string();
-        let http = http.clone();
-        let config = config.clone();
-        let pool = pool.clone();
-        let topic = topic.clone();
-
-        let handle = tokio::spawn(async move {
-            let result = generate_for_locale(&http, &config, &pool, &topic, &locale).await;
-            (locale, result)
-        });
-        handles.push(handle);
-    }
-
-    let mut generated = 0usize;
-    let mut failed = 0usize;
-
-    for handle in handles {
-        match handle.await {
-            Ok((locale, Ok(()))) => {
-                tracing::info!(locale, "Locale retried successfully");
-                generated += 1;
-            }
-            Ok((locale, Err(e))) => {
-                tracing::error!(locale, "Retry failed: {}", e);
-                failed += 1;
-            }
-            Err(e) => {
-                tracing::error!("Retry task panicked: {}", e);
-                failed += 1;
-            }
-        }
-    }
-
-    tracing::info!(
-        generated,
-        failed,
-        topic = %topic.title,
-        "Blog retry complete"
-    );
-
+    tracing::warn!("Blog retry: exhausted skip attempts without finding a topic to retry");
     Ok(())
 }
 
 /// Main blog generation function -- called by CRON scheduler or manual trigger.
 /// Generates posts for ONE topic per run (all missing locales in parallel),
 /// picking the next topic that is missing at least one locale.
+///
+/// Uses a loop to skip topics whose slugs already exist in the DB (even if
+/// `source_topic_id` tracking is stale). Tags skipped topics so future runs
+/// skip them via the SQL query directly.
 pub async fn run_blog_generation(
     pool: &PgPool,
     config: &Config,
@@ -221,82 +239,97 @@ pub async fn run_blog_generation(
 ) -> Result<(), AppError> {
     tracing::info!("Starting blog generation CRON job");
 
-    // 1. Find the next topic that is missing at least one locale
-    let topic = match post::find_next_ungenerated_topic(pool).await? {
-        Some(t) => t,
-        None => {
-            tracing::info!(
-                "All topics already have blog posts for all locales — nothing to generate"
-            );
-            return Ok(());
+    const MAX_SKIP_ATTEMPTS: usize = 20;
+
+    for attempt in 0..MAX_SKIP_ATTEMPTS {
+        // 1. Find the next topic that the SQL query thinks is missing locales
+        let topic = match post::find_next_ungenerated_topic(pool).await? {
+            Some(t) => t,
+            None => {
+                tracing::info!(
+                    "All topics already have blog posts for all locales — nothing to generate"
+                );
+                return Ok(());
+            }
+        };
+
+        // 2. Check which locales actually need generation (by slug existence)
+        let mut missing_locales: Vec<&str> = Vec::new();
+        for locale in LOCALES {
+            let slug = format!("{}-{}", slug::slugify(&topic.title), locale);
+            if !post::slug_exists(pool, &slug).await? {
+                missing_locales.push(locale);
+            } else {
+                // Tag existing post so SQL query skips this topic next time
+                post::tag_existing_post_source(pool, &slug, topic.topic_id, topic.path_id).await?;
+            }
         }
-    };
 
-    tracing::info!(topic = %topic.title, "Found topic with missing locales");
+        if missing_locales.is_empty() {
+            tracing::info!(
+                topic = %topic.title,
+                attempt,
+                "All locale slugs exist, tagged and skipping to next topic"
+            );
+            continue;
+        }
 
-    // 2. Determine which locales are still missing
-    let already_generated = post::get_generated_locales(pool, topic.id).await?;
-    let missing_locales: Vec<&str> = LOCALES
-        .iter()
-        .copied()
-        .filter(|l| !already_generated.contains(&l.to_string()))
-        .collect();
+        // 3. Generate missing locales
+        tracing::info!(
+            topic = %topic.title,
+            missing = ?missing_locales,
+            "Generating missing locales in parallel"
+        );
 
-    if missing_locales.is_empty() {
-        tracing::info!(topic = %topic.title, "All locales already generated, skipping");
+        let mut handles = Vec::with_capacity(missing_locales.len());
+
+        for locale in missing_locales {
+            let locale = locale.to_string();
+            let http = http.clone();
+            let config = config.clone();
+            let pool = pool.clone();
+            let topic = topic.clone();
+
+            let handle = tokio::spawn(async move {
+                let result = generate_for_locale(&http, &config, &pool, &topic, &locale).await;
+                (locale, result)
+            });
+            handles.push(handle);
+        }
+
+        let mut generated = 0usize;
+        let mut failed = 0usize;
+
+        for handle in handles {
+            match handle.await {
+                Ok((locale, Ok(()))) => {
+                    tracing::info!(locale, "Locale generated successfully");
+                    generated += 1;
+                }
+                Ok((locale, Err(e))) => {
+                    tracing::error!(locale, "Study API failed: {}", e);
+                    failed += 1;
+                }
+                Err(e) => {
+                    tracing::error!("Generation task panicked: {}", e);
+                    failed += 1;
+                }
+            }
+        }
+
+        tracing::info!(
+            generated,
+            failed,
+            topic = %topic.title,
+            "Blog generation complete"
+        );
+
         return Ok(());
     }
 
-    tracing::info!(
-        topic = %topic.title,
-        missing = ?missing_locales,
-        already_done = ?already_generated,
-        "Generating missing locales in parallel"
+    tracing::warn!(
+        "Exhausted {} skip attempts without finding a topic to generate",
+        MAX_SKIP_ATTEMPTS
     );
-
-    // 3. Spawn one task per missing locale and run them in parallel
-    let mut handles = Vec::with_capacity(missing_locales.len());
-
-    for locale in missing_locales {
-        let locale = locale.to_string();
-        let http = http.clone();
-        let config = config.clone();
-        let pool = pool.clone();
-        let topic = topic.clone();
-
-        let handle = tokio::spawn(async move {
-            let result = generate_for_locale(&http, &config, &pool, &topic, &locale).await;
-            (locale, result)
-        });
-        handles.push(handle);
-    }
-
-    let mut generated = 0usize;
-    let mut failed = 0usize;
-
-    for handle in handles {
-        match handle.await {
-            Ok((locale, Ok(()))) => {
-                tracing::info!(locale, "Locale generated successfully");
-                generated += 1;
-            }
-            Ok((locale, Err(e))) => {
-                tracing::error!(locale, "Study API failed: {}", e);
-                failed += 1;
-            }
-            Err(e) => {
-                tracing::error!("Generation task panicked: {}", e);
-                failed += 1;
-            }
-        }
-    }
-
-    tracing::info!(
-        generated,
-        failed,
-        topic = %topic.title,
-        "Blog generation complete"
-    );
-
     Ok(())
 }

--- a/rs-backend/src/models/post.rs
+++ b/rs-backend/src/models/post.rs
@@ -585,6 +585,40 @@ pub async fn create_post_if_not_exists(
     Ok(post)
 }
 
+/// Returns true if a blog post with the given slug already exists.
+pub async fn slug_exists(pool: &PgPool, slug: &str) -> Result<bool, AppError> {
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM blog_posts WHERE slug = $1)")
+            .bind(slug)
+            .fetch_one(pool)
+            .await?;
+    Ok(exists)
+}
+
+/// Tags an existing blog post (found by slug) with source tracking fields.
+/// Used when the CRON hits a slug conflict — ensures the topic is marked as "done"
+/// so the next CRON run doesn't re-pick it.
+pub async fn tag_existing_post_source(
+    pool: &PgPool,
+    slug: &str,
+    source_topic_id: Uuid,
+    source_learning_path_id: Uuid,
+) -> Result<(), AppError> {
+    sqlx::query(
+        "UPDATE blog_posts
+         SET source_topic_id = $2,
+             source_learning_path_id = $3,
+             source_type = 'learning_path_topic'
+         WHERE slug = $1",
+    )
+    .bind(slug)
+    .bind(source_topic_id)
+    .bind(source_learning_path_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 pub async fn update_post(
     pool: &PgPool,
     id: Uuid,
@@ -736,27 +770,6 @@ pub async fn find_next_partially_generated_topic(
     .fetch_optional(pool)
     .await?;
     Ok(topic)
-}
-
-/// Returns the list of locales that already have blog posts for the given topic.
-/// Checks the recommended_topics.id (topic_id) AND all lpt.id values for that topic
-/// to handle old records (stored any lpt.id) and new records (store topic_id).
-pub async fn get_generated_locales(pool: &PgPool, lpt_id: Uuid) -> Result<Vec<String>, AppError> {
-    let locales: Vec<String> = sqlx::query_scalar(
-        "SELECT DISTINCT bp.locale FROM blog_posts bp
-         WHERE (
-             bp.source_topic_id = (SELECT topic_id FROM learning_path_topics WHERE id = $1)
-             OR bp.source_topic_id IN (
-                 SELECT x.id FROM learning_path_topics x
-                 WHERE x.topic_id = (SELECT topic_id FROM learning_path_topics WHERE id = $1)
-             )
-         )
-         AND bp.locale = ANY(ARRAY['en', 'hi', 'ml'])",
-    )
-    .bind(lpt_id)
-    .fetch_all(pool)
-    .await?;
-    Ok(locales)
 }
 
 /// Fetch a study guide by ID with all columns needed for blog generation.


### PR DESCRIPTION
## Summary
- CRON now checks slug existence before making LLM calls — skips topics that already have posts
- Loops through topics until it finds one with genuinely missing locales (max 20 iterations)
- Tags existing posts with `source_topic_id` so SQL query skips them on future runs (self-healing)
- Same pattern applied to retry CRON
- Removed stale `get_generated_locales` function (replaced by slug checks)

## Test plan
- [x] Local test: CRON picks "Daily Devotions" (no existing slugs), generates ML successfully
- [ ] Deploy and verify CRON advances past "The Great Commission" to new topics
- [ ] Verify no wasted LLM calls on already-existing posts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blog post generation reliability by implementing bounded retry logic to handle incomplete posts and source tracking inconsistencies.

* **Enhancements**
  * Enhanced slug conflict handling: existing posts with duplicate slugs are now properly tagged with source identifiers instead of being skipped, improving content tracking and attribution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fennsaji/disciplefy/pull/285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->