### PR TITLE
feat: native Sign in with Apple + working iOS CI signing

### DIFF
--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -314,8 +314,10 @@ skip_nonce_check = true
 # signInWithOAuth scopes param + access_type=offline to get providerRefreshToken.
 
 [auth.external.apple]
-enabled = false
-client_id = ""
+enabled = true
+# Native Sign in with Apple: the idToken audience is the app bundle ID.
+# (Add a Services ID here too, comma-separated, if web Apple OAuth is added later.)
+client_id = "com.disciplefy.biblestudy"
 # DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
 secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
 # Overrides the default auth redirectUrl.

--- a/docs/deployment/APP_STORE_DEPLOYMENT.md
+++ b/docs/deployment/APP_STORE_DEPLOYMENT.md
@@ -119,6 +119,25 @@ Reuse existing secrets: `SUPABASE_PROJECT_REF`, `SUPABASE_ANON_KEY`, `GOOGLE_CLO
 
 ---
 
+## Authentication providers (native, via `signInWithIdToken`)
+
+Both social logins use the **native** Supabase ID-token flow, not web OAuth. For each, Supabase's provider **Client IDs** list must include the platform client ID whose value becomes the idToken's `aud`:
+
+| Provider | idToken `aud` on iOS | Supabase "Client IDs" must include |
+|----------|----------------------|-----------------------------------|
+| Google | iOS OAuth client (`...mlgetf72t019...`) | the **iOS** client ID (Android works off the web client) |
+| Apple | app **bundle ID** | `com.disciplefy.biblestudy` |
+
+**Production dashboard setup (one-time):**
+- **Google** → Authentication → Providers → Google → *Client IDs*: comma-separated list including the **iOS** client. (Without it, iOS Google login fails with "Something went wrong" while Android works.)
+- **Apple** → Authentication → Providers → Apple → enable, and add `com.disciplefy.biblestudy` to *Client IDs*. No client secret needed for the native flow (that's only for web Apple OAuth). The app sends a hashed nonce to Apple + raw nonce to Supabase, so leave "Skip nonce checks" **off**.
+
+`config.toml` mirrors this for local dev (`[auth.external.google]`, `[auth.external.apple]`). Keep the dashboard and `config.toml` in sync if you manage config via `supabase config push`.
+
+Apple Sign-In is **required by App Store Guideline 4.8** whenever another social login is offered. The button is iOS-only (`Platform.isIOS`) and uses `sign_in_with_apple` + `signInWithIdToken`.
+
+---
+
 ## Gotchas
 
 - iOS CI **must** run on macOS runners (more GH minutes than Android's ubuntu).

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -52,11 +52,17 @@ platform :ios do
   # --- helpers -------------------------------------------------------------
 
   def asc_api_key
+    # Decode the base64 .p8 to a real file. Spaceship (match) can use key_content,
+    # but altool (upload_to_testflight) needs the key as a PEM file on disk —
+    # handing it the base64 string causes "file isn't in the correct format (259)".
+    require "base64"
+    require "tmpdir"
+    key_path = File.expand_path("fastlane_asc_api_key.p8", Dir.tmpdir)
+    File.write(key_path, Base64.decode64(ENV["APP_STORE_CONNECT_API_KEY_BASE64"]))
     app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY_BASE64"],
-      is_key_content_base64: true,
+      key_filepath: key_path,
       in_house: false
     )
   end

--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -10,6 +10,7 @@
 default_platform(:ios)
 
 APP_IDENTIFIER = "com.disciplefy.biblestudy"
+TEAM_ID        = "4V6VA2U9MW"
 WORKSPACE      = "Runner.xcworkspace"
 SCHEME         = "Runner"
 MATCH_PROFILE  = "match AppStore #{APP_IDENTIFIER}"
@@ -70,16 +71,29 @@ platform :ios do
   end
 
   def build_ios
+    # The project ships with automatic signing, which on CI tries to create a
+    # *development* profile and needs a logged-in Apple ID. Switch the Runner
+    # target to manual signing so the archive uses the match distribution profile.
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: "Runner.xcodeproj",
+      team_id: TEAM_ID,
+      code_sign_identity: "Apple Distribution",
+      profile_name: MATCH_PROFILE,
+      bundle_identifier: APP_IDENTIFIER,
+      targets: ["Runner"]
+    )
+
     build_app(
       workspace: WORKSPACE,
       scheme: SCHEME,
       configuration: "Release",
       export_method: "app-store",
-      export_options: {
-        provisioningProfiles: { APP_IDENTIFIER => MATCH_PROFILE }
-      },
       # Flutter already compiled via `flutter build ios --no-codesign`; gym re-archives.
-      xcargs: "-allowProvisioningUpdates"
+      export_options: {
+        signingStyle: "manual",
+        provisioningProfiles: { APP_IDENTIFIER => MATCH_PROFILE }
+      }
     )
   end
 end

--- a/frontend/lib/core/i18n/app_translations.dart
+++ b/frontend/lib/core/i18n/app_translations.dart
@@ -313,6 +313,7 @@ class AppTranslations {
       'welcome': 'Welcome to Disciplefy',
       'subtitle': 'Deepen your faith through guided Bible study',
       'continue_with_google': 'Continue with Google',
+      'continue_with_apple': 'Continue with Apple',
       'features_title': 'What you\'ll get:',
       'feature_ai_study_guides': 'Personalized Study Guides',
       'feature_ai_study_guides_subtitle':
@@ -2295,6 +2296,7 @@ class AppTranslations {
       'welcome': 'Disciplefy में आपका स्वागत है',
       'subtitle': 'निर्देशित बाइबिल अध्ययन से अपने विश्वास को बढ़ाएं',
       'continue_with_google': 'Google के साथ जारी रखें',
+      'continue_with_apple': 'Apple के साथ जारी रखें',
       'features_title': 'आपको क्या मिलेगा:',
       'feature_ai_study_guides': 'व्यक्तिगत अध्ययन गाइड',
       'feature_ai_study_guides_subtitle': 'किसी भी आयत की सरल व्याख्या',
@@ -4291,6 +4293,7 @@ class AppTranslations {
       'welcome': 'Disciplefy-ലേക്ക് സ്വാഗതം',
       'subtitle': 'ബൈബിൾ അധ്യയനം ചെയ്ത് വിശ്വാസം വളര്‍ത്തുക',
       'continue_with_google': 'Google ഉപയോഗിച്ച് തുടരുക',
+      'continue_with_apple': 'Apple ഉപയോഗിച്ച് തുടരുക',
       'features_title': 'നിങ്ങൾക്ക് ലഭിക്കുന്നത്:',
       'feature_ai_study_guides': 'വ്യക്തിഗത പഠന ഗൈഡുകൾ',
       'feature_ai_study_guides_subtitle':

--- a/frontend/lib/core/i18n/translation_keys.dart
+++ b/frontend/lib/core/i18n/translation_keys.dart
@@ -225,6 +225,7 @@ class TranslationKeys {
   static const loginWelcome = 'login.welcome';
   static const loginSubtitle = 'login.subtitle';
   static const loginContinueWithGoogle = 'login.continue_with_google';
+  static const loginContinueWithApple = 'login.continue_with_apple';
 
   static const loginFeaturesTitle = 'login.features_title';
   static const loginFeatureAiStudyGuides = 'login.feature_ai_study_guides';

--- a/frontend/lib/features/auth/data/services/oauth_service.dart
+++ b/frontend/lib/features/auth/data/services/oauth_service.dart
@@ -1,7 +1,10 @@
 import 'dart:convert';
+import 'dart:math';
 
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../../../../core/config/app_config.dart';
@@ -265,33 +268,91 @@ class OAuthService {
     }
   }
 
-  /// Sign in with Apple OAuth (iOS/Web only)
-  /// FIXED: Updated for corrected PKCE flow configuration
+  /// Native Sign in with Apple (iOS).
+  ///
+  /// Uses the native Apple authorization sheet via `sign_in_with_apple`, then
+  /// exchanges the returned identity token with Supabase via [signInWithIdToken].
+  /// A hashed nonce is sent to Apple and the raw nonce to Supabase so the token
+  /// can be verified without weakening security (no "skip nonce" required).
   Future<bool> signInWithApple() async {
     try {
-      Logger.debug('🍎 [OAUTH SERVICE] 🚀 Starting Apple OAuth PKCE flow...');
+      Logger.debug('🍎 [OAUTH SERVICE] 🚀 Starting native Apple Sign-In...');
 
-      // FIXED: Same as Google - use native Supabase PKCE flow
-      // Apple OAuth will also redirect to Supabase auth endpoints
-      await Supabase.instance.client.auth.signInWithOAuth(
-        OAuthProvider.apple,
-        // NO redirectTo - native PKCE flow with Supabase auth endpoints
-        // NO authScreenLaunchMode - use default platform behavior
+      // Nonce: Apple receives the SHA-256 hash, Supabase receives the raw value.
+      final rawNonce = _generateNonce();
+      final hashedNonce = sha256.convert(utf8.encode(rawNonce)).toString();
+
+      final credential = await SignInWithApple.getAppleIDCredential(
+        scopes: [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        nonce: hashedNonce,
       );
 
-      Logger.debug(
-          '🍎 [OAUTH SERVICE] ✅ Apple OAuth PKCE flow initiated successfully');
-      return true;
-    } catch (e) {
-      Logger.error('🍎 [OAUTH SERVICE] ❌ Apple Sign-In Error: $e');
-
-      if (e.toString().contains('redirect_uri_mismatch')) {
-        throw auth_exceptions.AuthConfigException(
-            'Apple OAuth redirect URI mismatch. Ensure Apple Developer Console configuration matches Supabase auth endpoints.');
+      final idToken = credential.identityToken;
+      if (idToken == null) {
+        throw auth_exceptions.AuthenticationFailedException(
+            'Apple Sign-In did not return an identity token');
       }
 
+      Logger.debug('🍎 [OAUTH SERVICE] ✅ Apple credential received');
+
+      final AuthResponse response =
+          await Supabase.instance.client.auth.signInWithIdToken(
+        provider: OAuthProvider.apple,
+        idToken: idToken,
+        nonce: rawNonce,
+      );
+
+      if (response.user == null) {
+        throw auth_exceptions.AuthenticationFailedException(
+            'Failed to create Supabase session');
+      }
+
+      // Apple returns the user's name ONLY on the first authorization. Persist
+      // it to user metadata so the profile isn't left blank on later logins.
+      final fullName = [credential.givenName, credential.familyName]
+          .where((p) => p != null && p.isNotEmpty)
+          .join(' ');
+      if (fullName.isNotEmpty) {
+        try {
+          await Supabase.instance.client.auth.updateUser(
+            UserAttributes(data: {'full_name': fullName, 'name': fullName}),
+          );
+        } catch (e) {
+          Logger.error(
+              '🍎 [OAUTH SERVICE] Failed to set Apple display name: $e');
+        }
+      }
+
+      Logger.debug('🍎 [OAUTH SERVICE] ✅ Supabase session created via Apple');
+      return true;
+    } on SignInWithAppleAuthorizationException catch (e) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        throw const auth_exceptions.OAuthCancelledException(
+            'Apple Sign-In was cancelled');
+      }
+      Logger.error(
+          '🍎 [OAUTH SERVICE] ❌ Apple authorization error: ${e.code} - ${e.message}');
+      throw auth_exceptions.AuthenticationFailedException(
+          'Apple Sign-In failed: ${e.message}');
+    } on auth_exceptions.OAuthCancelledException {
       rethrow;
+    } catch (e) {
+      Logger.error('🍎 [OAUTH SERVICE] ❌ Apple Sign-In Error: $e');
+      throw auth_exceptions.AuthenticationFailedException(
+          'Apple Sign-In failed: ${e.toString()}');
     }
+  }
+
+  /// Generates a cryptographically secure random nonce for Apple Sign-In.
+  String _generateNonce([int length = 32]) {
+    const charset =
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-._';
+    final random = Random.secure();
+    return List.generate(length, (_) => charset[random.nextInt(charset.length)])
+        .join();
   }
 
   /// Sign out from Google if available

--- a/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -58,6 +58,7 @@ class AuthBloc extends Bloc<AuthEvent, auth_states.AuthState> {
     // Register event handlers
     on<AuthInitializeRequested>(_onAuthInitialize);
     on<GoogleSignInRequested>(_onGoogleSignIn);
+    on<AppleSignInRequested>(_onAppleSignIn);
     on<GoogleOAuthCallbackRequested>(_onGoogleOAuthCallback);
     on<SessionCheckRequested>(_onSessionCheck);
     on<SessionValidationRequested>(_onSessionValidation);
@@ -254,6 +255,46 @@ class AuthBloc extends Bloc<AuthEvent, auth_states.AuthState> {
       },
       onError: (e) => emit(_mapExceptionToErrorState(e)),
       operationName: 'Google Sign-In',
+    );
+  }
+
+  /// Handles native Apple sign-in (iOS).
+  Future<void> _onAppleSignIn(
+    AppleSignInRequested event,
+    Emitter<auth_states.AuthState> emit,
+  ) async {
+    await _retryWithExponentialBackoff(
+      operation: () async {
+        emit(const auth_states.AuthLoadingState());
+
+        final success = await _authService.signInWithApple();
+
+        final validationResult = AuthValidator.validateAuthenticationSuccess(
+          success: success,
+          currentUser: _authService.currentUser,
+          operationName: 'Apple Sign-In',
+        );
+
+        if (validationResult.isSuccess) {
+          final user = validationResult.user!;
+
+          final profile =
+              await _retryOperation(() => _getProfileWithCache(user.id));
+
+          RouterGuard.invalidateLanguageSelectionCache();
+
+          emit(auth_states.AuthenticatedState(
+            user: user,
+            profile: profile,
+          ));
+        } else {
+          final errorMessage =
+              validationResult.errorMessage ?? 'Apple sign-in failed';
+          throw auth_exceptions.AuthenticationFailedException(errorMessage);
+        }
+      },
+      onError: (e) => emit(_mapExceptionToErrorState(e)),
+      operationName: 'Apple Sign-In',
     );
   }
 

--- a/frontend/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/frontend/lib/features/auth/presentation/bloc/auth_event.dart
@@ -20,6 +20,11 @@ class GoogleSignInRequested extends AuthEvent {
   const GoogleSignInRequested();
 }
 
+/// Event to trigger native Apple sign-in (iOS).
+class AppleSignInRequested extends AuthEvent {
+  const AppleSignInRequested();
+}
+
 /// Event to check current session state (for OAuth callbacks)
 class SessionCheckRequested extends AuthEvent {
   const SessionCheckRequested();

--- a/frontend/lib/features/auth/presentation/pages/login_screen.dart
+++ b/frontend/lib/features/auth/presentation/pages/login_screen.dart
@@ -1,3 +1,6 @@
+import 'dart:io' show Platform;
+
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -329,6 +332,13 @@ class _LoginScreenState extends State<LoginScreen> {
 
               const SizedBox(height: 16),
 
+              // Apple Sign-In Button — iOS only (required by App Store
+              // Guideline 4.8 when other social logins are offered).
+              if (!kIsWeb && Platform.isIOS) ...[
+                _buildAppleSignInButton(context, isLoading),
+                const SizedBox(height: 16),
+              ],
+
               // Email Sign-In Button
               _buildEmailSignInButton(context, isLoading),
 
@@ -566,6 +576,66 @@ class _LoginScreenState extends State<LoginScreen> {
       ),
       textAlign: TextAlign.center,
     );
+  }
+
+  /// Builds the Sign in with Apple button (iOS only), following Apple's
+  /// Human Interface Guidelines: black button, Apple logo, white label.
+  Widget _buildAppleSignInButton(BuildContext context, bool isLoading) {
+    const bgColor = Colors.black;
+    const fgColor = Colors.white;
+
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: OutlinedButton(
+        onPressed: isLoading ? null : () => _handleAppleSignIn(context),
+        style: OutlinedButton.styleFrom(
+          backgroundColor: isLoading ? bgColor.withOpacity(0.6) : bgColor,
+          foregroundColor: fgColor,
+          side: BorderSide.none,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: EdgeInsets.zero,
+        ),
+        child: isLoading
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(fgColor),
+                ),
+              )
+            : Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Icon(Icons.apple, color: fgColor, size: 22),
+                  const SizedBox(width: 12),
+                  Text(
+                    context.tr(TranslationKeys.loginContinueWithApple),
+                    style: AppFonts.inter(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      color: fgColor,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }
+
+  /// Handles Apple sign-in button tap
+  void _handleAppleSignIn(BuildContext context) {
+    String? redirectTo;
+    try {
+      redirectTo = GoRouterState.of(context).uri.queryParameters['redirect'];
+    } catch (_) {}
+    if (redirectTo != null && redirectTo.isNotEmpty) {
+      Hive.box('app_settings').put('pending_deep_link_redirect', redirectTo);
+    }
+    context.read<AuthBloc>().add(const AppleSignInRequested());
   }
 
   /// Handles Google sign-in button tap


### PR DESCRIPTION
## Summary

Adds **native Sign in with Apple** for iOS, and brings the **working CI signing fixes** to `main` (the iOS TestFlight pipeline was validated on `dev` but those Fastfile fixes weren't in `main` yet).

## Sign in with Apple (required by App Store Guideline 4.8)
Native flow via `sign_in_with_apple` + `signInWithIdToken(provider: apple, idToken, nonce)` — same pattern as Google. No Services ID or 6-month-expiring web secret needed.
- **Service:** `oauth_service.signInWithApple()` rewritten to native (hashed nonce → Apple, raw nonce → Supabase; captures name on first sign-in)
- **BLoC:** `AppleSignInRequested` event + handler
- **UI:** iOS-only "Continue with Apple" button (Apple HIG), with en/hi/ml strings
- **Backend:** Apple provider enabled in `config.toml`

✅ **Verified on the iOS simulator: both Google and Apple sign-in work.**

## CI signing fixes (validated on dev, run #27220307055 green → TestFlight)
- `fix(ci)`: manual signing with the match distribution profile (automatic signing fails on CI — no Apple ID / dev profile needs a device)
- `fix(ci)`: write the ASC API key to a real `.p8` file so altool can read it (fixes the "(259) not in correct format" upload error)

## Production setup (already done out-of-band)
- Supabase **Apple** provider enabled + bundle ID `com.disciplefy.biblestudy` in Client IDs (native, no secret; nonce checks left on)
- Supabase **Google** provider: iOS client ID added to Client IDs (fixed iOS Google login)

## Notes
- `.env.production` is missing the live `RAZORPAY_KEY_ID` — local prod builds crash at startup without it (CI unaffected). Follow-up.

## Test plan
- Simulator: Google + Apple sign-in confirmed working.
- Post-merge: auto TestFlight build → verify Apple sign-in on a real device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Apple Sign-In support for iOS users, providing a convenient additional authentication option on the login screen.

* **Documentation**
  * Added comprehensive iOS App Store and TestFlight deployment guide with detailed instructions for setting up and configuring authentication providers, including Google and Apple logins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->