### PR TITLE
ci: platform-specific prod deploy gating + fix: language selection for new users

### DIFF
--- a/.github/workflows/android-deploy-playstore-production.yml
+++ b/.github/workflows/android-deploy-playstore-production.yml
@@ -1,10 +1,11 @@
 name: Deploy Android to Play Store (Production)
 
-# Production releases triggered by version tags or manual dispatch
+# Production releases: manual dispatch, or a platform-specific tag (android-v1.2.3)
+# so a shared "v*" tag can't fire Android + iOS prod at once.
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'android-v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       rollout_percentage:
@@ -49,7 +50,7 @@ jobs:
           # If triggered by tag, validate tag matches pubspec
           if [ "${{ github.event_name }}" = "push" ]; then
             TAG="${{ github.ref_name }}"
-            TAG_VERSION="${TAG#v}"
+            TAG_VERSION="${TAG#android-v}"
             if [ "$TAG_VERSION" != "$VERSION" ]; then
               echo "❌ Tag version ($TAG_VERSION) does not match pubspec.yaml ($VERSION)"
               echo "   Update pubspec.yaml version before tagging."

--- a/.github/workflows/ios-deploy-appstore.yml
+++ b/.github/workflows/ios-deploy-appstore.yml
@@ -1,12 +1,14 @@
 name: Deploy iOS to App Store
 
 # Production releases — mirrors android-deploy-playstore-production.yml.
-# Push a version tag (v1.2.3) → builds with Xcode 26 → uploads to App Store Connect.
+# Trigger: manual dispatch, or push a platform-specific tag (ios-v1.2.3) so a
+# shared "v*" tag can't fire iOS + Android prod at once.
+# → builds with Xcode 26 → uploads to App Store Connect.
 # Does NOT auto-submit for review (submit manually in App Store Connect).
 on:
   push:
     tags:
-      - 'v[0-9]*.[0-9]*.[0-9]*'
+      - 'ios-v[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 env:
@@ -37,7 +39,7 @@ jobs:
           echo "✅ Version: $VERSION+$BUILD_NUMBER"
 
           if [ "${{ github.event_name }}" = "push" ]; then
-            TAG="${{ github.ref_name }}"; TAG_VERSION="${TAG#v}"
+            TAG="${{ github.ref_name }}"; TAG_VERSION="${TAG#ios-v}"
             if [ "$TAG_VERSION" != "$VERSION" ]; then
               echo "❌ Tag ($TAG_VERSION) does not match pubspec.yaml ($VERSION). Bump pubspec before tagging."
               exit 1

--- a/frontend/lib/core/services/language_preference_service.dart
+++ b/frontend/lib/core/services/language_preference_service.dart
@@ -249,51 +249,35 @@ class LanguagePreferenceService {
           return false;
         }
 
-        final languageResult =
-            await _userProfileService.getLanguagePreference();
-        final hasLanguage = languageResult.fold(
-          (failure) {
-            Logger.error(
-                '❌ [LANGUAGE_SELECTION] Failed to get language preference: ${failure.message}');
-
-            // Failure: Use locally stored/cached value as fallback instead of overwriting
-            final locallyMarked =
-                _prefs.getBool(_hasCompletedLanguageSelectionKey) ?? false;
-            Logger.debug(
-                '📦 [LANGUAGE_SELECTION] Using cached local completion status: $locallyMarked');
-
-            // Return local state, DO NOT cache false when remote call failed
-            return locallyMarked;
-          },
-          (language) {
-            Logger.info(
-                '✅ [LANGUAGE_SELECTION] Found language preference in DB: ${language.displayName}');
-            return true; // Has language preference in DB means completed
-          },
-        );
-
-        // Only cache the result if it came from a successful remote call
-        // Don't cache when using fallback local state
-        if (languageResult.isRight()) {
-          _cacheLanguageCompletion(currentUserId, hasLanguage);
-        } else {
-          Logger.warning(
-              '⚠️ [LANGUAGE_SELECTION] Not caching result - using fallback local state due to API failure');
-        }
-
-        // If we have a language preference in DB (successful call), mark local storage for consistency
-        if (hasLanguage && languageResult.isRight()) {
+        // Determine completion from the RAW (null-preserving) language value.
+        // The typed profile model coerces a null `language_preference` to 'en'
+        // (UserProfileModel), which would hide new users who haven't chosen a
+        // language yet — so use the raw map here, not getLanguagePreference().
+        // getUserProfileAsMap() returns the raw API JSON (preserves null);
+        // the userId arg is ignored by the API service (it uses the auth token).
+        final rawProfile =
+            await _userProfileService.getUserProfileAsMap(currentUserId ?? '');
+        if (rawProfile == null) {
+          // Raw profile unavailable (transient API error) → fall back to the
+          // local flag and DON'T cache, so we re-check next time.
           final locallyMarked =
               _prefs.getBool(_hasCompletedLanguageSelectionKey) ?? false;
-          Logger.debug(
-              '🔍 [LANGUAGE_SELECTION] Locally marked as completed: $locallyMarked');
+          Logger.warning(
+              '⚠️ [LANGUAGE_SELECTION] Raw profile unavailable — using local flag: $locallyMarked');
+          return locallyMarked;
+        }
 
-          // If not locally marked but has DB preference, mark it locally for consistency
-          if (!locallyMarked) {
-            Logger.debug(
-                '🔄 [LANGUAGE_SELECTION] Marking locally as completed for consistency');
-            await _prefs.setBool(_hasCompletedLanguageSelectionKey, true);
-          }
+        final rawLang = rawProfile['language_preference'] as String?;
+        final hasLanguage = rawLang != null && rawLang.isNotEmpty;
+        Logger.info(
+            '🔍 [LANGUAGE_SELECTION] Raw language_preference="${rawLang ?? 'null'}" → completed=$hasLanguage');
+
+        _cacheLanguageCompletion(currentUserId, hasLanguage);
+
+        // Keep the local flag consistent when the DB already has a language.
+        if (hasLanguage &&
+            !(_prefs.getBool(_hasCompletedLanguageSelectionKey) ?? false)) {
+          await _prefs.setBool(_hasCompletedLanguageSelectionKey, true);
         }
 
         return hasLanguage;


### PR DESCRIPTION
## Summary
Two changes on `dev` since the last release (#297):

### 🛡️ CI — gate production deploys (`f7b7a47f`)
A single `v1.0.0` tag previously fired **both** iOS App Store *and* Android Play Store production deploys (both listened on `v*.*.*`). Now:
- **iOS** (`ios-deploy-appstore.yml`): `workflow_dispatch` **or** tag `ios-v1.2.3`
- **Android** (`android-deploy-playstore-production.yml`): `workflow_dispatch` **or** tag `android-v1.2.3`
- Tag-version validators updated to strip the platform prefix.
- A bare `v*` tag now triggers **neither** pipeline.

### 🐛 Fix — language selection skipped for new users (`0df2f80b`)
On first login, the language-selection screen was skipped. Root cause: `UserProfileModel` coerced a `null` `language_preference` → `'en'`, so `hasCompletedLanguageSelection()` saw a non-null language and treated new users as "already chose."
Fix: the completion check now reads the **raw, null-preserving** profile (`getUserProfileAsMap()`) instead of the coercing typed model. New users (`language_preference = null`) correctly see the screen; the `'en'` display default is unchanged.

## Test plan
- **CI**: pushing `v1.0.0` should trigger nothing; `ios-v1.2.3` → iOS only; `android-v1.2.3` → Android only; manual "Run workflow" still works.
- **Language**: log in with a brand-new account → language selection shows before home. Existing users who already picked a language are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android and iOS deployment workflows to use platform-specific release tags for more organized version management across platforms.

* **Bug Fixes**
  * Improved language preference completion tracking to ensure the app properly detects when users have selected a language.
