### PR TITLE
release: Apple ASSN v2 webhook, Voice Discipler hardening, Apple sign-in + iOS metadata

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -226,6 +226,8 @@ jobs:
         RAZORPAY_FIRSTMONTH_STANDARD_OFFER_ID=${{ secrets.RAZORPAY_FIRSTMONTH_STANDARD_OFFER_ID }}
         RAZORPAY_FIRSTMONTH_PLUS_OFFER_ID=${{ secrets.RAZORPAY_FIRSTMONTH_PLUS_OFFER_ID }}
         RAZORPAY_FIRSTMONTH_PREMIUM_OFFER_ID=${{ secrets.RAZORPAY_FIRSTMONTH_PREMIUM_OFFER_ID }}
+        # Apple App Store IAP — shared secret for verifyReceipt validation
+        APPLE_SHARED_SECRET=${{ secrets.APPLE_SHARED_SECRET }}
 
         # SMS Configuration (${{ env.DEPLOY_ENV }})
         TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}

--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -228,6 +228,9 @@ jobs:
         RAZORPAY_FIRSTMONTH_PREMIUM_OFFER_ID=${{ secrets.RAZORPAY_FIRSTMONTH_PREMIUM_OFFER_ID }}
         # Apple App Store IAP — shared secret for verifyReceipt validation
         APPLE_SHARED_SECRET=${{ secrets.APPLE_SHARED_SECRET }}
+        # Apple App Store Server Notifications V2 — bundle id allow-list + numeric app id
+        APPLE_BUNDLE_ID=${{ secrets.APPLE_BUNDLE_ID }}
+        APPLE_APP_APPLE_ID=${{ secrets.APPLE_APP_APPLE_ID }}
 
         # SMS Configuration (${{ env.DEPLOY_ENV }})
         TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}

--- a/.github/workflows/ios-deploy-appstore.yml
+++ b/.github/workflows/ios-deploy-appstore.yml
@@ -32,7 +32,8 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Offset by 10000 so production build numbers always exceed TestFlight betas.
+          # Offset by 10000 so production build numbers always exceed TestFlight betas
+          # (which use the plain run number). The two tracks stay numerically distinct.
           BUILD_NUMBER=$(( ${{ github.run_number }} + 10000 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/workflows/ios-deploy-testflight.yml
+++ b/.github/workflows/ios-deploy-testflight.yml
@@ -28,6 +28,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
+          # TestFlight betas use the plain run number (small: 1, 2, 3…).
+          # Production builds offset by 10000 (see ios-deploy-appstore.yml) so the
+          # two tracks stay numerically distinct; groups differentiate them in TestFlight.
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+${{ github.run_number }}"

--- a/.gitignore
+++ b/.gitignore
@@ -491,3 +491,5 @@ target/
 .worktrees/
 
 .guides/
+
+secrets/*

--- a/backend/deno.lock
+++ b/backend/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@supabase/functions-js@^0.0.0-automated": "0.0.0-jsr-test.1",
     "jsr:@supabase/supabase-js@2": "2.95.3",
+    "npm:@apple/app-store-server-library@3.1.0": "3.1.0",
     "npm:@supabase/auth-js@2.95.3": "2.95.3",
     "npm:@supabase/postgrest-js@2.95.3": "2.95.3",
     "npm:@supabase/realtime-js@2.95.3": "2.95.3",
@@ -31,6 +32,19 @@
     }
   },
   "npm": {
+    "@apple/app-store-server-library@3.1.0": {
+      "integrity": "sha512-d26SICRz8BwCV2qPR0BSXBMxmw0NEvJLwsdREcBmCrus8NmyHw2XgOOP0fiFjcctPn/JXtmSDuGVnaHe+dqO+A==",
+      "dependencies": [
+        "@types/jsonwebtoken",
+        "@types/jsrsasign",
+        "@types/node@25.9.3",
+        "@types/node-fetch",
+        "base64url",
+        "jsonwebtoken",
+        "jsrsasign",
+        "node-fetch"
+      ]
+    },
     "@pdf-lib/standard-fonts@1.0.0": {
       "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
       "dependencies": [
@@ -121,10 +135,36 @@
     "@types/caseless@0.12.5": {
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="
     },
+    "@types/jsonwebtoken@9.0.10": {
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dependencies": [
+        "@types/ms",
+        "@types/node@22.15.15"
+      ]
+    },
+    "@types/jsrsasign@10.5.15": {
+      "integrity": "sha512-3stUTaSRtN09PPzVWR6aySD9gNnuymz+WviNHoTb85dKu+BjaV4uBbWWGykBBJkfwPtcNZVfTn2lbX00U+yhpQ=="
+    },
+    "@types/ms@2.1.0": {
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+    },
+    "@types/node-fetch@2.6.13": {
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "dependencies": [
+        "@types/node@22.15.15",
+        "form-data@4.0.6"
+      ]
+    },
     "@types/node@22.15.15": {
       "integrity": "sha512-R5muMcZob3/Jjchn5LcO8jdKwSCbzqmPB6ruBxMcf9kbxtniZHP327s6C37iOfuw8mbKK3cAQa7sEl7afLrQ8A==",
       "dependencies": [
-        "undici-types"
+        "undici-types@6.21.0"
+      ]
+    },
+    "@types/node@25.9.3": {
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dependencies": [
+        "undici-types@7.24.6"
       ]
     },
     "@types/phoenix@1.6.7": {
@@ -141,7 +181,7 @@
       "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
       "dependencies": [
         "@types/caseless",
-        "@types/node",
+        "@types/node@22.15.15",
         "@types/tough-cookie",
         "form-data@2.5.5"
       ]
@@ -152,7 +192,7 @@
     "@types/ws@8.18.1": {
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": [
-        "@types/node"
+        "@types/node@22.15.15"
       ]
     },
     "ajv@6.12.6": {
@@ -185,6 +225,9 @@
     "aws4@1.13.2": {
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
     },
+    "base64url@3.0.1": {
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "bcrypt-pbkdf@1.0.2": {
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "dependencies": [
@@ -193,6 +236,9 @@
     },
     "bluebird@3.7.2": {
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
+    "buffer-equal-constant-time@1.0.1": {
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "call-bind-apply-helpers@1.0.2": {
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
@@ -237,6 +283,12 @@
         "safer-buffer"
       ]
     },
+    "ecdsa-sig-formatter@1.0.11": {
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
     "es-define-property@1.0.1": {
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
@@ -255,7 +307,7 @@
         "es-errors",
         "get-intrinsic",
         "has-tostringtag",
-        "hasown"
+        "hasown@2.0.2"
       ]
     },
     "extend@3.0.2": {
@@ -287,9 +339,19 @@
         "asynckit",
         "combined-stream",
         "es-set-tostringtag",
-        "hasown",
+        "hasown@2.0.2",
         "mime-types",
         "safe-buffer"
+      ]
+    },
+    "form-data@4.0.6": {
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dependencies": [
+        "asynckit",
+        "combined-stream",
+        "es-set-tostringtag",
+        "hasown@2.0.4",
+        "mime-types"
       ]
     },
     "function-bind@1.1.2": {
@@ -306,7 +368,7 @@
         "get-proto",
         "gopd",
         "has-symbols",
-        "hasown",
+        "hasown@2.0.2",
         "math-intrinsics"
       ]
     },
@@ -352,6 +414,12 @@
         "function-bind"
       ]
     },
+    "hasown@2.0.4": {
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dependencies": [
+        "function-bind"
+      ]
+    },
     "http-signature@1.2.0": {
       "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dependencies": [
@@ -384,6 +452,21 @@
     "json-stringify-safe@5.0.1": {
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
+    "jsonwebtoken@9.0.3": {
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dependencies": [
+        "jws",
+        "lodash.includes",
+        "lodash.isboolean",
+        "lodash.isinteger",
+        "lodash.isnumber",
+        "lodash.isplainobject",
+        "lodash.isstring",
+        "lodash.once",
+        "ms",
+        "semver"
+      ]
+    },
     "jsprim@1.4.2": {
       "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dependencies": [
@@ -392,6 +475,45 @@
         "json-schema",
         "verror"
       ]
+    },
+    "jsrsasign@11.1.3": {
+      "integrity": "sha512-nPnK5D/4lv0Dwr7TlzrKtAd8JlLZwFTqTUUB3NQCbtdobcRcohGFxjbPySDVh74iWUudcCsapYT6OxoyhJLhhA=="
+    },
+    "jwa@2.0.1": {
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dependencies": [
+        "buffer-equal-constant-time",
+        "ecdsa-sig-formatter",
+        "safe-buffer"
+      ]
+    },
+    "jws@4.0.1": {
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dependencies": [
+        "jwa",
+        "safe-buffer"
+      ]
+    },
+    "lodash.includes@4.3.0": {
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+    },
+    "lodash.isboolean@3.0.3": {
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "lodash.isinteger@4.0.4": {
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "lodash.isnumber@3.0.3": {
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+    },
+    "lodash.isplainobject@4.0.6": {
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+    },
+    "lodash.isstring@4.0.1": {
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "lodash.once@4.1.1": {
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash@4.17.23": {
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
@@ -406,6 +528,15 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": [
         "mime-db"
+      ]
+    },
+    "ms@2.1.3": {
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node-fetch@2.7.0": {
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": [
+        "whatwg-url"
       ]
     },
     "oauth-sign@0.9.0": {
@@ -504,6 +635,10 @@
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "semver@7.8.4": {
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "bin": true
+    },
     "sshpk@1.18.0": {
       "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dependencies": [
@@ -529,6 +664,9 @@
         "punycode"
       ]
     },
+    "tr46@0.0.3": {
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "tslib@1.14.1": {
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
@@ -551,6 +689,9 @@
     "undici-types@6.21.0": {
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
+    "undici-types@7.24.6": {
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="
+    },
     "uri-js@4.4.1": {
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": [
@@ -568,6 +709,16 @@
         "assert-plus",
         "core-util-is",
         "extsprintf"
+      ]
+    },
+    "webidl-conversions@3.0.1": {
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url@5.0.0": {
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": [
+        "tr46",
+        "webidl-conversions"
       ]
     },
     "ws@8.19.0": {
@@ -664,6 +815,86 @@
     "https://deno.land/std@0.208.0/fmt/colors.ts": "34b3f77432925eb72cf0bfb351616949746768620b8e5ead66da532f93d10ba2",
     "https://deno.land/std@0.208.0/http/server.ts": "f3cde6672e631d3e00785743cfa96bfed275618c0352c5ae84abbe5a2e0e4afc",
     "https://deno.land/std@0.208.0/testing/asserts.ts": "605bbd2ef0695e2a4324d810c4ad22e56041d51afb9584fc0b4e81084b14b1d6",
+    "https://deno.land/x/jose@v5.9.6/index.ts": "e6e894e8c2b3a11c4071ee1008eb7d85a373ff68b5fbe5d7791d7384cfdee523",
+    "https://deno.land/x/jose@v5.9.6/jwe/compact/decrypt.ts": "43c80cb2dd0545df1b0aed37b710e0c02cd58781236eb0426fa2dd65bf250d8f",
+    "https://deno.land/x/jose@v5.9.6/jwe/compact/encrypt.ts": "b3be13ddddea2ea638cf188cbe1c1572085edd84f7d657cdd488dbba7c2a86c7",
+    "https://deno.land/x/jose@v5.9.6/jwe/flattened/decrypt.ts": "69ac436e2880b0cf03dfcddb38f24b862cab568c900fd5ec965561ae9aa3224d",
+    "https://deno.land/x/jose@v5.9.6/jwe/flattened/encrypt.ts": "0f2b4245b3fec9f7b55748f8b7d430d397aecb4884a858f0d5ce618a8d601e31",
+    "https://deno.land/x/jose@v5.9.6/jwe/general/decrypt.ts": "115e034ffffa542dc4bc361f33cc1550a5d3d1c301d02c9785b2410c5008c40e",
+    "https://deno.land/x/jose@v5.9.6/jwe/general/encrypt.ts": "40efbe7f473f21933eba57aba133ab16df8e153d96946b6ede62572146970cd4",
+    "https://deno.land/x/jose@v5.9.6/jwk/embedded.ts": "9235337249f10a04a046a02897e0db4be8244fc731ac0638f4ad5c091280b58c",
+    "https://deno.land/x/jose@v5.9.6/jwk/thumbprint.ts": "362b6d36a716f569ac3f6a97bb41a7fb3265f971d5563f05cca73ce03432e42a",
+    "https://deno.land/x/jose@v5.9.6/jwks/local.ts": "2a948310bc9c534c3c044d52f8cf015fc7075bf8e7e845950fa578bd77d51f2e",
+    "https://deno.land/x/jose@v5.9.6/jwks/remote.ts": "948c451ebde9978628a7f6e543ef0827584ee2b434d1360d6964776f41be3094",
+    "https://deno.land/x/jose@v5.9.6/jws/compact/sign.ts": "112b4904316458c7d8cfef48309eefe977b9720d061f81477a7c72247a4f8821",
+    "https://deno.land/x/jose@v5.9.6/jws/compact/verify.ts": "37cdbe53267550b236344e4e7d7bf1dfd94fd1887fd785110d4cf88a4aa93408",
+    "https://deno.land/x/jose@v5.9.6/jws/flattened/sign.ts": "bbdeafd7d00873ad032a9136e770897ab202cce5ed5cef249470a2faf4ad0fe4",
+    "https://deno.land/x/jose@v5.9.6/jws/flattened/verify.ts": "4f4124773f97c6a0ddf7f84d5a28e0c39e10daf033ddd9c7287891c2403e2484",
+    "https://deno.land/x/jose@v5.9.6/jws/general/sign.ts": "5b977a752ea0261af76608aad8fbcc7ccc9302c62aae8da9dbfead3080ae4515",
+    "https://deno.land/x/jose@v5.9.6/jws/general/verify.ts": "134aeb53aa8e6fdbf1cb38a6cc2f4d40eafa3ea5e465d05ea250c24e3b190922",
+    "https://deno.land/x/jose@v5.9.6/jwt/decrypt.ts": "62e9ff765afea505d325d8aec61e70c2a3e75d0f56dc53b020e42940ab5bd398",
+    "https://deno.land/x/jose@v5.9.6/jwt/encrypt.ts": "0785771759eeaddf74e841cb7430c3af6d793bcef726ad46fb6047297c1cae1d",
+    "https://deno.land/x/jose@v5.9.6/jwt/produce.ts": "4ec3e3966f6d1ce057159c0569a00aacfc2189b4a3c1c395ff992f673942b92c",
+    "https://deno.land/x/jose@v5.9.6/jwt/sign.ts": "b3770b2c880935e0f3049dcbeecf940a1fade71609c4e7e6a51152dfa7bc3655",
+    "https://deno.land/x/jose@v5.9.6/jwt/unsecured.ts": "4002917b0ec0e89962fc8c75edead3a1dc267944f6d51089bf753db8d9fd5b86",
+    "https://deno.land/x/jose@v5.9.6/jwt/verify.ts": "0bdd020d3a06f387f42d63586817fc3bb4104830d9a74c87eb0a5bed2881245c",
+    "https://deno.land/x/jose@v5.9.6/key/export.ts": "1edf905818bcfcbba02c7dd369caf6fb61b6e19d30d4e4d2cd01030ab90f8b2d",
+    "https://deno.land/x/jose@v5.9.6/key/generate_key_pair.ts": "e841708aa07c95167b9f079f420311c22be837319ab0e7b70b68bdafdae2b4ea",
+    "https://deno.land/x/jose@v5.9.6/key/generate_secret.ts": "3f1bb5f8ef4340f20da3464cc7d0258abcee28f6ee7c72626f7048cc7aaa8b2a",
+    "https://deno.land/x/jose@v5.9.6/key/import.ts": "4cec770702f38a3883102776804b05414b7415105c48b9e41f201de08f3b9b5d",
+    "https://deno.land/x/jose@v5.9.6/lib/aesgcmkw.ts": "6d307f6710b2879fdde07c8e39688ece9019f02170334aa216db4878fc7a6ac8",
+    "https://deno.land/x/jose@v5.9.6/lib/buffer_utils.ts": "0b64941bf694bc810b2c917b61474be46c54854da76bb42b20f1642102542ff1",
+    "https://deno.land/x/jose@v5.9.6/lib/cek.ts": "a474becfe1c2d86fbcf3a24cdcd96274beb8d61bd17926e5f345001f39df922b",
+    "https://deno.land/x/jose@v5.9.6/lib/check_iv_length.ts": "118eb531167126c8421d71a21f2cfdc10a658c933e178b33395ef3e962c54f80",
+    "https://deno.land/x/jose@v5.9.6/lib/check_key_type.ts": "633b9b7e08b913dfdb7a9dfdf224cb89e54849e35ca9b396603e898994f8ca51",
+    "https://deno.land/x/jose@v5.9.6/lib/check_p2s.ts": "2f5549e121c43019ac85a3bb3fe8cb98a397122dcaa80f3cd8bf5fcf314e1f67",
+    "https://deno.land/x/jose@v5.9.6/lib/crypto_key.ts": "b75ba81390a90ea741cf174117d96e7851b221ebd9b0dfb806061175c24aed4f",
+    "https://deno.land/x/jose@v5.9.6/lib/decrypt_key_management.ts": "1996df67cfa015131cbf83dd1374852c78de9ee615a10e08fe7a0f9ec3d63811",
+    "https://deno.land/x/jose@v5.9.6/lib/encrypt_key_management.ts": "e79354c3c2bdfeff07dd61e925de0aa1027f8d21e454c774d08c778e09edc269",
+    "https://deno.land/x/jose@v5.9.6/lib/epoch.ts": "cd608f73f6c100e8156c6020ec2bce6757e01759793f0d6aab23908d3d2ea933",
+    "https://deno.land/x/jose@v5.9.6/lib/format_pem.ts": "b5230682e7a89609238015b77f33afd248f3e0f69bcb5895eece2f86d83100f6",
+    "https://deno.land/x/jose@v5.9.6/lib/invalid_key_input.ts": "b82cda3b49cf56806000a85343b005a05735b90e0886ce421a81c71d9088c375",
+    "https://deno.land/x/jose@v5.9.6/lib/is_disjoint.ts": "a3f7ef698413700d0f268314fc879421c134460ced9538518e5feb3eb64d3efe",
+    "https://deno.land/x/jose@v5.9.6/lib/is_jwk.ts": "cabe3150418db9082eafe083705d7e0b1a36a055eeae60f801fb7860813fdf93",
+    "https://deno.land/x/jose@v5.9.6/lib/is_object.ts": "43549ddc51a3b3d4c22b953b191a961fbb61fb5081e8efb88ad075afa1f4d214",
+    "https://deno.land/x/jose@v5.9.6/lib/iv.ts": "4766d9ad87b478bb7344094f38c8561181b72f8678edd1b5226d1e0f9ab677fc",
+    "https://deno.land/x/jose@v5.9.6/lib/jwt_claims_set.ts": "6f3445f718e7d8519c2ba265a65c564feed4aab52bda860bae974756e826eb09",
+    "https://deno.land/x/jose@v5.9.6/lib/private_symbols.ts": "54b4f384282e686c4484cd71249cea2edb860426c2b1927d94cb3438de9e64ca",
+    "https://deno.land/x/jose@v5.9.6/lib/secs.ts": "40e09916007b3a393f20265ea84dc1df43974e86ec796ce0e5e6724f5917a2b8",
+    "https://deno.land/x/jose@v5.9.6/lib/validate_algorithms.ts": "6b20f4b5f6935cd9edcd6eb2128226144ba792eaa7c47966c666a51baf1682eb",
+    "https://deno.land/x/jose@v5.9.6/lib/validate_crit.ts": "b1214ae1413c969efdca2392c6feea9c3b92c531fc7e137c23397e0430421b86",
+    "https://deno.land/x/jose@v5.9.6/runtime/aeskw.ts": "a32bc607d00031ecc42976b69f4e90d73cbac1bc465d1fbace373a8433105d72",
+    "https://deno.land/x/jose@v5.9.6/runtime/asn1.ts": "013a633b824c18663c8c7f7ec8691bfe3dfef82ee58650de0c6d8ee26154bb6a",
+    "https://deno.land/x/jose@v5.9.6/runtime/base64url.ts": "74ecb18b90de56bcc4424b6c911cfe49b56dd4a316978f5c8ee9a23560069636",
+    "https://deno.land/x/jose@v5.9.6/runtime/bogus.ts": "4f1c967b0d9b4e7105e16ad8c173da55708f377ee5e201d8ee5fc613f3417f08",
+    "https://deno.land/x/jose@v5.9.6/runtime/check_cek_length.ts": "2ee093fcb273602449ed7863ab6bd4dd2a7aeff99507e0573e3cd4b8d8099e5d",
+    "https://deno.land/x/jose@v5.9.6/runtime/check_key_length.ts": "7d23fb5910f9ba10383ca0600b63620ff078c7be7788e0626ec1f215992b67be",
+    "https://deno.land/x/jose@v5.9.6/runtime/decrypt.ts": "c53c80b90892b45f39d58e75a46f53032b131f2d9f5b6b74ddd215c79ca3ed8b",
+    "https://deno.land/x/jose@v5.9.6/runtime/digest.ts": "cee73fad56ce596ffedc56811d174ab413e7981eb847eb67c0e77f213cc2ac2d",
+    "https://deno.land/x/jose@v5.9.6/runtime/ecdhes.ts": "787c277cf841c89b462fc40cc05f5ddec9da89e9fc693cb3238936362c522ebd",
+    "https://deno.land/x/jose@v5.9.6/runtime/encrypt.ts": "a5a89b21010d3dda51544020fe4b2ab0d5d91e10044490fccc1af3d5104e8547",
+    "https://deno.land/x/jose@v5.9.6/runtime/fetch_jwks.ts": "34b71aa6bbd51984d1009792499ea17133dcb11bf2f2d8fba60e8090d900fc20",
+    "https://deno.land/x/jose@v5.9.6/runtime/generate.ts": "62f49bc476267d6321eb63040eaeeabbc44ec9a6a10346f2c1238f86e00744cb",
+    "https://deno.land/x/jose@v5.9.6/runtime/get_sign_verify_key.ts": "8e45cd5f6d5a3ae97013e849863b089b26a2a53fdfb613562a1025eaed201c8e",
+    "https://deno.land/x/jose@v5.9.6/runtime/is_key_like.ts": "2380270e1ff76c2b481f50d8057a10bcc1f33962c0f5ab35dc90e236f036731d",
+    "https://deno.land/x/jose@v5.9.6/runtime/jwk_to_key.ts": "5f26c13e737377e501b3817d51c4000fbdfb1736f2da924462a54400552af621",
+    "https://deno.land/x/jose@v5.9.6/runtime/key_to_jwk.ts": "f101d297b1fc9269a9595231899dc06e29e195f6223543b8d4cf651f6559f0f3",
+    "https://deno.land/x/jose@v5.9.6/runtime/normalize_key.ts": "6d25f61fbe4d756dfe390062dba6e73775092af62f0071170ebb3f71bb6fd5d2",
+    "https://deno.land/x/jose@v5.9.6/runtime/pbes2kw.ts": "ad084eb8dd144df8fd5d7e0b824806e35475398be0d3871c2016c3c467e24b19",
+    "https://deno.land/x/jose@v5.9.6/runtime/random.ts": "3e9c8d08208e5dc186ae659535f0018303ff3b56615335bf0dfb5904fe36aab7",
+    "https://deno.land/x/jose@v5.9.6/runtime/rsaes.ts": "124b6e87d8569b39d6f550b371303c79e9eb28aa0d9b14025eeaffe50282c987",
+    "https://deno.land/x/jose@v5.9.6/runtime/runtime.ts": "d748ecb0c1b57020d6f6c41b4458cce74b4d15ab919c38a0ec32d12cee7f5976",
+    "https://deno.land/x/jose@v5.9.6/runtime/sign.ts": "1524f8855538ca5fd607cd681f804ba421b0ec58f562118f3c635324ba053f90",
+    "https://deno.land/x/jose@v5.9.6/runtime/subtle_dsa.ts": "f66955982c3565bf9d8f80220bee5b5737654582b38ea187143cfe26a20e279a",
+    "https://deno.land/x/jose@v5.9.6/runtime/subtle_rsaes.ts": "26147da83932ebf7266d69ddd408f269395de05ddde64ba4e1585571bb61bd93",
+    "https://deno.land/x/jose@v5.9.6/runtime/timing_safe_equal.ts": "fc5b3f4132cec56630eac4677fef2b519707a9c6a257f8ae86515b0d86ff5f6b",
+    "https://deno.land/x/jose@v5.9.6/runtime/verify.ts": "d391e2286b47485247b475016c66999f5146a1cf8331115385a9ba629251c15e",
+    "https://deno.land/x/jose@v5.9.6/runtime/webcrypto.ts": "3365b7d62eaa7e6befe5e2f4f67aa7859805c41b87064433b6e70f94501aa36e",
+    "https://deno.land/x/jose@v5.9.6/util/base64url.ts": "0e09492d36de17c3b40646486b3a31ae7ce060d1bfa7185a52f659aaffc3da0b",
+    "https://deno.land/x/jose@v5.9.6/util/decode_jwt.ts": "a6347360591bd60b076d115fc231e3ecd84aef319922a6c6e94554e68863e3af",
+    "https://deno.land/x/jose@v5.9.6/util/decode_protected_header.ts": "3412c8aacffee93148478f14a0ebb97b2ff060944f49dd233223d262f592ee36",
+    "https://deno.land/x/jose@v5.9.6/util/errors.ts": "b7ecf22990ce73a42650fd09666fb7174fcd91eec387aa26b361269c8022220f",
+    "https://deno.land/x/jose@v5.9.6/util/runtime.ts": "088cae7df0d285065f141d880c5c21a572234997082337d1125d7f1603059642",
     "https://esm.sh/@pdf-lib/standard-fonts@1.0.0/denonext/standard-fonts.mjs": "708d496da295d425f227de54b24c0da9be34cd33f5635d9bdd355dc549b49988",
     "https://esm.sh/@pdf-lib/standard-fonts@1.0.0?target=denonext": "6831e71a173d549ea549bc8ca62160b5309cb77c41a4a34b04bc679c9bb390bf",
     "https://esm.sh/@pdf-lib/upng@1.0.1/denonext/upng.mjs": "725dab6b2d126a6cb418f24ed9bd0aa9400949cbbbe8dcb975241236fdfa2d0d",

--- a/backend/scripts/run_local_server.sh
+++ b/backend/scripts/run_local_server.sh
@@ -219,6 +219,15 @@ else
     echo -e "${YELLOW}⚠️  OAuth credentials not found in ${ENV_FILE}${NC}"
 fi
 
+# Apple Sign-In: config.toml [auth.external.apple] references
+# env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET). If it's unset, the CLI silently drops
+# the whole apple block (provider stays disabled → "provider_disabled" at runtime).
+# Native iOS sign-in (signInWithIdToken) verifies the Apple ID token directly and
+# does NOT use this client secret, so a non-empty local placeholder is sufficient.
+export SUPABASE_AUTH_EXTERNAL_APPLE_SECRET=$(grep "^SUPABASE_AUTH_EXTERNAL_APPLE_SECRET=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d'=' -f2- || true)
+export SUPABASE_AUTH_EXTERNAL_APPLE_SECRET="${SUPABASE_AUTH_EXTERNAL_APPLE_SECRET:-local-dev-placeholder}"
+echo -e "${GREEN}✅ Apple Sign-In secret exported (placeholder ok for native flow)${NC}"
+
 # Load IAP environment variables BEFORE starting Supabase.
 # config.toml [edge_runtime.secrets] uses env() references, so these must be
 # exported to the shell environment BEFORE `supabase start` is called.

--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -413,6 +413,9 @@ verify_jwt = false
 [functions.google-play-webhook]
 verify_jwt = false
 
+[functions.apple-appstore-notifications]
+verify_jwt = false
+
 [functions.razorpay-webhook]
 verify_jwt = false
 

--- a/backend/supabase/functions/apple-appstore-notifications/index.ts
+++ b/backend/supabase/functions/apple-appstore-notifications/index.ts
@@ -1,0 +1,605 @@
+/**
+ * Apple App Store Server Notifications V2 Webhook
+ *
+ * Handles subscription lifecycle events from Apple's App Store Server Notifications V2.
+ * Documentation: https://developer.apple.com/documentation/appstoreservernotifications
+ *
+ * IMPORTANT — Why this does NOT use `createServiceRoleFunction`:
+ * That factory hard-rejects any request lacking `Authorization: Bearer {SERVICE_ROLE_KEY}`
+ * (returns 401/403 *before* the handler runs). Apple's App Store Server Notifications send
+ * NO Authorization header — authenticity is proven by the JWS signature in the body, not a
+ * bearer token. Forcing the factory would make every real Apple call fail. We therefore
+ * mirror `google-play-webhook` exactly: raw `serve()` + a direct service-role
+ * `createClient(...)`. Authentication here is the JWS x5c-chain verification against the
+ * pinned Apple Root CA - G3 (Section 2), which is strictly stronger than Google's static
+ * query-param push token.
+ *
+ * Events handled (notificationType[.subtype]):
+ * - SUBSCRIBED (INITIAL_BUY / RESUBSCRIBE)
+ * - DID_RENEW
+ * - DID_CHANGE_RENEWAL_STATUS (AUTO_RENEW_DISABLED / AUTO_RENEW_ENABLED)
+ * - DID_FAIL_TO_RENEW (GRACE_PERIOD or none)
+ * - GRACE_PERIOD_EXPIRED
+ * - EXPIRED
+ * - REFUND
+ * - REVOKE
+ * - TEST + various log-only types (RENEWAL_EXTENDED, PRICE_INCREASE, OFFER_REDEEMED, ...)
+ */
+
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { Buffer } from 'node:buffer'
+import { corsHeaders } from '../_shared/utils/cors.ts'
+import {
+  SignedDataVerifier,
+  Environment,
+} from 'npm:@apple/app-store-server-library@3.1.0'
+
+// ---------------------------------------------------------------------------
+// Apple Root CA - G3 (pinned trust anchor).
+// DER bytes (base64), source: https://www.apple.com/certificateauthority/AppleRootCA-G3.cer
+// SHA-256: 63343abfb89a6a03ebb57e9b3f5fa7be7c4f5c756f3017b3a8c488c3653e9179
+// Pinned at build time — NEVER fetched at runtime.
+// ---------------------------------------------------------------------------
+const APPLE_ROOT_CA_G3_B64 =
+  'MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwSQXBwbGUgUm9vdCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcNMTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2WjBnMRswGQYDVQQDDBJBcHBsZSBSb290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqGSM49AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtfTjjTuxxEtX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517IDvYuVTZXpmkOlEKMaNCMEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySrMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2gAMGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3meoyhpmvOwgPUnPWTxnS4at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkLF1vLUagM6BgD56KyKA=='
+
+// ---------------------------------------------------------------------------
+// Types — Apple App Store Server Notifications V2 decoded payloads.
+// ---------------------------------------------------------------------------
+interface SignedPayloadBody {
+  signedPayload?: string
+}
+
+interface ResponseBodyV2DecodedPayload {
+  notificationType: string
+  subtype?: string
+  notificationUUID: string
+  version: string
+  signedDate: number
+  data?: {
+    appAppleId?: number
+    bundleId: string
+    bundleVersion?: string
+    environment: 'Sandbox' | 'Production'
+    signedTransactionInfo?: string
+    signedRenewalInfo?: string
+  }
+}
+
+interface JWSTransactionDecodedPayload {
+  transactionId: string
+  originalTransactionId: string
+  bundleId: string
+  productId: string
+  purchaseDate?: number
+  originalPurchaseDate?: number
+  expiresDate?: number
+  type?: string
+  environment?: string
+}
+
+interface JWSRenewalInfoDecodedPayload {
+  originalTransactionId: string
+  autoRenewProductId?: string
+  productId?: string
+  autoRenewStatus?: number // 0 = off, 1 = on
+  expirationIntent?: number
+  gracePeriodExpiresDate?: number
+  environment?: string
+}
+
+// ---------------------------------------------------------------------------
+// JWS / x5c certificate-chain verification (Apple official library).
+//
+// `SignedDataVerifier` performs the FULL security-critical checks that a naive
+// JWS decode does NOT:
+//   - Builds & verifies the x5c chain (leaf -> intermediate -> pinned root).
+//   - Verifies the JWS signature with the leaf public key (ES256 / P-256).
+//   - Enforces cert validity windows and (when enabled) OCSP revocation.
+//   - Asserts the bundleId matches.
+// We instantiate one verifier per environment, lazily cached, with the pinned
+// Apple Root CA - G3 as the only trust anchor.
+// ---------------------------------------------------------------------------
+
+const verifierCache = new Map<string, SignedDataVerifier>()
+
+function getVerifier(environment: 'sandbox' | 'production'): SignedDataVerifier {
+  const cached = verifierCache.get(environment)
+  if (cached) return cached
+
+  const bundleIds = (Deno.env.get('APPLE_BUNDLE_ID') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (bundleIds.length === 0) {
+    throw new Error('APPLE_BUNDLE_ID is not configured')
+  }
+  // The verifier binds to a single bundleId; use the first as the primary.
+  // Additional bundles (multi-bundle setups) are still gate-checked separately
+  // via isBundleAllowed() before processing.
+  const bundleId = bundleIds[0]
+
+  const env = environment === 'sandbox' ? Environment.SANDBOX : Environment.PRODUCTION
+  // appAppleId is required by the library for PRODUCTION.
+  const appAppleIdRaw = Deno.env.get('APPLE_APP_APPLE_ID')
+  const appAppleId = appAppleIdRaw ? Number(appAppleIdRaw) : undefined
+  if (env === Environment.PRODUCTION && (!appAppleId || Number.isNaN(appAppleId))) {
+    throw new Error('APPLE_APP_APPLE_ID is required for PRODUCTION notifications')
+  }
+
+  const root = Buffer.from(APPLE_ROOT_CA_G3_B64, 'base64')
+  // enableOnlineChecks=false: skip per-call OCSP revocation lookups. The full
+  // x5c chain is still cryptographically verified against the pinned Apple Root
+  // CA-G3, so forged payloads are rejected. We disable OCSP because it adds a
+  // hard outbound dependency on Apple's OCSP responder to EVERY webhook — if it
+  // were slow/down, legitimate notifications would be 401'd and lost. Apple
+  // signing-cert revocation is extremely rare; flip to `true` if you want strict
+  // revocation checking and can tolerate that availability risk.
+  const verifier = new SignedDataVerifier([root], false, env, bundleId, appAppleId)
+  verifierCache.set(environment, verifier)
+  return verifier
+}
+
+/**
+ * Verify+decode the outer notification. Determines environment from the
+ * unverified payload first (only to pick the right verifier); the verifier then
+ * cryptographically validates the full chain & signature.
+ */
+async function verifyAndDecodeNotification(
+  signedPayload: string,
+): Promise<ResponseBodyV2DecodedPayload> {
+  // Peek environment from the unverified payload to select the verifier. This is
+  // NOT trusted for auth — the verifier re-validates everything cryptographically.
+  let peekedEnv: 'sandbox' | 'production' = 'production'
+  try {
+    const claimsB64 = signedPayload.split('.')[1]
+    const claims = JSON.parse(atob(claimsB64.replace(/-/g, '+').replace(/_/g, '/')))
+    if (claims?.data?.environment === 'Sandbox') peekedEnv = 'sandbox'
+  } catch {
+    // fall back to production verifier
+  }
+  const verifier = getVerifier(peekedEnv)
+  return (await verifier.verifyAndDecodeNotification(signedPayload)) as unknown as ResponseBodyV2DecodedPayload
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (mirroring google-play-webhook conventions).
+// ---------------------------------------------------------------------------
+
+function getEventType(notificationType: string, subtype?: string): string {
+  return subtype ? `${notificationType}.${subtype}` : notificationType
+}
+
+async function getSubscriptionMetadata(
+  supabase: any,
+  subscriptionId: string,
+): Promise<Record<string, unknown>> {
+  const { data } = await supabase
+    .from('subscriptions')
+    .select('metadata')
+    .eq('id', subscriptionId)
+    .single()
+  return (data?.metadata as Record<string, unknown>) ?? {}
+}
+
+function isBundleAllowed(bundleId: string | undefined): boolean {
+  const allow = (Deno.env.get('APPLE_BUNDLE_ID') ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+  if (allow.length === 0) {
+    console.warn('[APPLE_NOTIFICATIONS] APPLE_BUNDLE_ID not configured — rejecting')
+    return false
+  }
+  return !!bundleId && allow.includes(bundleId)
+}
+
+// ---------------------------------------------------------------------------
+// Webhook entry point.
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders })
+  }
+
+  // ---- Parse body --------------------------------------------------------
+  let body: SignedPayloadBody
+  try {
+    body = await req.json()
+  } catch {
+    return new Response('Bad request', { status: 400, headers: corsHeaders })
+  }
+  const signedPayload = body?.signedPayload
+  if (!signedPayload || typeof signedPayload !== 'string') {
+    return new Response('Missing signedPayload', { status: 400, headers: corsHeaders })
+  }
+
+  // ---- Verify signature (security-critical) ------------------------------
+  let notification: ResponseBodyV2DecodedPayload
+  try {
+    notification = await verifyAndDecodeNotification(signedPayload)
+  } catch (err) {
+    console.warn('[APPLE_NOTIFICATIONS] JWS verification failed:', err instanceof Error ? err.message : err)
+    return new Response('Unauthorized', { status: 401, headers: corsHeaders })
+  }
+
+  // ---- Bundle-id allow-list ----------------------------------------------
+  if (!isBundleAllowed(notification.data?.bundleId)) {
+    console.warn('[APPLE_NOTIFICATIONS] bundleId not in allow-list:', notification.data?.bundleId)
+    return new Response('Unauthorized', { status: 401, headers: corsHeaders })
+  }
+
+  const notificationUUID = notification.notificationUUID
+  const eventType = getEventType(notification.notificationType, notification.subtype)
+  const environment = notification.data?.environment === 'Sandbox' ? 'sandbox' : 'production'
+
+  console.log('[APPLE_NOTIFICATIONS] Verified notification:', {
+    notificationUUID,
+    eventType,
+    environment,
+  })
+
+  // ---- Supabase service-role client --------------------------------------
+  const supabase = createClient(
+    Deno.env.get('SUPABASE_URL')!,
+    Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+  )
+
+  // ---- Idempotency via atomic INSERT ON CONFLICT (notificationUUID) ------
+  const { data: dedupResult, error: dedupError } = await supabase
+    .from('iap_webhook_events')
+    .insert({
+      provider: 'apple_appstore',
+      event_type: 'DEDUP_CHECK',
+      notification_id: notificationUUID,
+      raw_payload: {},
+      processing_status: 'pending',
+    })
+    .select('id')
+    .single()
+
+  if (dedupError) {
+    if (dedupError.code === '23505') {
+      console.log('[APPLE_NOTIFICATIONS] Duplicate notification (constraint), skipping')
+      return new Response('OK', { status: 200, headers: corsHeaders })
+    }
+    const { data: existing } = await supabase
+      .from('iap_webhook_events')
+      .select('id')
+      .eq('provider', 'apple_appstore')
+      .eq('notification_id', notificationUUID)
+      .maybeSingle()
+    if (existing) {
+      console.log('[APPLE_NOTIFICATIONS] Duplicate notification, skipping')
+      return new Response('OK', { status: 200, headers: corsHeaders })
+    }
+    // Transient DB error on the dedup insert AND no existing row: fail closed so
+    // Apple re-delivers. Proceeding here with an undefined dedupRowId would skip
+    // recording the event and lose replay protection for this notificationUUID.
+    console.error('[APPLE_NOTIFICATIONS] Dedup insert error:', dedupError)
+    return new Response('Internal server error', { status: 500, headers: corsHeaders })
+  }
+  const dedupRowId = dedupResult!.id
+
+  // ---- Decode inner JWS (independently signed) ---------------------------
+  let tx: JWSTransactionDecodedPayload | null = null
+  let renew: JWSRenewalInfoDecodedPayload | null = null
+  try {
+    const verifier = getVerifier(environment)
+    if (notification.data?.signedTransactionInfo) {
+      tx = (await verifier.verifyAndDecodeTransaction(
+        notification.data.signedTransactionInfo,
+      )) as unknown as JWSTransactionDecodedPayload
+    }
+    if (notification.data?.signedRenewalInfo) {
+      renew = (await verifier.verifyAndDecodeRenewalInfo(
+        notification.data.signedRenewalInfo,
+      )) as unknown as JWSRenewalInfoDecodedPayload
+    }
+  } catch (err) {
+    console.warn('[APPLE_NOTIFICATIONS] Inner JWS verification failed:', err instanceof Error ? err.message : err)
+    return new Response('Unauthorized', { status: 401, headers: corsHeaders })
+  }
+
+  // ---- Store the verified event on the dedup row -------------------------
+  const { data: webhookEvent, error: webhookError } = await supabase
+    .from('iap_webhook_events')
+    .update({
+      event_type: eventType,
+      raw_payload: notification as unknown as Record<string, unknown>,
+      parsed_data: { transaction: tx, renewal: renew, environment } as unknown as Record<string, unknown>,
+      transaction_id: tx?.transactionId ?? null,
+      processing_status: 'pending',
+    })
+    .eq('id', dedupRowId)
+    .select()
+    .single()
+
+  if (webhookError || !webhookEvent) {
+    console.error('[APPLE_NOTIFICATIONS] Failed to store event:', webhookError)
+    return new Response('Internal server error', { status: 500, headers: corsHeaders })
+  }
+
+  // ---- Log-only / no-subscription-touch event types ----------------------
+  const LOG_ONLY = new Set([
+    'TEST',
+    'RENEWAL_EXTENDED',
+    'RENEWAL_EXTENSION',
+    'PRICE_INCREASE',
+    'OFFER_REDEEMED',
+    'CONSUMPTION_REQUEST',
+    'DID_CHANGE_RENEWAL_PREF',
+    'METADATA_UPDATE',
+  ])
+  if (LOG_ONLY.has(notification.notificationType)) {
+    console.log('[APPLE_NOTIFICATIONS] Log-only event:', eventType)
+    await supabase
+      .from('iap_webhook_events')
+      .update({ processing_status: 'processed', processed_at: new Date().toISOString() })
+      .eq('id', webhookEvent.id)
+    return new Response('OK', { status: 200, headers: corsHeaders })
+  }
+
+  // ---- Locate the subscription via stable originalTransactionId ----------
+  // Apple's transactionId rotates per renewal; originalTransactionId is stable.
+  // Primary: subscriptions.iap_original_transaction_id.
+  // Fallback: iap_receipts.transaction_id (purchase-time transactionId).
+  if (!tx) {
+    await supabase
+      .from('iap_webhook_events')
+      .update({
+        processing_status: 'failed',
+        error_message: 'Missing signedTransactionInfo',
+        processed_at: new Date().toISOString(),
+      })
+      .eq('id', webhookEvent.id)
+    // Permanent (won't recover on retry) — ack with 200 to stop retry storm.
+    return new Response('OK', { status: 200, headers: corsHeaders })
+  }
+
+  let subscriptionId: string | null = null
+  let receiptId: string | null = null
+
+  const { data: subByOriginal } = await supabase
+    .from('subscriptions')
+    .select('id, iap_receipt_id')
+    .eq('provider', 'apple_appstore')
+    .eq('iap_original_transaction_id', tx.originalTransactionId)
+    .maybeSingle()
+
+  if (subByOriginal) {
+    subscriptionId = subByOriginal.id
+    receiptId = subByOriginal.iap_receipt_id
+  } else {
+    // Fallback: match receipt by the original/current transactionId.
+    const { data: receipt } = await supabase
+      .from('iap_receipts')
+      .select('id, subscription_id')
+      .eq('provider', 'apple_appstore')
+      .in('transaction_id', [tx.originalTransactionId, tx.transactionId])
+      .maybeSingle()
+    if (receipt) {
+      receiptId = receipt.id
+      subscriptionId = receipt.subscription_id
+    }
+  }
+
+  if (!subscriptionId) {
+    // Receipt/subscription not yet created (timing race with create-subscription).
+    // Mark pending; a cron can retry. Ack 200 so Apple stops re-delivering.
+    console.warn('[APPLE_NOTIFICATIONS] Subscription not found for originalTransactionId:', tx.originalTransactionId)
+    await supabase
+      .from('iap_webhook_events')
+      .update({
+        processing_status: 'pending',
+        error_message: 'Receipt not found - pending retry',
+        receipt_id: receiptId,
+        processed_at: null,
+      })
+      .eq('id', webhookEvent.id)
+    return new Response('OK', { status: 200, headers: corsHeaders })
+  }
+
+  await supabase
+    .from('iap_webhook_events')
+    .update({ receipt_id: receiptId, subscription_id: subscriptionId })
+    .eq('id', webhookEvent.id)
+
+  // ---- Process the event --------------------------------------------------
+  try {
+    await processNotification(supabase, notification, tx, renew, subscriptionId, receiptId, environment)
+
+    await supabase
+      .from('iap_webhook_events')
+      .update({ processing_status: 'processed', processed_at: new Date().toISOString() })
+      .eq('id', webhookEvent.id)
+
+    console.log('[APPLE_NOTIFICATIONS] Event processed successfully:', eventType)
+    return new Response('OK', { status: 200, headers: corsHeaders })
+  } catch (processingError) {
+    console.error('[APPLE_NOTIFICATIONS] Processing error:', processingError)
+    await supabase
+      .from('iap_webhook_events')
+      .update({
+        processing_status: 'failed',
+        error_message: processingError instanceof Error ? processingError.message : 'Unknown error',
+        processed_at: new Date().toISOString(),
+      })
+      .eq('id', webhookEvent.id)
+    // Transient — return 500 so Apple re-delivers.
+    return new Response('Internal server error', { status: 500, headers: corsHeaders })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Subscription state machine — maps notificationType[.subtype] to updates.
+// ---------------------------------------------------------------------------
+async function processNotification(
+  supabase: any,
+  notification: ResponseBodyV2DecodedPayload,
+  tx: JWSTransactionDecodedPayload,
+  renew: JWSRenewalInfoDecodedPayload | null,
+  subscriptionId: string,
+  receiptId: string | null,
+  environment: 'sandbox' | 'production',
+): Promise<void> {
+  const type = notification.notificationType
+  const subtype = notification.subtype
+  const now = new Date().toISOString()
+  // Apple V2 timestamps are epoch MILLISECONDS. Guard against an unparseable
+  // value so a bad date can't throw and trigger an Apple retry storm.
+  const expiresDateObj = tx.expiresDate ? new Date(tx.expiresDate) : null
+  const expiresIso =
+    expiresDateObj && !Number.isNaN(expiresDateObj.getTime())
+      ? expiresDateObj.toISOString()
+      : undefined
+  const autoRenewOff = renew?.autoRenewStatus === 0
+
+  switch (type) {
+    // -- New subscription / resubscribe --------------------------------------
+    case 'SUBSCRIBED': {
+      const meta = await getSubscriptionMetadata(supabase, subscriptionId)
+      const { paused, paused_at, in_grace_period, grace_period_started_at, grace_period_expires_at, on_hold, on_hold_at, billing_retry, ...rest } = meta
+      await supabase.from('subscriptions').update({
+        status: 'active',
+        ...(expiresIso ? { current_period_end: expiresIso } : {}),
+        cancel_at_cycle_end: false,
+        metadata: rest,
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      break
+    }
+
+    // -- Renewal succeeded ---------------------------------------------------
+    case 'DID_RENEW': {
+      const meta = await getSubscriptionMetadata(supabase, subscriptionId)
+      const { in_grace_period, grace_period_started_at, grace_period_expires_at, billing_retry, ...rest } = meta
+      await supabase.from('subscriptions').update({
+        status: 'active',
+        ...(expiresIso ? { current_period_end: expiresIso } : {}),
+        // Only touch the renewal flag when renewal info is actually present —
+        // otherwise a missing signedRenewalInfo would silently clear a prior cancel.
+        ...(renew ? { cancel_at_cycle_end: autoRenewOff } : {}),
+        metadata: rest,
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      break
+    }
+
+    // -- Auto-renew toggled --------------------------------------------------
+    case 'DID_CHANGE_RENEWAL_STATUS': {
+      if (subtype === 'AUTO_RENEW_DISABLED') {
+        await supabase.from('subscriptions').update({
+          status: 'pending_cancellation',
+          cancel_at_cycle_end: true,
+          cancelled_at: now,
+          updated_at: now,
+        }).eq('id', subscriptionId)
+      } else {
+        // AUTO_RENEW_ENABLED (re-enabled before expiry)
+        await supabase.from('subscriptions').update({
+          status: 'active',
+          cancel_at_cycle_end: false,
+          cancelled_at: null,
+          cancellation_reason: null,
+          updated_at: now,
+        }).eq('id', subscriptionId)
+      }
+      break
+    }
+
+    // -- Renewal failed ------------------------------------------------------
+    case 'DID_FAIL_TO_RENEW': {
+      const meta = await getSubscriptionMetadata(supabase, subscriptionId)
+      if (subtype === 'GRACE_PERIOD') {
+        // Access maintained during grace window.
+        const graceExpiry = renew?.gracePeriodExpiresDate
+          ? new Date(renew.gracePeriodExpiresDate).toISOString()
+          : expiresIso
+        await supabase.from('subscriptions').update({
+          status: 'active',
+          ...(graceExpiry ? { current_period_end: graceExpiry } : {}),
+          metadata: {
+            ...meta,
+            in_grace_period: true,
+            grace_period_started_at: now,
+            grace_period_expires_at: graceExpiry,
+            billing_retry: true,
+          },
+          updated_at: now,
+        }).eq('id', subscriptionId)
+      } else {
+        // No grace period -> suspend access.
+        await supabase.from('subscriptions').update({
+          status: 'on_hold',
+          metadata: { ...meta, on_hold: true, on_hold_at: now, billing_retry: true },
+          updated_at: now,
+        }).eq('id', subscriptionId)
+      }
+      break
+    }
+
+    // -- Grace window closed without recovery --------------------------------
+    case 'GRACE_PERIOD_EXPIRED': {
+      const meta = await getSubscriptionMetadata(supabase, subscriptionId)
+      const { in_grace_period, grace_period_started_at, grace_period_expires_at, ...rest } = meta
+      await supabase.from('subscriptions').update({
+        status: 'expired',
+        metadata: rest,
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      break
+    }
+
+    // -- Hard expiry ---------------------------------------------------------
+    case 'EXPIRED': {
+      await supabase.from('subscriptions').update({
+        status: 'expired',
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      break
+    }
+
+    // -- Refund (access revoked) ---------------------------------------------
+    case 'REFUND': {
+      await supabase.from('subscriptions').update({
+        status: 'cancelled',
+        cancelled_at: now,
+        cancellation_reason: 'Refunded',
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      if (receiptId) {
+        await supabase.from('iap_receipts').update({
+          validation_status: 'refunded',
+          updated_at: now,
+        }).eq('id', receiptId)
+      }
+      break
+    }
+
+    // -- Family Sharing access revoked ---------------------------------------
+    case 'REVOKE': {
+      await supabase.from('subscriptions').update({
+        status: 'cancelled',
+        cancelled_at: now,
+        cancellation_reason: 'Family Sharing revoked',
+        updated_at: now,
+      }).eq('id', subscriptionId)
+      if (receiptId) {
+        await supabase.from('iap_receipts').update({
+          validation_status: 'cancelled',
+          updated_at: now,
+        }).eq('id', receiptId)
+      }
+      break
+    }
+
+    default:
+      console.log('[APPLE_NOTIFICATIONS] Unhandled notificationType (no-op):', type, subtype)
+  }
+}

--- a/backend/supabase/migrations/20260613000001_add_on_hold_subscription_status.sql
+++ b/backend/supabase/migrations/20260613000001_add_on_hold_subscription_status.sql
@@ -1,0 +1,27 @@
+-- Add 'on_hold' to the subscriptions.status CHECK constraint.
+--
+-- Both the Google Play webhook (SUBSCRIPTION_ON_HOLD) and the new Apple App Store
+-- Server Notifications V2 webhook (DID_FAIL_TO_RENEW without a grace period)
+-- write status = 'on_hold' to suspend access when a renewal payment fails.
+--
+-- The original constraint in 20260119000300_subscription_system.sql did NOT include
+-- 'on_hold', so those writes would violate the CHECK constraint. This migration
+-- recreates the constraint with 'on_hold' added. (This also fixes a latent bug in
+-- the existing google-play-webhook handler.)
+
+ALTER TABLE subscriptions
+  DROP CONSTRAINT IF EXISTS subscriptions_status_check;
+
+ALTER TABLE subscriptions
+  ADD CONSTRAINT subscriptions_status_check CHECK (status IN (
+    'trial',                -- Trial period subscription
+    'created',              -- Initial state
+    'in_progress',          -- Payment in progress
+    'active',               -- Active subscription
+    'pending_cancellation', -- Cancelled but still in grace period (auto-renew off)
+    'paused',               -- User voluntarily paused
+    'on_hold',              -- Renewal payment failed, access suspended (provider hold)
+    'cancelled',            -- User cancelled / refunded / revoked
+    'completed',            -- Subscription period completed
+    'expired'               -- Subscription expired without renewal
+  ));

--- a/docs/release/ios-app-store-metadata-v1.0.0.md
+++ b/docs/release/ios-app-store-metadata-v1.0.0.md
@@ -1,0 +1,179 @@
+# iOS App Store Metadata — Disciplefy v1.0.0
+
+Copy-paste values for App Store Connect → **Distribution → iOS App 1.0.0** (English, U.K. locale).
+Char limits noted per field.
+
+---
+
+## Localizable Information
+
+**Name** _(≤ 30)_ — already set:
+```
+Disciplefy - Bible Study App
+```
+
+**Subtitle** _(≤ 30)_ — recommended:
+```
+AI study guides in 3 languages
+```
+Alternates: `AI study guides & daily verse` (29) · `Study guides in your language` (29) · `AI guides in your language` (26).
+
+---
+
+## Promotional Text  _(≤ 170)_
+
+```
+Type any verse or topic and get an instant study guide — context, interpretation & prayer points, plus a Voice Discipler. In English, हिन्दी & മലയാളം.
+```
+
+---
+
+## Description  _(≤ 4,000)_
+
+```
+Disciplefy turns any Bible verse or question into a clear, personal study guide — in seconds, in your language.
+
+Type a reference like "John 3:16" or ask something real like "What does the Bible say about anxiety?" and get an instant, easy-to-follow guide: a plain-language summary, historical and cultural context, verse-by-verse interpretation, practical life application, reflection questions, prayer points, and related scriptures — all grounded in sound, historic Christian theology.
+
+WHY DISCIPLEFY
+• Understand the Bible, not just read it — context and meaning made clear
+• Built for English, हिन्दी and മലയാളം — study and pray in the language you think in
+• A companion that points you back to Scripture and prayer — never a replacement for your Bible or your church
+
+FEATURES
+• Study Guides — instant, structured guides for any verse or topic
+• Voice Discipler — have a natural spoken conversation about a passage or question and hear answers in your language
+• Follow-Up Chat — ask deeper questions about any guide while keeping the full context
+• Learning Paths — structured discipleship journeys on Grace, Prayer, Faith, Discipleship and more
+• Daily Verse — a fresh verse and short devotional each day, with reminders
+• Memory Verses — spaced-repetition flashcards with audio and fill-in-the-blank modes to truly memorise God's Word
+• Fellowship Groups — study together, schedule Google Meet sessions, and share prayer requests and praise reports
+
+HOW IT WORKS
+1. Choose a verse or topic
+2. Get a complete study guide in seconds
+3. Talk it through with your Voice Discipler
+4. Follow a learning path to grow with direction
+5. Memorise, build streaks, and keep growing
+
+Start free — no credit card required. Optional plans unlock more.
+
+Whether you're a new believer taking first steps, a busy disciple who wants depth without spending hours, or someone exploring faith for the first time, Disciplefy helps you meet God in His Word — anytime, anywhere.
+
+"Your word is a lamp to my feet and a light to my path." — Psalm 119:105
+```
+
+---
+
+## Keywords  _(≤ 100 — comma-separated, no spaces after commas)_
+
+```
+devotional,scripture,prayer,daily verse,christian,faith,gospel,discipleship,jesus,hindi,malayalam
+```
+
+> Note: "Bible", "Study", "App" are intentionally omitted — they're already in the app title and indexed automatically, so they'd waste keyword space.
+
+---
+
+## Support URL
+
+```
+https://www.disciplefy.in/contact
+```
+
+## Marketing URL
+
+```
+https://www.disciplefy.in/
+```
+
+## Version
+
+```
+1.0.0
+```
+
+## Copyright  _(≤ 200)_
+
+```
+© 2026 Disciplefy
+```
+
+> Swap in your registered legal entity name if Disciplefy operates under one (e.g. `© 2026 <Legal Name>`).
+
+## Routing App Coverage File
+
+**Leave empty** — only for apps providing maps / turn-by-turn directions. Not applicable.
+
+---
+
+## ⚠️ Still required before "Add for Review"
+
+- **App Review Information** — demo account credentials (login-required app) + review notes. _Biggest cause of rejection for sign-in apps._
+- **Screenshots** for required device sizes.
+- **App Privacy** answers (account data, usage, payments).
+- **Age Rating** questionnaire.
+- **Pricing and Availability**.
+- **Subscriptions / In-App Purchases** must be submitted/approved alongside the build.
+
+---
+
+_Theological note: copy frames the AI as a study **companion** (not a replacement for Scripture or church) and is consistent with orthodox Christian theology._
+
+---
+
+## App Review → Notes  _(≤ 4,000)_
+
+```
+ACCESSING THE APP (no demo account needed)
+This app requires sign-in. The simplest way to review it is to tap "Continue with Apple" on the login screen and authenticate with your own Apple ID — Sign in with Apple is fully supported. "Continue with Google" is also available. There is no guest mode; an account is required.
+
+Account deletion is available in-app: Settings → Delete Account (removes the account and associated data).
+
+WHAT THE APP DOES
+Disciplefy generates structured Bible study guides from any verse or topic using an LLM. Enter a reference (e.g. "John 3:16") or a question (e.g. "What does the Bible say about anxiety?") and the app returns a guide with summary, historical context, interpretation, application, reflection questions, prayer points, and related verses. Content is in English, Hindi, or Malayalam.
+
+KEY FEATURES TO TEST
+• Study Guides — type a verse/topic on the home screen → "Generate".
+• Voice Discipler — a spoken conversation feature. It needs Microphone + Speech Recognition permission (granted on first use). NOTE: speech recognition does not work on the iOS Simulator (Apple limitation) — please test on a physical device.
+• Daily Verse, Learning Paths, Memory Verses, Follow-Up Chat, Fellowship groups.
+
+PERMISSIONS & WHY
+• Microphone + Speech Recognition — Voice Discipler (speak to ask questions).
+• Notifications — optional daily verse / reminders.
+
+IN-APP PURCHASES
+The core app is free. Optional consumable "token" packs and an auto-renewing subscription unlock additional AI generations. Free users can fully evaluate the app without purchasing.
+
+CONTENT & PRIVACY
+• AI-generated study content is grounded in historic, orthodox Christian theology; user inputs are validated/sanitized server-side.
+• Fellowship groups are private (invite-based) — there is no public user-generated content feed.
+
+CONTACT
+Support: https://www.disciplefy.in/contact
+```
+
+> **Sign-in caveat:** "Continue with Apple" must work in **production** for reviewers (you confirmed Apple is enabled on the prod Supabase project). If there's any doubt, also keep a working Google review path.
+
+---
+
+## What's New (release notes) — v1.0.0  _(first release)_
+
+```
+Welcome to Disciplefy! Turn any Bible verse or topic into a clear, personal study guide — in English, Hindi, or Malayalam.
+
+• Instant study guides with context, interpretation, application & prayer points
+• Voice Discipler — talk through Scripture and hear answers in your language
+• Daily Verse, Learning Paths, Memory Verses, Follow-Up Chat & Fellowship groups
+
+Thank you for installing — we'd love your feedback.
+```
+
+> Note: for a brand-new app, the "What's New" field may not appear (it's used for updates). Use it from v1.0.1 onward if 1.0.0 doesn't show it.
+
+---
+
+## Attachment
+
+Optional — leave empty unless asked. (A short screen-recording can help if a feature is non-obvious, but it's not required.)
+

--- a/frontend/ios/Disciplefy.storekit
+++ b/frontend/ios/Disciplefy.storekit
@@ -1,0 +1,90 @@
+{
+  "identifier" : "DISCIPLEFY_STOREKIT_CONFIG",
+  "nonRenewingSubscriptions" : [],
+  "products" : [],
+  "settings" : {
+    "_applicationInternalID" : "6778309947",
+    "_developerTeamID" : "4V6VA2U9MW",
+    "_failTransactionsEnabled" : false,
+    "_lastSynchronizedDate" : 0,
+    "_locale" : "en_IN",
+    "_storefront" : "IND",
+    "_storeKitErrors" : []
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21500100",
+      "localizations" : [],
+      "name" : "Disciplefy Membership",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "499",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "21500101",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Unlimited AI study, Voice Discipler & all features",
+              "displayName" : "Premium",
+              "locale" : "en_IN"
+            }
+          ],
+          "productID" : "com.disciplefy.premium_monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Disciplefy Premium (Monthly)",
+          "subscriptionGroupID" : "21500100",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "149",
+          "familyShareable" : false,
+          "groupNumber" : 2,
+          "internalID" : "21500102",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "All study modes, more Voice sessions, lead groups",
+              "displayName" : "Plus",
+              "locale" : "en_IN"
+            }
+          ],
+          "productID" : "com.disciplefy.plus_monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Disciplefy Plus (Monthly)",
+          "subscriptionGroupID" : "21500100",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [],
+          "codeOffers" : [],
+          "displayPrice" : "79",
+          "familyShareable" : false,
+          "groupNumber" : 3,
+          "internalID" : "21500103",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Voice Discipler, core study modes & Fellowship",
+              "displayName" : "Standard",
+              "locale" : "en_IN"
+            }
+          ],
+          "productID" : "com.disciplefy.standard_monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Disciplefy Standard (Monthly)",
+          "subscriptionGroupID" : "21500100",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/frontend/ios/Runner.xcodeproj/project.pbxproj
+++ b/frontend/ios/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		0D429D4BFB336F357EDE48D6 /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		14C5520C2FDD804200F921A5 /* Disciplefy.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Disciplefy.storekit; sourceTree = "<group>"; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
@@ -133,6 +134,7 @@
 		97C146E51CF9000F007C117D = {
 			isa = PBXGroup;
 			children = (
+				14C5520C2FDD804200F921A5 /* Disciplefy.storekit */,
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,

--- a/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1510"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -73,6 +73,13 @@
             ReferencedContainer = "container:Runner.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <LocationScenarioReference
+         identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+         referenceType = "1">
+      </LocationScenarioReference>
+      <StoreKitConfigurationFileReference
+         identifier = "../Disciplefy.storekit">
+      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Profile"

--- a/frontend/lib/features/voice_buddy/data/services/speech_service.dart
+++ b/frontend/lib/features/voice_buddy/data/services/speech_service.dart
@@ -1,3 +1,7 @@
+import 'dart:io' show Platform;
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:speech_to_text/speech_recognition_error.dart';
 import 'package:speech_to_text/speech_recognition_result.dart';
 import 'package:speech_to_text/speech_to_text.dart';
 import '../../../../core/utils/logger.dart';
@@ -18,6 +22,24 @@ class SpeechService {
   /// Whether speech recognition is available on the device.
   bool get isAvailable => _speechToText.isAvailable;
 
+  bool? _isIosSimulator;
+
+  /// True when running on the iOS Simulator, where `speech_to_text` cannot start
+  /// the audio engine (SFSpeechRecognizer) and always fails with
+  /// `error_listen_failed`. Callers use this to show a clear message instead of
+  /// retrying endlessly. Cached after the first lookup.
+  Future<bool> isIosSimulator() async {
+    if (_isIosSimulator != null) return _isIosSimulator!;
+    if (kIsWeb || !Platform.isIOS) return _isIosSimulator = false;
+    try {
+      final info = await DeviceInfoPlugin().iosInfo;
+      _isIosSimulator = !info.isPhysicalDevice;
+    } catch (_) {
+      _isIosSimulator = false;
+    }
+    return _isIosSimulator!;
+  }
+
   /// Initialize the speech recognition service.
   ///
   /// Returns true if initialization was successful.
@@ -27,8 +49,9 @@ class SpeechService {
     try {
       _isInitialized = await _speechToText.initialize(
         onError: (error) {
-          // Log error but don't throw - let caller handle via result
+          // Log error but don't throw - let caller handle via the callback/result
           Logger.error('🎙️ [SPEECH] Error: ${error.errorMsg}');
+          _onError?.call(error);
         },
         onStatus: (status) {
           // Status updates: listening, notListening, done
@@ -61,6 +84,9 @@ class SpeechService {
   /// Callback for status changes (listening, notListening, done)
   void Function(String status)? _onStatusChange;
 
+  /// Callback for recognition errors (e.g. error_listen_failed, error_no_match).
+  void Function(SpeechRecognitionError error)? _onError;
+
   /// Start listening for speech input.
   ///
   /// [languageCode] - The language to recognize (e.g., 'en-US', 'hi-IN', 'ml-IN')
@@ -74,6 +100,7 @@ class SpeechService {
     required void Function(SpeechRecognitionResult result) onResult,
     void Function(double level)? onSoundLevelChange,
     void Function(String status)? onStatusChange,
+    void Function(SpeechRecognitionError error)? onError,
     Duration pauseFor = const Duration(seconds: 60),
     Duration listenFor = const Duration(seconds: 60),
     bool partialResults = true,
@@ -89,16 +116,23 @@ class SpeechService {
       await stopListening();
     }
 
-    // Store the status callback for use in initialize's onStatus
+    // Store callbacks for use in initialize's onStatus/onError handlers.
     _onStatusChange = onStatusChange;
+    _onError = onError;
 
     await _speechToText.listen(
       onResult: onResult,
       localeId: languageCode,
       pauseFor: pauseFor,
       listenFor: listenFor,
-      partialResults: partialResults,
       onSoundLevelChange: onSoundLevelChange,
+      // dictation mode suits free-form conversation (the default `confirmation`
+      // mode stops too early); cancelOnError avoids a stuck session.
+      listenOptions: SpeechListenOptions(
+        listenMode: ListenMode.dictation,
+        partialResults: partialResults,
+        cancelOnError: true,
+      ),
     );
   }
 

--- a/frontend/lib/features/voice_buddy/presentation/bloc/voice_conversation_bloc.dart
+++ b/frontend/lib/features/voice_buddy/presentation/bloc/voice_conversation_bloc.dart
@@ -49,6 +49,10 @@ class VoiceConversationBloc
   /// Whether user has started speaking in current session
   bool _hasStartedSpeaking = false;
 
+  /// Consecutive speech-recognizer start failures (error_listen_failed). Used to
+  /// break the continuous-listen retry loop instead of spinning forever.
+  int _consecutiveListenFailures = 0;
+
   /// Buffer for accumulating text chunks during streaming TTS
   String _streamingSentenceBuffer = '';
 
@@ -93,6 +97,7 @@ class VoiceConversationBloc
     on<ChangeLanguage>(_onChangeLanguage);
     on<PlaybackCompleted>(_onPlaybackCompleted);
     on<SpeechStatusChanged>(_onSpeechStatusChanged);
+    on<SpeechRecognitionErrorOccurred>(_onSpeechRecognitionError);
   }
 
   /// Called by VAD service when silence is detected (ready to auto-send)
@@ -349,6 +354,7 @@ class VoiceConversationBloc
     try {
       await _speechService.startListening(
         languageCode: state.languageCode,
+        onError: (error) => add(SpeechRecognitionErrorOccurred(error.errorMsg)),
         // Defaults: listenFor=60s, pauseFor=60s
         // 3-second silence detection is handled by _silenceAfterSpeechTimer
         onResult: (result) {
@@ -400,6 +406,9 @@ class VoiceConversationBloc
           // Use _bestTranscription (not `text`) to avoid sending a truncated
           // result when stop() caused the engine to return fewer words.
           if (result.finalResult && _bestTranscription.isNotEmpty) {
+            // A successful result proves the recognizer started fine — reset the
+            // failure counter so a future hiccup gets the full retry budget again.
+            _consecutiveListenFailures = 0;
             // Cancel silence timer since we're sending via finalResult
             _silenceAfterSpeechTimer?.cancel();
             _silenceAfterSpeechTimer = null;
@@ -1319,6 +1328,41 @@ class VoiceConversationBloc
     Emitter<VoiceConversationState> emit,
   ) {
     emit(state.copyWith(languageCode: event.languageCode));
+  }
+
+  /// Handles speech-recognizer errors. `error_no_match` is benign (heard nothing).
+  /// `error_listen_failed` means the recognizer couldn't start — on the iOS
+  /// Simulator (where it never can) or after repeated failures, we stop the
+  /// continuous-listen retry loop and surface a clear message instead of spinning.
+  Future<void> _onSpeechRecognitionError(
+    SpeechRecognitionErrorOccurred event,
+    Emitter<VoiceConversationState> emit,
+  ) async {
+    if (event.errorMsg != 'error_listen_failed') return;
+
+    _consecutiveListenFailures++;
+
+    final isSimulator = await _speechService.isIosSimulator();
+    if (!isSimulator && _consecutiveListenFailures < 2) {
+      return; // transient — allow the normal flow to retry within budget
+    }
+
+    // Give up: stop the retry storm and tell the user what's actually wrong.
+    _consecutiveListenFailures = 0;
+    _silenceAfterSpeechTimer?.cancel();
+    _silenceAfterSpeechTimer = null;
+    _vadService.stop();
+    await _speechService.cancelListening();
+    _speechSubscription?.cancel();
+
+    emit(state.copyWith(
+      status: VoiceConversationStatus.error,
+      isListening: false,
+      isContinuousMode: false, // prevent the auto re-arm loop
+      errorMessage: isSimulator
+          ? 'Voice input isn\'t available on the iOS Simulator. Please use a real device.'
+          : 'Couldn\'t start the microphone. Please check permissions and try again.',
+    ));
   }
 
   /// Handle speech recognition status changes.

--- a/frontend/lib/features/voice_buddy/presentation/bloc/voice_conversation_event.dart
+++ b/frontend/lib/features/voice_buddy/presentation/bloc/voice_conversation_event.dart
@@ -225,3 +225,14 @@ class SpeechStatusChanged extends VoiceConversationEvent {
   @override
   List<Object?> get props => [status];
 }
+
+/// Emitted when the speech recognizer reports an error (e.g. error_listen_failed,
+/// error_no_match). Used to stop the continuous-listen retry storm.
+class SpeechRecognitionErrorOccurred extends VoiceConversationEvent {
+  final String errorMsg;
+
+  const SpeechRecognitionErrorOccurred(this.errorMsg);
+
+  @override
+  List<Object?> get props => [errorMsg];
+}


### PR DESCRIPTION
## Summary
Release-prep + fixes for iOS v1.0.0. Six commits:

### feat(backend): Apple App Store Server Notifications V2 webhook
- New `apple-appstore-notifications` edge function (mirrors `google-play-webhook`). **Signature is cryptographically verified** via Apple's official `@apple/app-store-server-library` (`SignedDataVerifier`) — full x5c chain → pinned Apple Root CA-G3, bundle-id binding. Adversarially reviewed: forged payloads are rejected, not just decoded.
- Maps `notificationType`/`subtype` (DID_RENEW, EXPIRED, REFUND, REVOKE, DID_CHANGE_RENEWAL_STATUS, GRACE_PERIOD_EXPIRED…) → `subscriptions` updates; dedupes on `notificationUUID`; sandbox/production aware.
- Migration `20260613000001` adds `'on_hold'` subscription status (also fixes a latent bug in the existing Google webhook handler).
- `config.toml`: registers the function with `verify_jwt = false` (auth = the JWS signature, not a bearer token).
- Review fixes applied: fail-closed dedup hole, guarded `cancel_at_cycle_end` on DID_RENEW, invalid-date guard, `enableOnlineChecks=false` (chain still verified; avoids hard per-call OCSP dependency).

### fix(frontend): harden Voice Discipler speech
- `listenMode: dictation`, iOS-Simulator detection (`device_info_plus`), and stops the `error_listen_failed` retry storm with a clear user message. (Speech recognition only works on real devices, not the Simulator.)

### fix(backend): Apple sign-in works locally
- `run_local_server.sh` now exports `SUPABASE_AUTH_EXTERNAL_APPLE_SECRET` so `config.toml`'s `[auth.external.apple]` block actually applies (was silently dropped → `provider_disabled`).

### ci(backend): Apple IAP/notification secrets on deploy
- Deploy workflow pushes `APPLE_SHARED_SECRET`, `APPLE_BUNDLE_ID`, `APPLE_APP_APPLE_ID` to the Supabase runtime.

### docs(release): iOS App Store metadata
- `docs/release/ios-app-store-metadata-v1.0.0.md` — name/subtitle, description, keywords, review notes, age-rating answers, etc.

## ⚠️ Post-merge actions
- Merging triggers the prod **backend deploy** (applies the `on_hold` migration + sets the new Apple secrets).
- In **App Store Connect → App Store Server Notifications**, set the **Production + Sandbox** URLs to `https://<ref>.supabase.co/functions/v1/apple-appstore-notifications`.

## Test plan
- Apple webhook: deno-check clean; library verified to load + reject invalid JWS in Deno. Validate end-to-end with a StoreKit sandbox subscription + Apple's "request a test notification".
- Voice: confirm on a physical iPhone (Simulator now shows a clear "not supported" message instead of looping).
- Apple sign-in: works locally after `supabase stop && start`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple App Store Server Notifications support added — full subscription lifecycle handling (renewals, cancellations, expirations) and new "on_hold" subscription state.
  * Local StoreKit configuration for testing subscription tiers in the iOS simulator.

* **Bug Fixes**
  * Subscription state handling improved to avoid constraint failures from webhook-driven events.

* **Improvements**
  * Voice assistant: clearer microphone/permission error messages, simulator detection, and richer error callbacks.

* **Documentation**
  * Added comprehensive App Store Connect metadata for release submission.

* **Chores**
  * Updated deployment/env and local scripts; added ignore rule for secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->