### PR TITLE
fix(db): set Corinthians recommended_mode to standard

### DIFF
--- a/backend/supabase/migrations/20260511000001_fix_corinthians_recommended_mode.sql
+++ b/backend/supabase/migrations/20260511000001_fix_corinthians_recommended_mode.sql
@@ -1,0 +1,3 @@
+UPDATE learning_paths
+SET recommended_mode = 'standard'
+WHERE id = 'aaa00000-0000-0000-0000-000000000041';


### PR DESCRIPTION
## Summary
- Migration to update Corinthians learning path `recommended_mode` from `deep` to `standard`
- Aligns it with all other 40 learning paths

## Test plan
- [x] Run `supabase db push` on production
- [x] Verify `SELECT recommended_mode FROM learning_paths WHERE id = 'aaa00000-0000-0000-0000-000000000041'` returns `standard`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed learning path recommendation mode configuration to ensure the correct default mode is applied.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fennsaji/disciplefy/pull/289)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->