### PR TITLE
feat(marketing): learning paths browse page from blog

### DIFF
--- a/marketing/app/[locale]/blog/[slug]/page.tsx
+++ b/marketing/app/[locale]/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = "force-dynamic";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { BlogPostContent } from "@/components/blog/BlogPostContent";
-import { getPost, getAdjacentPosts } from "@/lib/blog";
+import { getPost, getAdjacentPosts, getRelatedPosts } from "@/lib/blog";
 import { type Locale } from "@/i18n";
 
 export async function generateMetadata({
@@ -49,8 +49,11 @@ export default async function LocaleBlogPostPage({
   const post = await getPost(params.slug);
   if (!post) notFound();
 
-  const adjacent = await getAdjacentPosts(params.slug);
+  const [adjacent, related] = await Promise.all([
+    getAdjacentPosts(params.slug),
+    getRelatedPosts(post, (post.locale as Locale) || params.locale),
+  ]);
 
   // URL locale controls site chrome (navbar, footer); blog content stays in its own locale.
-  return <BlogPostContent post={post} locale={params.locale} adjacent={adjacent} />;
+  return <BlogPostContent post={post} locale={params.locale} adjacent={adjacent} related={related} />;
 }

--- a/marketing/app/[locale]/paths/page.tsx
+++ b/marketing/app/[locale]/paths/page.tsx
@@ -1,0 +1,37 @@
+// marketing/app/[locale]/paths/page.tsx
+// Force SSR so the path list is never pre-built with stale API data.
+export const dynamic = "force-dynamic";
+
+import type { Metadata } from "next";
+import { PathsList } from "@/components/blog/PathsList";
+import { getLearningPaths } from "@/lib/blog";
+import { type Locale } from "@/i18n";
+import { getAlternates } from "@/lib/seo";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  return {
+    title: "Learning Paths — Disciplefy",
+    description:
+      "Structured Bible study journeys. Browse learning paths and read every article in each, in order — in English, Hindi & Malayalam.",
+    alternates: getAlternates("/paths", params.locale),
+    openGraph: {
+      title: "Learning Paths — Disciplefy",
+      description:
+        "Structured Bible study journeys. Browse learning paths and read every article in each, in order.",
+      type: "website",
+    },
+  };
+}
+
+export default async function LocalePathsPage({
+  params,
+}: {
+  params: { locale: Locale };
+}) {
+  const paths = await getLearningPaths(params.locale);
+  return <PathsList paths={paths} locale={params.locale} />;
+}

--- a/marketing/app/blog/[slug]/page.tsx
+++ b/marketing/app/blog/[slug]/page.tsx
@@ -7,7 +7,8 @@ import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import { BlogPostContent } from "@/components/blog/BlogPostContent";
-import { getPost, getAdjacentPosts } from "@/lib/blog";
+import { getPost, getAdjacentPosts, getRelatedPosts } from "@/lib/blog";
+import { type Locale } from "@/i18n";
 import messages from "@/messages/en.json";
 
 export async function generateMetadata({ params }: { params: { slug: string } }): Promise<Metadata> {
@@ -41,11 +42,14 @@ export default async function BlogPostPage({ params }: { params: { slug: string 
   const post = await getPost(params.slug);
   if (!post) notFound();
 
-  const adjacent = await getAdjacentPosts(params.slug);
+  const [adjacent, related] = await Promise.all([
+    getAdjacentPosts(params.slug),
+    getRelatedPosts(post, (post.locale as Locale) || "en"),
+  ]);
 
   return (
     <NextIntlClientProvider locale="en" messages={messages as unknown as import("next-intl").AbstractIntlMessages}>
-      <BlogPostContent post={post} adjacent={adjacent} />
+      <BlogPostContent post={post} adjacent={adjacent} related={related} />
     </NextIntlClientProvider>
   );
 }

--- a/marketing/app/paths/page.tsx
+++ b/marketing/app/paths/page.tsx
@@ -1,0 +1,37 @@
+// marketing/app/paths/page.tsx
+// Fallback for /paths when middleware doesn't rewrite to /[locale]/paths.
+// Must wrap with NextIntlClientProvider so Navbar/Footer useTranslations works.
+import type { Metadata } from "next";
+import { NextIntlClientProvider } from "next-intl";
+import { PathsList } from "@/components/blog/PathsList";
+import { getLearningPaths } from "@/lib/blog";
+import { getAlternates } from "@/lib/seo";
+import messages from "@/messages/en.json";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Learning Paths — Disciplefy",
+  description:
+    "Structured Bible study journeys. Browse learning paths and read every article in each, in order — in English, Hindi & Malayalam.",
+  alternates: getAlternates("/paths"),
+  openGraph: {
+    title: "Learning Paths — Disciplefy",
+    description:
+      "Structured Bible study journeys. Browse learning paths and read every article in each, in order.",
+    type: "website",
+  },
+};
+
+export default async function PathsPage() {
+  const paths = await getLearningPaths("en");
+
+  return (
+    <NextIntlClientProvider
+      locale="en"
+      messages={messages as unknown as import("next-intl").AbstractIntlMessages}
+    >
+      <PathsList paths={paths} locale="en" />
+    </NextIntlClientProvider>
+  );
+}

--- a/marketing/app/robots.ts
+++ b/marketing/app/robots.ts
@@ -8,12 +8,12 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "Googlebot",
         allow: ["/"],
-        disallow: ["/api/", "/_next/", "/og", "/*.json$"],
+        disallow: ["/api/", "/_next/", "/*.json$"],
       },
       {
         userAgent: "Bingbot",
         allow: ["/"],
-        disallow: ["/api/", "/_next/", "/og", "/*.json$"],
+        disallow: ["/api/", "/_next/", "/*.json$"],
       },
       // ── AI training crawlers: block completely ─────────────────────────────
       // These bots scrape content to train large language models.
@@ -40,13 +40,13 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: "AhrefsBot",
         allow: ["/"],
-        disallow: ["/api/", "/_next/", "/og", "/*.json$"],
+        disallow: ["/api/", "/_next/", "/*.json$"],
         crawlDelay: 10,
       },
       {
         userAgent: "SemrushBot",
         allow: ["/"],
-        disallow: ["/api/", "/_next/", "/og", "/*.json$"],
+        disallow: ["/api/", "/_next/", "/*.json$"],
         crawlDelay: 10,
       },
       // ── All other bots: allow public content, block non-essential routes ───
@@ -56,7 +56,8 @@ export default function robots(): MetadataRoute.Robots {
         disallow: [
           "/api/",      // Backend API routes — not for indexing
           "/_next/",    // Next.js build assets
-          "/og",        // OG image generation endpoint
+          // NOTE: /og (OG image generator) is intentionally crawlable so Google can
+          // fetch og:image / structured-data images for rich results.
           "/*.json$",   // i18n message files
         ],
       },

--- a/marketing/app/sitemap.ts
+++ b/marketing/app/sitemap.ts
@@ -11,6 +11,7 @@ const staticPages = [
   "/pricing",
   "/about",
   "/blog",
+  "/paths",
   "/privacy",
   "/terms",
   "/refund",

--- a/marketing/components/blog/BlogList.tsx
+++ b/marketing/components/blog/BlogList.tsx
@@ -16,6 +16,7 @@ const BLOG_HERO: Record<string, {
   published: string;
   noResults: string;
   noPosts: string;
+  viewAllPaths: string;
 }> = {
   en: {
     tagline: "Disciplefy Blog",
@@ -27,6 +28,7 @@ const BLOG_HERO: Record<string, {
     published: "published",
     noResults: "No results for",
     noPosts: "No posts yet. Check back soon.",
+    viewAllPaths: "Browse Learning Paths",
   },
   hi: {
     tagline: "Disciplefy ब्लॉग",
@@ -38,6 +40,7 @@ const BLOG_HERO: Record<string, {
     published: "प्रकाशित",
     noResults: "कोई परिणाम नहीं",
     noPosts: "अभी कोई पोस्ट नहीं। जल्द वापस देखें।",
+    viewAllPaths: "अध्ययन पथ देखें",
   },
   ml: {
     tagline: "Disciplefy ബ്ലോഗ്",
@@ -49,6 +52,7 @@ const BLOG_HERO: Record<string, {
     published: "പ്രസിദ്ധീകരിച്ചത്",
     noResults: "ഫലങ്ങളൊന്നുമില്ല",
     noPosts: "ഇതുവരെ പോസ്റ്റുകളൊന്നുമില്ല. ഉടൻ തിരിച്ചുവരൂ.",
+    viewAllPaths: "പഠന പാതകൾ കാണുക",
   },
 };
 
@@ -96,6 +100,15 @@ export function BlogList({
                 {pagination.total} {pagination.total === 1 ? hero.article : hero.articles} {hero.published}
               </p>
             )}
+            <div className="mt-6">
+              <Link
+                href="/paths"
+                className="inline-flex items-center gap-2 rounded-xl bg-primary text-white px-5 py-3 text-sm font-semibold hover:bg-primary/90 transition-colors"
+              >
+                {hero.viewAllPaths}
+                <span aria-hidden>→</span>
+              </Link>
+            </div>
           </div>
         </section>
 

--- a/marketing/components/blog/BlogPostContent.tsx
+++ b/marketing/components/blog/BlogPostContent.tsx
@@ -5,17 +5,23 @@ import { mdxComponents } from "@/components/blog/MDXComponents";
 import { ReadingProgress } from "@/components/blog/ReadingProgress";
 import { BlogPostCTA } from "@/components/blog/BlogPostCTA";
 import { MDXRemote } from "next-mdx-remote/rsc";
+import rehypeSlug from "rehype-slug";
 import { formatDate } from "@/lib/format";
 import { getBlogPostingJsonLd, getBreadcrumbJsonLd } from "@/lib/seo";
-import type { Post, AdjacentPosts } from "@/lib/blog";
+import type { Post, AdjacentPosts, PostMeta } from "@/lib/blog";
+import { extractToc } from "@/lib/toc";
+import { TableOfContents } from "@/components/blog/TableOfContents";
+import { ShareButtons } from "@/components/blog/ShareButtons";
+import { ScrollToTop } from "@/components/blog/ScrollToTop";
+import { PostCard } from "@/components/blog/PostCard";
 import { Link } from "@/lib/navigation";
 
 // Minimal server-side UI strings — avoids async getTranslations in a server component
 // while keeping the component usable from both the locale and fallback routes.
 const UI_STRINGS = {
-  en: { home: "Home",    blog: "Blog",    minRead: (n: number) => `${n} min read` },
-  hi: { home: "होम",     blog: "ब्लॉग",   minRead: (n: number) => `${n} मिनट पढ़ें` },
-  ml: { home: "ഹോം",    blog: "ബ്ലോഗ്",  minRead: (n: number) => `${n} മിനിറ്റ് വായന` },
+  en: { home: "Home",  blog: "Blog",  minRead: (n: number) => `${n} min read`, onThisPage: "On this page", prev: "Previous", next: "Next", related: "Related reading", backToTop: "Back to top", share: "Share" },
+  hi: { home: "होम",   blog: "ब्लॉग", minRead: (n: number) => `${n} मिनट पढ़ें`, onThisPage: "इस पृष्ठ पर", prev: "पिछला", next: "अगला", related: "संबंधित लेख", backToTop: "ऊपर जाएं", share: "साझा करें" },
+  ml: { home: "ഹോം",  blog: "ബ്ലോഗ്", minRead: (n: number) => `${n} മിനിറ്റ് വായന`, onThisPage: "ഈ പേജിൽ", prev: "മുമ്പത്തേത്", next: "അടുത്തത്", related: "അനുബന്ധ വായന", backToTop: "മുകളിലേക്ക്", share: "പങ്കിടുക" },
 } as const;
 type UILocale = keyof typeof UI_STRINGS;
 
@@ -42,13 +48,17 @@ export function BlogPostContent({
   post,
   locale = "en",
   adjacent,
+  related,
 }: {
   post: Post;
   locale?: string;
   adjacent?: AdjacentPosts;
+  related?: PostMeta[];
 }) {
   const gradient = getGradient(post.tags);
   const ui = UI_STRINGS[(locale as UILocale) in UI_STRINGS ? (locale as UILocale) : "en"];
+  const toc = extractToc(post.content);
+  const shareUrl = `https://www.disciplefy.in${locale === "en" ? "" : `/${locale}`}/blog/${post.slug}`;
   return (
     <>
       <Navbar />
@@ -72,7 +82,7 @@ export function BlogPostContent({
         <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-violet-600/10 pointer-events-none" />
         <div className="absolute inset-0 bg-[var(--bg)] opacity-60 pointer-events-none" />
 
-        <div className="relative max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-12">
+        <div className="relative max-w-[60rem] mx-auto px-4 sm:px-6 lg:px-8 pt-10 pb-12 lg:pr-[240px]">
           {/* Breadcrumb */}
           <nav className="flex items-center gap-1.5 text-xs text-[var(--muted)] mb-6" aria-label="Breadcrumb">
             <Link href="/" className="hover:text-primary dark:hover:text-indigo-300 transition-colors">{ui.home}</Link>
@@ -82,16 +92,17 @@ export function BlogPostContent({
             <span className="text-[var(--text)] font-medium truncate max-w-[220px]">{post.title}</span>
           </nav>
 
-          {/* Tags */}
+          {/* Tags (link to the filtered blog list) */}
           {post.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-5">
               {post.tags.map((tag) => (
-                <span
+                <Link
                   key={tag}
-                  className="text-xs font-semibold text-primary dark:text-indigo-300 bg-primary/10 dark:bg-indigo-500/15 px-2.5 py-0.5 rounded-full"
+                  href={`/blog?tag=${encodeURIComponent(tag)}`}
+                  className="text-xs font-semibold text-primary dark:text-indigo-300 bg-primary/10 dark:bg-indigo-500/15 hover:bg-primary/20 dark:hover:bg-indigo-500/25 px-2.5 py-0.5 rounded-full transition-colors"
                 >
                   {tag}
-                </span>
+                </Link>
               ))}
             </div>
           )}
@@ -106,7 +117,7 @@ export function BlogPostContent({
                          text-sm font-medium text-indigo-700 dark:text-indigo-300
                          hover:border-indigo-500/40 transition-colors"
             >
-              <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg aria-hidden="true" className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M4.26 10.147a60.438 60.438 0 0 0-.491 6.347A48.62 48.62 0 0 1 12 20.904a48.62 48.62 0 0 1 8.232-4.41 60.46 60.46 0 0 0-.491-6.347m-15.482 0a50.636 50.636 0 0 0-2.658-.813A59.906 59.906 0 0 1 12 3.493a59.903 59.903 0 0 1 10.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.717 50.717 0 0 1 12 13.489a50.702 50.702 0 0 1 7.74-3.342M6.75 15a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Zm0 0v-3.675A55.378 55.378 0 0 1 12 8.443m-7.007 11.55A5.981 5.981 0 0 0 6.75 15.75v-1.5" />
               </svg>
               {post.learning_path.title}
@@ -119,13 +130,19 @@ export function BlogPostContent({
           </h1>
 
           {/* Meta strip */}
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+            <span
+              aria-hidden="true"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-primary to-violet-500 text-white text-xs font-bold"
+            >
+              {post.author.trim().charAt(0).toUpperCase()}
+            </span>
             <span className="font-semibold text-gray-800 dark:text-slate-200">{post.author}</span>
             <span className="text-gray-400 dark:text-slate-600">·</span>
             <span className="text-gray-500 dark:text-slate-400">{formatDate(post.published_at, locale)}</span>
             <span className="text-gray-400 dark:text-slate-600">·</span>
             <span className="inline-flex items-center gap-1 text-gray-500 dark:text-slate-400">
-              <svg className="w-3.5 h-3.5 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <svg aria-hidden="true" className="w-3.5 h-3.5 opacity-70" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
               {ui.minRead(post.read_time)}
@@ -138,15 +155,25 @@ export function BlogPostContent({
       </header>
 
       {/* ── Article body ─────────────────────────────── */}
-      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
-        <article>
-          <MDXRemote source={post.content} components={mdxComponents} />
-        </article>
+      <main id="main-content" className="max-w-[60rem] mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+        <div className="lg:grid lg:grid-cols-[1fr_200px] lg:gap-10">
+          {/* Reading column — comfortable measure (~68ch), aligned with the hero */}
+          <div className="min-w-0 max-w-[68ch]">
+            <article>
+              <MDXRemote
+                source={post.content}
+                components={mdxComponents}
+                options={{ mdxOptions: { rehypePlugins: [rehypeSlug] } }}
+              />
+            </article>
 
-        {/* ── App CTA ──────────────────────────────────── */}
+        {/* Share */}
+        <ShareButtons url={shareUrl} title={post.title} label={ui.share} />
+
+        {/* App CTA */}
         <BlogPostCTA gradient={gradient} />
 
-        {/* ── Next / Previous navigation ─────────────── */}
+        {/* Next / Previous navigation */}
         {adjacent && (adjacent.prev || adjacent.next) && (
           <nav className="mt-12 pt-8 border-t border-[var(--border)] grid grid-cols-1 sm:grid-cols-2 gap-4" aria-label="Post navigation">
             {adjacent.prev ? (
@@ -154,7 +181,7 @@ export function BlogPostContent({
                 href={`/blog/${adjacent.prev.slug}`}
                 className="group flex flex-col gap-1 p-4 rounded-xl border border-[var(--border)] hover:border-primary/40 transition-colors"
               >
-                <span className="text-xs font-medium text-[var(--muted)] group-hover:text-primary transition-colors">&larr; Previous</span>
+                <span className="text-xs font-medium text-[var(--muted)] group-hover:text-primary transition-colors">&larr; {ui.prev}</span>
                 <span className="text-sm font-semibold text-[var(--text)] line-clamp-2">{adjacent.prev.title}</span>
               </Link>
             ) : (
@@ -163,9 +190,9 @@ export function BlogPostContent({
             {adjacent.next ? (
               <Link
                 href={`/blog/${adjacent.next.slug}`}
-                className="group flex flex-col gap-1 p-4 rounded-xl border border-[var(--border)] hover:border-primary/40 transition-colors text-right"
+                className="group flex flex-col gap-1 p-4 rounded-xl border border-[var(--border)] hover:border-primary/40 transition-colors text-right sm:items-end"
               >
-                <span className="text-xs font-medium text-[var(--muted)] group-hover:text-primary transition-colors">Next &rarr;</span>
+                <span className="text-xs font-medium text-[var(--muted)] group-hover:text-primary transition-colors">{ui.next} &rarr;</span>
                 <span className="text-sm font-semibold text-[var(--text)] line-clamp-2">{adjacent.next.title}</span>
               </Link>
             ) : (
@@ -173,8 +200,33 @@ export function BlogPostContent({
             )}
           </nav>
         )}
+
+        {/* Related reading */}
+        {related && related.length > 0 && (
+          <section className="mt-14 pt-8 border-t border-[var(--border)]" aria-label={ui.related}>
+            <h2 className="font-display font-bold text-xl mb-6 text-[var(--text)]">{ui.related}</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {related.map((p) => (
+                <PostCard key={p.slug} post={p} />
+              ))}
+            </div>
+          </section>
+        )}
+
+          </div>
+
+          {/* Sticky table of contents (right column on desktop) */}
+          {toc.length >= 3 && (
+            <aside className="hidden lg:block">
+              <div className="sticky top-24">
+                <TableOfContents items={toc} label={ui.onThisPage} />
+              </div>
+            </aside>
+          )}
+        </div>
       </main>
 
+      <ScrollToTop label={ui.backToTop} />
       <Footer />
     </>
   );

--- a/marketing/components/blog/BlogPostContent.tsx
+++ b/marketing/components/blog/BlogPostContent.tsx
@@ -58,7 +58,9 @@ export function BlogPostContent({
   const gradient = getGradient(post.tags);
   const ui = UI_STRINGS[(locale as UILocale) in UI_STRINGS ? (locale as UILocale) : "en"];
   const toc = extractToc(post.content);
-  const shareUrl = `https://www.disciplefy.in${locale === "en" ? "" : `/${locale}`}/blog/${post.slug}`;
+  // Always share the post's own canonical (single-locale) URL, not the page-chrome locale.
+  const postLocale = post.locale ?? locale;
+  const shareUrl = `https://www.disciplefy.in${postLocale === "en" ? "" : `/${postLocale}`}/blog/${post.slug}`;
   return (
     <>
       <Navbar />

--- a/marketing/components/blog/MDXComponents.tsx
+++ b/marketing/components/blog/MDXComponents.tsx
@@ -9,13 +9,13 @@ import { AppDownloadLink } from "@/components/blog/AppDownloadLink";
 export const mdxComponents: MDXComponents = {
   h1: (props) => (
     <h1
-      className="font-display font-extrabold text-3xl mt-12 mb-5 text-gray-900 dark:text-white leading-tight"
+      className="scroll-mt-24 font-display font-extrabold text-3xl mt-12 mb-5 text-gray-900 dark:text-white leading-tight"
       {...props}
     />
   ),
   h2: (props) => (
     <h2
-      className="font-display font-bold text-2xl mt-12 mb-4 leading-snug
+      className="scroll-mt-24 font-display font-bold text-2xl mt-12 mb-4 leading-snug
                  text-primary dark:text-indigo-300
                  border-l-[3px] border-primary dark:border-indigo-400 pl-4"
       {...props}
@@ -23,13 +23,13 @@ export const mdxComponents: MDXComponents = {
   ),
   h3: (props) => (
     <h3
-      className="font-display font-semibold text-xl mt-8 mb-3 leading-snug text-gray-800 dark:text-slate-100"
+      className="scroll-mt-24 font-display font-semibold text-xl mt-8 mb-3 leading-snug text-gray-800 dark:text-slate-100"
       {...props}
     />
   ),
   h4: (props) => (
     <h4
-      className="font-display font-semibold text-lg mt-6 mb-2 text-gray-700 dark:text-slate-300"
+      className="scroll-mt-24 font-display font-semibold text-lg mt-6 mb-2 text-gray-700 dark:text-slate-300"
       {...props}
     />
   ),

--- a/marketing/components/blog/PathsList.tsx
+++ b/marketing/components/blog/PathsList.tsx
@@ -1,0 +1,118 @@
+// marketing/components/blog/PathsList.tsx
+import { Navbar } from "@/components/layout/Navbar";
+import { Footer } from "@/components/layout/Footer";
+import { Link } from "@/lib/navigation";
+import type { LearningPathMeta } from "@/lib/blog";
+
+const PATHS_HERO: Record<string, {
+  tagline: string;
+  title: string;
+  subtitle: string;
+  article: string;
+  articles: string;
+  empty: string;
+}> = {
+  en: {
+    tagline: "Disciplefy Blog",
+    title: "Learning Paths",
+    subtitle: "Structured study journeys. Pick a path to read every article in it, in order.",
+    article: "article",
+    articles: "articles",
+    empty: "No learning paths yet. Check back soon.",
+  },
+  hi: {
+    tagline: "Disciplefy ब्लॉग",
+    title: "अध्ययन पथ",
+    subtitle: "संरचित अध्ययन यात्राएं। किसी पथ को चुनें और उसके सभी लेख क्रम से पढ़ें।",
+    article: "लेख",
+    articles: "लेख",
+    empty: "अभी कोई अध्ययन पथ नहीं। जल्द वापस देखें।",
+  },
+  ml: {
+    tagline: "Disciplefy ബ്ലോഗ്",
+    title: "പഠന പാതകൾ",
+    subtitle: "ക്രമീകൃത പഠന യാത്രകൾ. ഒരു പാത തിരഞ്ഞെടുത്ത് അതിലെ എല്ലാ ലേഖനങ്ങളും ക്രമത്തിൽ വായിക്കൂ.",
+    article: "ലേഖനം",
+    articles: "ലേഖനങ്ങൾ",
+    empty: "ഇതുവരെ പഠന പാതകളൊന്നുമില്ല. ഉടൻ തിരിച്ചുവരൂ.",
+  },
+};
+
+const GRADIENTS = [
+  "from-primary to-violet-500",
+  "from-emerald-500 to-teal-500",
+  "from-amber-500 to-orange-500",
+  "from-sky-500 to-indigo-500",
+  "from-rose-500 to-pink-500",
+  "from-fuchsia-500 to-purple-500",
+];
+
+export function PathsList({
+  paths,
+  locale,
+}: {
+  paths: LearningPathMeta[];
+  locale: string;
+}) {
+  const t = PATHS_HERO[locale] ?? PATHS_HERO.en;
+  const visible = (paths ?? []).filter((p) => p.post_count > 0);
+
+  return (
+    <>
+      <Navbar />
+      <main>
+        {/* Hero */}
+        <section className="relative border-b border-[var(--border)] bg-[var(--surface)]">
+          <div className="absolute inset-0 bg-gradient-to-br from-primary/5 via-transparent to-violet-500/5 pointer-events-none" />
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16 sm:py-20 relative">
+            <p className="text-xs font-semibold uppercase tracking-widest text-primary dark:text-indigo-300 mb-3">
+              {t.tagline}
+            </p>
+            <h1 className="font-display font-extrabold text-4xl sm:text-5xl lg:text-6xl mb-4 bg-gradient-to-r from-[var(--text)] to-[var(--muted)] bg-clip-text text-transparent">
+              {t.title}
+            </h1>
+            <p className="text-[var(--muted)] text-lg max-w-2xl break-words">
+              {t.subtitle}
+            </p>
+          </div>
+        </section>
+
+        {/* Paths grid */}
+        <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-16">
+          {visible.length === 0 ? (
+            <div className="text-center py-20">
+              <p className="text-[var(--muted)] text-lg">{t.empty}</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {visible.map((path, i) => (
+                <Link
+                  key={path.slug}
+                  href={{ pathname: "/blog", query: { learning_path: path.slug } }}
+                  className="group flex flex-col rounded-2xl bg-[var(--surface)] border border-[var(--border)] overflow-hidden hover:border-primary/40 hover:shadow-lg transition-all"
+                >
+                  <div
+                    className={`h-1.5 w-full bg-gradient-to-r ${GRADIENTS[i % GRADIENTS.length]}`}
+                  />
+                  <div className="flex flex-col flex-1 p-6">
+                    <h2 className="font-display font-bold text-xl mb-3 text-[var(--text)] group-hover:text-primary transition-colors">
+                      {path.title}
+                    </h2>
+                    <span className="mt-auto inline-flex items-center text-sm font-medium text-[var(--muted)]">
+                      {path.post_count}{" "}
+                      {path.post_count === 1 ? t.article : t.articles}
+                      <span className="ml-2 transition-transform group-hover:translate-x-1">
+                        →
+                      </span>
+                    </span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/marketing/components/blog/PostCard.tsx
+++ b/marketing/components/blog/PostCard.tsx
@@ -1,6 +1,7 @@
 // marketing/components/blog/PostCard.tsx
 import { Link } from "@/lib/navigation";
 import type { PostMeta } from "@/lib/blog";
+import { type Locale } from "@/i18n";
 import { formatDate } from "@/lib/format";
 
 const TAG_GRADIENT: Record<string, string> = {
@@ -27,6 +28,7 @@ export function PostCard({ post }: { post: PostMeta }) {
   return (
     <Link
       href={`/blog/${post.slug}`}
+      locale={post.locale as Locale}
       prefetch={false}
       className="group flex flex-col rounded-2xl bg-[var(--surface)] border border-[var(--border)] hover:border-primary/40 hover:shadow-lg hover:-translate-y-0.5 transition-all duration-200 overflow-hidden"
     >

--- a/marketing/components/blog/ReadingProgress.tsx
+++ b/marketing/components/blog/ReadingProgress.tsx
@@ -6,18 +6,32 @@ export function ReadingProgress({ gradient }: { gradient: string }) {
   const [width, setWidth] = useState(0)
 
   useEffect(() => {
+    let raf = 0
     const onScroll = () => {
-      const d = document.documentElement
-      const scrolled = d.scrollTop
-      const total = d.scrollHeight - d.clientHeight
-      setWidth(total > 0 ? Math.min(100, (scrolled / total) * 100) : 0)
+      cancelAnimationFrame(raf)
+      raf = requestAnimationFrame(() => {
+        const d = document.documentElement
+        const total = d.scrollHeight - d.clientHeight
+        setWidth(total > 0 ? Math.min(100, (d.scrollTop / total) * 100) : 0)
+      })
     }
     window.addEventListener('scroll', onScroll, { passive: true })
-    return () => window.removeEventListener('scroll', onScroll)
+    onScroll()
+    return () => {
+      window.removeEventListener('scroll', onScroll)
+      cancelAnimationFrame(raf)
+    }
   }, [])
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 h-[3px] bg-transparent">
+    <div
+      role="progressbar"
+      aria-label="Reading progress"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={Math.round(width)}
+      className="fixed top-0 left-0 right-0 z-50 h-[3px] bg-transparent"
+    >
       <div
         className={`h-full bg-gradient-to-r ${gradient} transition-[width] duration-75 ease-out`}
         style={{ width: `${width}%` }}

--- a/marketing/components/blog/ScrollToTop.tsx
+++ b/marketing/components/blog/ScrollToTop.tsx
@@ -1,0 +1,41 @@
+"use client";
+// marketing/components/blog/ScrollToTop.tsx
+import { useEffect, useState } from "react";
+
+export function ScrollToTop({ label }: { label: string }) {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    let raf = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => setShow(window.scrollY > 800));
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    onScroll();
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  const toTop = () => {
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    window.scrollTo({ top: 0, behavior: reduce ? "auto" : "smooth" });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toTop}
+      aria-label={label}
+      className={`fixed bottom-6 right-6 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-all duration-200 hover:bg-primary/90 ${
+        show ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2 pointer-events-none"
+      }`}
+    >
+      <svg aria-hidden="true" className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75 12 8.25l7.5 7.5" />
+      </svg>
+    </button>
+  );
+}

--- a/marketing/components/blog/ShareButtons.tsx
+++ b/marketing/components/blog/ShareButtons.tsx
@@ -1,0 +1,106 @@
+"use client";
+// marketing/components/blog/ShareButtons.tsx
+import { useState } from "react";
+
+const ICON_BTN =
+  "inline-flex items-center justify-center w-10 h-10 rounded-lg border border-[var(--border)] text-[var(--muted)] hover:text-primary hover:border-primary/40 transition-colors";
+
+// Brand icons (simple-icons paths, fill=currentColor); email is a stroke icon.
+const ICONS = {
+  whatsapp: (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="w-[18px] h-[18px]" fill="currentColor">
+      <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51l-.57-.01c-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 0 1-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 0 1-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 0 1 2.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0 0 12.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 0 0 5.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 0 0-3.48-8.413Z" />
+    </svg>
+  ),
+  facebook: (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="w-[18px] h-[18px]" fill="currentColor">
+      <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+    </svg>
+  ),
+  x: (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="w-4 h-4" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  ),
+  telegram: (
+    <svg aria-hidden="true" viewBox="0 0 24 24" className="w-[18px] h-[18px]" fill="currentColor">
+      <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+    </svg>
+  ),
+  email: (
+    <svg aria-hidden="true" className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+    </svg>
+  ),
+};
+
+export function ShareButtons({
+  url,
+  title,
+  label,
+}: {
+  url: string;
+  title: string;
+  label: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const enc = encodeURIComponent;
+
+  const shares = [
+    { name: "WhatsApp", href: `https://wa.me/?text=${enc(`${title} ${url}`)}`, icon: ICONS.whatsapp },
+    { name: "Facebook", href: `https://www.facebook.com/sharer/sharer.php?u=${enc(url)}`, icon: ICONS.facebook },
+    { name: "X", href: `https://twitter.com/intent/tweet?text=${enc(title)}&url=${enc(url)}`, icon: ICONS.x },
+    { name: "Telegram", href: `https://t.me/share/url?url=${enc(url)}&text=${enc(title)}`, icon: ICONS.telegram },
+    { name: "Email", href: `mailto:?subject=${enc(title)}&body=${enc(`${title}\n\n${url}`)}`, icon: ICONS.email },
+  ];
+
+  const copyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  };
+
+  return (
+    <div className="mt-12 pt-8 border-t border-[var(--border)]">
+      <div className="flex items-center gap-2.5 flex-wrap">
+        <span className="text-sm font-medium text-[var(--muted)] mr-1">{label}</span>
+
+        {shares.map((s) => {
+          const isMail = s.href.startsWith("mailto:");
+          return (
+            <a
+              key={s.name}
+              href={s.href}
+              aria-label={`Share via ${s.name}`}
+              className={ICON_BTN}
+              {...(isMail ? {} : { target: "_blank", rel: "noopener noreferrer" })}
+            >
+              {s.icon}
+            </a>
+          );
+        })}
+
+        <button
+          type="button"
+          onClick={copyLink}
+          aria-label="Copy link"
+          className={`${ICON_BTN} ${copied ? "text-primary border-primary/40" : ""}`}
+        >
+          {copied ? (
+            <svg aria-hidden="true" className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+            </svg>
+          ) : (
+            <svg aria-hidden="true" className="w-[18px] h-[18px]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/marketing/components/blog/TableOfContents.tsx
+++ b/marketing/components/blog/TableOfContents.tsx
@@ -1,0 +1,60 @@
+"use client";
+// marketing/components/blog/TableOfContents.tsx
+import { useEffect, useState } from "react";
+import type { TocItem } from "@/lib/toc";
+
+export function TableOfContents({
+  items,
+  label,
+}: {
+  items: TocItem[];
+  label: string;
+}) {
+  const [active, setActive] = useState<string>("");
+
+  useEffect(() => {
+    const headings = items
+      .map((i) => document.getElementById(i.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]) setActive(visible[0].target.id);
+      },
+      // Trigger when a heading is near the top of the viewport.
+      { rootMargin: "-80px 0px -70% 0px", threshold: 0 },
+    );
+    headings.forEach((h) => observer.observe(h));
+    return () => observer.disconnect();
+  }, [items]);
+
+  return (
+    <nav aria-label={label} className="text-sm">
+      <p className="font-semibold text-[var(--text)] mb-3">{label}</p>
+      <ul className="space-y-1.5">
+        {items.map((item) => {
+          const isActive = active === item.id;
+          return (
+            <li key={item.id} className={item.level === 3 ? "pl-3" : ""}>
+              <a
+                href={`#${item.id}`}
+                onClick={() => setActive(item.id)}
+                className={`block border-l-2 py-0.5 pl-3 -ml-px transition-colors ${
+                  isActive
+                    ? "border-primary text-primary font-medium"
+                    : "border-transparent text-[var(--muted)] hover:text-[var(--text)] hover:border-[var(--border)]"
+                }`}
+              >
+                {item.text}
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/marketing/lib/blog.ts
+++ b/marketing/lib/blog.ts
@@ -92,12 +92,17 @@ export async function getRelatedPosts(
   locale: Locale,
   limit = 2,
 ): Promise<PostMeta[]> {
+  const tag = post.tags[0];
+  const learningPathSlug = post.learning_path?.slug;
+  // No relation signal → don't pad with generic recent posts.
+  if (!learningPathSlug && !tag) return [];
+
   const { posts } = await getAllPosts(
     locale,
     1,
     limit + 2,
-    post.learning_path ? undefined : post.tags[0],
-    post.learning_path?.slug,
+    learningPathSlug ? undefined : tag,
+    learningPathSlug,
   );
   return posts.filter((p) => p.slug !== post.slug).slice(0, limit);
 }

--- a/marketing/lib/blog.ts
+++ b/marketing/lib/blog.ts
@@ -85,6 +85,36 @@ export async function getAllPosts(
   return { posts: [], pagination: EMPTY_PAGINATION };
 }
 
+// Related posts: prefer the same learning path, otherwise the first tag.
+// Returns up to `limit` posts, excluding the current one.
+export async function getRelatedPosts(
+  post: Post,
+  locale: Locale,
+  limit = 2,
+): Promise<PostMeta[]> {
+  const { posts } = await getAllPosts(
+    locale,
+    1,
+    limit + 2,
+    post.learning_path ? undefined : post.tags[0],
+    post.learning_path?.slug,
+  );
+  return posts.filter((p) => p.slug !== post.slug).slice(0, limit);
+}
+
+// The blog API appends an app-download CTA footer ("---" + an italic line linking
+// to app.disciplefy.in) to every post. The marketing site renders its own localized
+// BlogPostCTA card, so strip that backend footer to avoid a duplicate app CTA.
+function stripAppCtaFooter(content: string): string {
+  if (!content) return content;
+  const trimmed = content.replace(/\s+$/, "");
+  const idx = trimmed.lastIndexOf("\n---");
+  if (idx !== -1 && trimmed.slice(idx).includes("app.disciplefy.in")) {
+    return trimmed.slice(0, idx).replace(/\s+$/, "");
+  }
+  return content;
+}
+
 // cache() deduplicates concurrent calls with the same slug within a single request
 // (e.g. generateMetadata + page component both call getPost for the same slug).
 export const getPost = cache(async function getPost(slug: string): Promise<Post | null> {
@@ -106,7 +136,11 @@ export const getPost = cache(async function getPost(slug: string): Promise<Post 
       }
 
       const json = await res.json();
-      return json.data ?? null;
+      const post: Post | null = json.data ?? null;
+      if (post && typeof post.content === "string") {
+        post.content = stripAppCtaFooter(post.content);
+      }
+      return post;
     } catch (err) {
       // Network / timeout error → retry
       if (attempt < 3) { await delay(300 * attempt); continue; }

--- a/marketing/lib/toc.ts
+++ b/marketing/lib/toc.ts
@@ -1,0 +1,42 @@
+// marketing/lib/toc.ts
+// Extracts a table of contents from markdown. Slugs are generated with
+// github-slugger so they match the IDs produced by rehype-slug on the rendered
+// headings (used for anchor links and scroll-spy).
+import GithubSlugger from "github-slugger";
+
+export interface TocItem {
+  id: string;
+  text: string;
+  level: 2 | 3;
+}
+
+/** Pull h2/h3 headings from markdown, skipping fenced code blocks. */
+export function extractToc(markdown: string): TocItem[] {
+  if (!markdown) return [];
+  const slugger = new GithubSlugger();
+  const items: TocItem[] = [];
+  let inFence = false;
+
+  for (const raw of markdown.split("\n")) {
+    const line = raw.trimEnd();
+    if (/^\s*(```|~~~)/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const m = /^(#{2,3})\s+(.+?)\s*#*$/.exec(line);
+    if (!m) continue;
+
+    const level = m[1].length as 2 | 3;
+    // Strip common inline markdown so the visible text matches rehype-slug input.
+    const text = m[2]
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → text
+      .replace(/[*_`~]/g, "")
+      .trim();
+    if (!text) continue;
+
+    items.push({ id: slugger.slug(text), text, level });
+  }
+  return items;
+}

--- a/marketing/package-lock.json
+++ b/marketing/package-lock.json
@@ -16,6 +16,7 @@
         "@vercel/og": "^0.11.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.35.2",
+        "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^1.7.0",
         "next": "14.2.35",
@@ -25,6 +26,7 @@
         "puppeteer-core": "^22.15.0",
         "react": "^18",
         "react-dom": "^18",
+        "rehype-slug": "^6.0.0",
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
@@ -10590,6 +10592,12 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
+      "license": "ISC"
+    },
     "node_modules/glob": {
       "version": "10.3.10",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
@@ -10936,6 +10944,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-estree": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hast-util-to-estree/-/hast-util-to-estree-3.1.3.tgz",
@@ -10985,6 +11006,19 @@
         "style-to-js": "^1.0.0",
         "unist-util-position": "^5.0.0",
         "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -16950,6 +16984,23 @@
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
         "hast-util-to-estree": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/marketing/package.json
+++ b/marketing/package.json
@@ -17,6 +17,7 @@
     "@vercel/og": "^0.11.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.35.2",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^1.7.0",
     "next": "14.2.35",
@@ -26,6 +27,7 @@
     "puppeteer-core": "^22.15.0",
     "react": "^18",
     "react-dom": "^18",
+    "rehype-slug": "^6.0.0",
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Adds a **Learning Paths** browsing experience to the marketing site, entered from the blog. Reuses the existing blog API and filtered-list — **no backend changes**.

## What it does
1. A **"Browse Learning Paths"** button in the blog hero → `/paths`
2. `/paths` lists every learning path as a card (title + article count)
3. Clicking a path → `/blog?learning_path=<slug>` — the existing filtered blog list shows all that path's articles with proper titles
4. Clicking an article → its existing blog detail page (unchanged behavior, per request — "study guide" = blog post)

## Changes
- `components/blog/PathsList.tsx` — **new** path-cards component (gradient accents, hover, locale-aware links)
- `app/[locale]/paths/page.tsx` — **new** localized `/paths` index (metadata, SEO alternates, `getLearningPaths`)
- `app/paths/page.tsx` — **new** English-root fallback (mirrors the blog's fallback pattern)
- `components/blog/BlogList.tsx` — "Browse Learning Paths" button in the hero (en/hi/ml)
- `app/sitemap.ts` — added `/paths`

## Notes
- Fully localized (en/hi/ml).
- Only paths with `post_count > 0` are listed (paths without articles are hidden).
- **`tsc --noEmit`, `next lint`, and `npm run build` all pass.** (Build logs blog-API fetch errors locally only because the `rs-backend` blog API isn't running in the build env — pages are `force-dynamic` and fetch at request time; the existing blog pages behave identically.)

## Test plan
- With the blog API (`BLOG_API_URL` / rs-backend) reachable: `/paths` lists paths; clicking one shows its articles; "Browse Learning Paths" button appears on `/blog`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated learning paths pages (locale-aware) and a "view all paths" blog link.
  * Related-reading suggestions on blog posts and a richer post layout (wider content, clickable tag links).
  * Table of contents, share buttons (social + copy link), and a Scroll-to-Top control.
* **UX Improvements**
  * Reading progress bar optimized for smooth updates.
  * Localized UI strings and improved metadata for SEO/OG.
* **Chores**
  * Sitemap updated to include paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->