### PR TITLE
fix(rs-backend): CRON blog generator - slug check + exclusion list

### DIFF
--- a/rs-backend/src/cron/blog_generator.rs
+++ b/rs-backend/src/cron/blog_generator.rs
@@ -139,9 +139,10 @@ pub async fn run_blog_retry(pool: &PgPool, config: &Config, http: &Client) -> Re
     tracing::info!("Starting blog retry CRON job");
 
     const MAX_SKIP_ATTEMPTS: usize = 10;
+    let mut excluded_ids: Vec<Uuid> = Vec::new();
 
     for attempt in 0..MAX_SKIP_ATTEMPTS {
-        let topic = match post::find_next_partially_generated_topic(pool).await? {
+        let topic = match post::find_next_partially_generated_topic(pool, &excluded_ids).await? {
             Some(t) => t,
             None => {
                 tracing::info!("No partially-generated topics found — nothing to retry");
@@ -166,6 +167,7 @@ pub async fn run_blog_retry(pool: &PgPool, config: &Config, http: &Client) -> Re
                 attempt,
                 "All locale slugs exist (retry), tagged and skipping"
             );
+            excluded_ids.push(topic.id);
             continue;
         }
 
@@ -240,10 +242,11 @@ pub async fn run_blog_generation(
     tracing::info!("Starting blog generation CRON job");
 
     const MAX_SKIP_ATTEMPTS: usize = 20;
+    let mut excluded_ids: Vec<Uuid> = Vec::new();
 
     for attempt in 0..MAX_SKIP_ATTEMPTS {
-        // 1. Find the next topic that the SQL query thinks is missing locales
-        let topic = match post::find_next_ungenerated_topic(pool).await? {
+        // 1. Find the next topic, excluding already-tried IDs from this run
+        let topic = match post::find_next_ungenerated_topic(pool, &excluded_ids).await? {
             Some(t) => t,
             None => {
                 tracing::info!(
@@ -271,6 +274,7 @@ pub async fn run_blog_generation(
                 attempt,
                 "All locale slugs exist, tagged and skipping to next topic"
             );
+            excluded_ids.push(topic.id);
             continue;
         }
 

--- a/rs-backend/src/models/post.rs
+++ b/rs-backend/src/models/post.rs
@@ -684,6 +684,7 @@ pub async fn unpublish_post(pool: &PgPool, id: Uuid) -> Result<BlogPost, AppErro
 
 pub async fn find_next_ungenerated_topic(
     pool: &PgPool,
+    exclude_ids: &[Uuid],
 ) -> Result<Option<crate::cron::blog_generator::LearningPathTopic>, AppError> {
     let topic = sqlx::query_as::<_, crate::cron::blog_generator::LearningPathTopic>(
         "SELECT lpt.id, lpt.topic_id, rt.title, rt.description, rt.input_type,
@@ -710,6 +711,7 @@ pub async fn find_next_ungenerated_topic(
          LEFT JOIN learning_path_translations ml_lp
                ON ml_lp.learning_path_id = lp.id AND ml_lp.lang_code = 'ml'
          WHERE lp.is_active = true AND rt.is_active = true
+           AND lpt.id != ALL($1)
            AND (
                SELECT COUNT(DISTINCT bp.locale) FROM blog_posts bp
                WHERE (
@@ -721,6 +723,7 @@ pub async fn find_next_ungenerated_topic(
          ORDER BY lp.display_order, lpt.position
          LIMIT 1",
     )
+    .bind(exclude_ids)
     .fetch_optional(pool)
     .await?;
     Ok(topic)
@@ -730,6 +733,7 @@ pub async fn find_next_ungenerated_topic(
 /// three). Used by the retry cron to avoid generating brand-new topics.
 pub async fn find_next_partially_generated_topic(
     pool: &PgPool,
+    exclude_ids: &[Uuid],
 ) -> Result<Option<crate::cron::blog_generator::LearningPathTopic>, AppError> {
     let topic = sqlx::query_as::<_, crate::cron::blog_generator::LearningPathTopic>(
         "SELECT lpt.id, lpt.topic_id, rt.title, rt.description, rt.input_type,
@@ -756,6 +760,7 @@ pub async fn find_next_partially_generated_topic(
          LEFT JOIN learning_path_translations ml_lp
                ON ml_lp.learning_path_id = lp.id AND ml_lp.lang_code = 'ml'
          WHERE lp.is_active = true AND rt.is_active = true
+           AND lpt.id != ALL($1)
            AND (
                SELECT COUNT(DISTINCT bp.locale) FROM blog_posts bp
                WHERE (
@@ -767,6 +772,7 @@ pub async fn find_next_partially_generated_topic(
          ORDER BY lp.display_order, lpt.position
          LIMIT 1",
     )
+    .bind(exclude_ids)
     .fetch_optional(pool)
     .await?;
     Ok(topic)


### PR DESCRIPTION
## Summary
- CRON now checks slug existence before making LLM calls — skips topics that already have posts
- Adds exclusion list (`lpt.id != ALL($1)`) so the loop never re-picks the same topic within a run
- Tags existing posts with `source_topic_id` for self-healing on future runs
- Same pattern applied to retry CRON
- Replaces blog filter pills with compact dropdowns on marketing site

## Test plan
- [x] Local test: CRON picks correct topic, generates ML successfully
- [ ] Deploy and verify CRON advances past stuck topics to generate new blogs
- [ ] Verify no wasted LLM calls on already-existing posts