### PR TITLE
feat(fellowship): posting permissions, unlimited members, reusable invite links

### DIFF
--- a/backend/supabase/functions/fellowship-invites/index.ts
+++ b/backend/supabase/functions/fellowship-invites/index.ts
@@ -46,16 +46,14 @@ async function handleListInvites(req: Request, services: ServiceContainer): Prom
       .update({ is_revoked: true })
       .eq('fellowship_id', fellowshipId)
       .eq('is_revoked', false)
-      .is('used_at', null)
       .lt('expires_at', new Date().toISOString())
   ).catch(() => {})
 
   const { data: invites, error } = await db
     .from('fellowship_invites')
-    .select('id, token, expires_at, used_at, created_at')
+    .select('id, token, expires_at, max_uses, use_count, created_at')
     .eq('fellowship_id', fellowshipId)
     .eq('is_revoked', false)
-    .is('used_at', null)
     .gt('expires_at', new Date().toISOString())
     .order('created_at', { ascending: false })
 
@@ -87,13 +85,19 @@ async function handleCreateInvite(req: Request, services: ServiceContainer): Pro
   )
   if (authError || !user) throw new AppError('AUTHENTICATION_ERROR', 'Invalid token', 401)
 
-  let body: { fellowship_id: string }
+  let body: { fellowship_id: string; max_uses?: number | null }
   try {
-    body = await req.json() as { fellowship_id: string }
+    body = await req.json() as { fellowship_id: string; max_uses?: number | null }
   } catch {
     throw new AppError('VALIDATION_ERROR', 'Request body must be valid JSON', 400)
   }
   if (!body.fellowship_id) throw new AppError('VALIDATION_ERROR', 'fellowship_id is required', 400)
+  // max_uses: null/undefined = unlimited (reusable link); otherwise a positive integer cap.
+  if (body.max_uses !== undefined && body.max_uses !== null) {
+    if (typeof body.max_uses !== 'number' || !Number.isInteger(body.max_uses) || body.max_uses < 1) {
+      throw new AppError('VALIDATION_ERROR', 'max_uses must be a positive integer or null (unlimited)', 400)
+    }
+  }
 
   const db = services.supabaseServiceClient
 
@@ -112,7 +116,6 @@ async function handleCreateInvite(req: Request, services: ServiceContainer): Pro
     .select('*', { count: 'exact', head: true })
     .eq('fellowship_id', body.fellowship_id)
     .eq('is_revoked', false)
-    .is('used_at', null)
     .gt('expires_at', new Date().toISOString())
 
   if (countError) {
@@ -126,7 +129,7 @@ async function handleCreateInvite(req: Request, services: ServiceContainer): Pro
 
   const { data: invite, error } = await db
     .from('fellowship_invites')
-    .insert({ fellowship_id: body.fellowship_id, created_by: user.id })
+    .insert({ fellowship_id: body.fellowship_id, created_by: user.id, max_uses: body.max_uses ?? null })
     .select()
     .single()
 
@@ -142,6 +145,8 @@ async function handleCreateInvite(req: Request, services: ServiceContainer): Pro
         id: invite.id,
         token: invite.token,
         expires_at: invite.expires_at,
+        max_uses: invite.max_uses,
+        use_count: invite.use_count,
         join_url: `https://app.disciplefy.in/fellowship/join/${invite.token}`
       }
     }),
@@ -176,11 +181,15 @@ async function handleJoinFellowship(req: Request, services: ServiceContainer): P
     .select('*, fellowships(id, name, max_members)')
     .eq('token', body.token)
     .eq('is_revoked', false)
-    .is('used_at', null)
     .gt('expires_at', new Date().toISOString())
     .maybeSingle()
 
   if (!invite) throw new AppError('NOT_FOUND', 'Invite link is invalid or expired', 404)
+
+  // Reusable link: enforce the optional usage cap (null max_uses = unlimited).
+  if (invite.max_uses !== null && (invite.use_count ?? 0) >= invite.max_uses) {
+    throw new AppError('VALIDATION_ERROR', 'This invite link has reached its usage limit', 400)
+  }
 
   const fellowship = invite.fellowships as any
   if (!fellowship) throw new AppError('NOT_FOUND', 'Fellowship not found', 404)
@@ -207,7 +216,7 @@ async function handleJoinFellowship(req: Request, services: ServiceContainer): P
     throw new AppError('DATABASE_ERROR', 'Failed to check member capacity', 500)
   }
 
-  if ((memberCount || 0) >= fellowship.max_members) {
+  if (fellowship.max_members !== null && (memberCount || 0) >= fellowship.max_members) {
     throw new AppError('VALIDATION_ERROR', 'Fellowship is full', 400)
   }
 
@@ -225,12 +234,13 @@ async function handleJoinFellowship(req: Request, services: ServiceContainer): P
     throw new AppError('DATABASE_ERROR', 'Failed to join fellowship', 500)
   }
 
-  const { error: markUsedError } = await db
+  // Reusable link: increment the join counter instead of single-use marking.
+  const { error: usageError } = await db
     .from('fellowship_invites')
-    .update({ used_at: new Date().toISOString(), used_by: user.id })
+    .update({ use_count: (invite.use_count ?? 0) + 1 })
     .eq('id', invite.id)
-  if (markUsedError) {
-    console.error('[fellowship-invites/join] Failed to mark invite used — token may be reusable:', invite.id, markUsedError)
+  if (usageError) {
+    console.error('[fellowship-invites/join] Failed to increment use_count:', invite.id, usageError)
   }
 
   // Fire-and-forget: notify new member of upcoming meetings (non-blocking)

--- a/backend/supabase/functions/fellowship-posts/index.ts
+++ b/backend/supabase/functions/fellowship-posts/index.ts
@@ -217,6 +217,27 @@ async function handleCreatePost(req: Request, services: ServiceContainer): Promi
   }
   if (!isMember) throw new AppError('PERMISSION_DENIED', 'Must be a fellowship member', 403)
 
+  // Posting permission: when the fellowship is 'mentor_only', only the mentor
+  // (the group admin) may create posts. 'all_members' lets any member post.
+  const { data: fellowshipRow, error: permError } = await db
+    .from('fellowships')
+    .select('posting_permission')
+    .eq('id', body.fellowship_id)
+    .maybeSingle()
+  if (permError) {
+    console.error('[fellowship-posts/create] Permission lookup error:', permError)
+    throw new AppError('DATABASE_ERROR', 'Failed to verify posting permission', 500)
+  }
+  if (fellowshipRow?.posting_permission === 'mentor_only') {
+    const { data: isMentor } = await db.rpc('is_fellowship_mentor', {
+      p_fellowship_id: body.fellowship_id,
+      p_user_id: user.id,
+    })
+    if (!isMentor) {
+      throw new AppError('PERMISSION_DENIED', 'Only the fellowship mentor can post in this group', 403)
+    }
+  }
+
   const { data: post, error } = await db
     .from('fellowship_posts')
     .insert({

--- a/backend/supabase/functions/fellowship/index.ts
+++ b/backend/supabase/functions/fellowship/index.ts
@@ -48,6 +48,7 @@ async function handleListFellowships(req: Request, services: ServiceContainer): 
         description,
         is_active,
         is_public,
+        posting_permission,
         created_at,
         mentor_user_id
       )
@@ -130,6 +131,7 @@ async function handleListFellowships(req: Request, services: ServiceContainer): 
         joined_at: membership.joined_at,
         created_at: fellowship.created_at,
         is_public: fellowship.is_public ?? false,
+        posting_permission: fellowship.posting_permission ?? 'all_members',
         mentor_name: mentorNameMap.get(fellowship.mentor_user_id) ?? null,
         current_study: study
           ? {
@@ -284,6 +286,7 @@ async function handleGetFellowship(req: Request, services: ServiceContainer): Pr
         name: fellowship.name,
         description: fellowship.description,
         max_members: fellowship.max_members,
+        posting_permission: fellowship.posting_permission,
         member_count: memberCount || 0,
         is_active: fellowship.is_active,
         active_study: study ? {
@@ -479,7 +482,7 @@ async function handleCreateFellowship(req: Request, services: ServiceContainer):
   )
   if (authError || !user) throw new AppError('AUTHENTICATION_ERROR', 'Invalid token', 401)
 
-  let body: { name: string; description?: string; max_members?: number; is_public?: boolean; language?: string }
+  let body: { name: string; description?: string; max_members?: number | null; is_public?: boolean; language?: string; posting_permission?: string }
   try {
     body = await req.json()
   } catch {
@@ -489,10 +492,15 @@ async function handleCreateFellowship(req: Request, services: ServiceContainer):
   if (!body.name || typeof body.name !== 'string') throw new AppError('VALIDATION_ERROR', 'name is required', 400)
   const name = body.name.trim()
   if (name.length < 3 || name.length > 60) throw new AppError('VALIDATION_ERROR', 'name must be 3–60 characters', 400)
-  if (body.max_members !== undefined) {
+  // max_members: a number 2..50, or null = unlimited (app-admin only — checked below).
+  if (body.max_members !== undefined && body.max_members !== null) {
     if (typeof body.max_members !== 'number' || !Number.isInteger(body.max_members) || body.max_members < 2 || body.max_members > 50) {
-      throw new AppError('VALIDATION_ERROR', 'max_members must be an integer between 2 and 50', 400)
+      throw new AppError('VALIDATION_ERROR', 'max_members must be an integer between 2 and 50 (or null for unlimited)', 400)
     }
+  }
+  const postingPermission = body.posting_permission ?? 'all_members'
+  if (postingPermission !== 'all_members' && postingPermission !== 'mentor_only') {
+    throw new AppError('VALIDATION_ERROR', "posting_permission must be 'all_members' or 'mentor_only'", 400)
   }
   if (body.description && body.description.trim().length > 500) {
     throw new AppError('VALIDATION_ERROR', 'description must be 500 characters or fewer', 400)
@@ -537,6 +545,9 @@ async function handleCreateFellowship(req: Request, services: ServiceContainer):
   if (body.is_public === true && !isAdmin) {
     throw new AppError('PERMISSION_DENIED', 'Only admins can create public fellowships', 403)
   }
+  if (body.max_members === null && !isAdmin) {
+    throw new AppError('PERMISSION_DENIED', 'Only admins can create unlimited-size fellowships', 403)
+  }
 
   const { data: fellowship, error: createError } = await db
     .from('fellowships')
@@ -544,9 +555,11 @@ async function handleCreateFellowship(req: Request, services: ServiceContainer):
       name,
       description: body.description?.trim() || null,
       mentor_user_id: user.id,
-      max_members: body.max_members || 12,
+      // null = unlimited (admin-gated above); undefined → default 12
+      max_members: body.max_members === undefined ? 12 : body.max_members,
       is_public: body.is_public ?? false,
       language,
+      posting_permission: postingPermission,
     })
     .select()
     .single()
@@ -579,6 +592,7 @@ async function handleCreateFellowship(req: Request, services: ServiceContainer):
         max_members: fellowship.max_members,
         is_public: fellowship.is_public,
         language: fellowship.language,
+        posting_permission: fellowship.posting_permission,
         mentor_user_id: fellowship.mentor_user_id,
         created_at: fellowship.created_at
       },
@@ -648,7 +662,7 @@ async function handleJoinPublicFellowship(req: Request, services: ServiceContain
     console.error('[fellowship/join] Count error:', countError)
     throw new AppError('DATABASE_ERROR', 'Failed to check member capacity', 500)
   }
-  if ((memberCount || 0) >= fellowship.max_members) throw new AppError('VALIDATION_ERROR', 'Fellowship is full', 400)
+  if (fellowship.max_members !== null && (memberCount || 0) >= fellowship.max_members) throw new AppError('VALIDATION_ERROR', 'Fellowship is full', 400)
 
   if (existing) {
     const { error: updateError } = await db.from('fellowship_members')
@@ -840,7 +854,7 @@ async function handleUpdateFellowship(req: Request, services: ServiceContainer):
   )
   if (authError || !user) throw new AppError('AUTHENTICATION_ERROR', 'Invalid token', 401)
 
-  let body: { fellowship_id: string; name?: string; description?: string; max_members?: number }
+  let body: { fellowship_id: string; name?: string; description?: string; max_members?: number | null; posting_permission?: string }
   try {
     body = await req.json()
   } catch {
@@ -886,10 +900,24 @@ async function handleUpdateFellowship(req: Request, services: ServiceContainer):
     updates.description = desc || null
   }
   if (body.max_members !== undefined) {
-    if (typeof body.max_members !== 'number' || !Number.isInteger(body.max_members) || body.max_members < 2 || body.max_members > 50) {
-      throw new AppError('VALIDATION_ERROR', 'max_members must be an integer between 2 and 50', 400)
+    if (body.max_members === null) {
+      // Unlimited — app-admin only (mentor alone is not enough).
+      const { data: profile } = await db.from('user_profiles').select('is_admin').eq('id', user.id).single()
+      if (profile?.is_admin !== true) {
+        throw new AppError('PERMISSION_DENIED', 'Only admins can set unlimited members', 403)
+      }
+      updates.max_members = null
+    } else if (typeof body.max_members !== 'number' || !Number.isInteger(body.max_members) || body.max_members < 2 || body.max_members > 50) {
+      throw new AppError('VALIDATION_ERROR', 'max_members must be an integer between 2 and 50 (or null for unlimited)', 400)
+    } else {
+      updates.max_members = body.max_members
     }
-    updates.max_members = body.max_members
+  }
+  if (body.posting_permission !== undefined) {
+    if (body.posting_permission !== 'all_members' && body.posting_permission !== 'mentor_only') {
+      throw new AppError('VALIDATION_ERROR', "posting_permission must be 'all_members' or 'mentor_only'", 400)
+    }
+    updates.posting_permission = body.posting_permission
   }
 
   const hasUpdate = Object.keys(updates).some(k => k !== 'updated_at')
@@ -915,6 +943,7 @@ async function handleUpdateFellowship(req: Request, services: ServiceContainer):
         name: fellowship.name,
         description: fellowship.description,
         max_members: fellowship.max_members,
+        posting_permission: fellowship.posting_permission,
         updated_at: fellowship.updated_at
       }
     }),

--- a/backend/supabase/migrations/20260613100000_fellowship_permissions_and_reusable_invites.sql
+++ b/backend/supabase/migrations/20260613100000_fellowship_permissions_and_reusable_invites.sql
@@ -1,0 +1,45 @@
+-- Fellowship enhancements:
+--   1) per-fellowship posting permission (all members vs mentor/admin only)
+--   2) unlimited members (NULL = unlimited; app-admin only)
+--   3) reusable invite links (one link, many joiners)
+
+-- ── Feature 1: posting permission ───────────────────────────────────────────
+ALTER TABLE fellowships
+  ADD COLUMN IF NOT EXISTS posting_permission TEXT NOT NULL DEFAULT 'all_members'
+    CHECK (posting_permission IN ('all_members', 'mentor_only'));
+
+COMMENT ON COLUMN fellowships.posting_permission IS
+  'all_members = any member can post; mentor_only = only the mentor (group admin) can post';
+
+-- ── Feature 2: unlimited members (NULL = unlimited) ─────────────────────────
+-- Keep DEFAULT 12 for normal creators; NULL is reserved for app-admins (enforced
+-- in the edge function). Relax the old 2..50 cap to "NULL or >= 2".
+ALTER TABLE fellowships ALTER COLUMN max_members DROP NOT NULL;
+ALTER TABLE fellowships DROP CONSTRAINT IF EXISTS fellowships_max_members_check;
+ALTER TABLE fellowships ADD CONSTRAINT fellowships_max_members_check
+  CHECK (max_members IS NULL OR max_members >= 2);
+
+COMMENT ON COLUMN fellowships.max_members IS
+  'Max members; NULL = unlimited (app-admin only); otherwise >= 2.';
+
+-- ── Feature 3: reusable invite links ────────────────────────────────────────
+ALTER TABLE fellowship_invites
+  ADD COLUMN IF NOT EXISTS max_uses INTEGER CHECK (max_uses IS NULL OR max_uses >= 1),
+  ADD COLUMN IF NOT EXISTS use_count INTEGER NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN fellowship_invites.max_uses IS
+  'Max successful joins via this link; NULL = unlimited (reusable).';
+COMMENT ON COLUMN fellowship_invites.use_count IS
+  'Number of successful joins via this link.';
+
+-- Reflect prior single-use joins in the new counter.
+UPDATE fellowship_invites SET use_count = 1 WHERE used_at IS NOT NULL AND use_count = 0;
+
+-- Rebuild token/fellowship indexes WITHOUT the `used_at IS NULL` filter so that
+-- reusable links remain discoverable after their first use.
+DROP INDEX IF EXISTS idx_fellowship_invites_token;
+DROP INDEX IF EXISTS idx_fellowship_invites_fellowship;
+CREATE INDEX IF NOT EXISTS idx_fellowship_invites_token
+  ON fellowship_invites(token) WHERE is_revoked = false;
+CREATE INDEX IF NOT EXISTS idx_fellowship_invites_fellowship
+  ON fellowship_invites(fellowship_id) WHERE is_revoked = false;

--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -276,6 +276,7 @@ class AppLocalizations {
       'feedLoadError': 'Something went wrong.',
       'feedRetry': 'Retry',
       'feedEmpty': 'No posts yet.\nBe the first to share!',
+      'feedEmptyReadOnly': 'No posts yet.\nCheck back soon for updates.',
       'postTypePrayer': 'Prayer',
       'postTypePraise': 'Praise',
       'postTypeQuestion': 'Question',
@@ -326,6 +327,19 @@ class AppLocalizations {
       'inviteGenerating': 'Generating invite...',
       'inviteShareCode': 'Share this code',
       'inviteExpires': 'Expires in 7 days',
+      'inviteManageTitle': 'Invite Links',
+      'inviteManageSubtitle':
+          'Anyone with an active link can join. Revoke a link to disable it.',
+      'inviteGenerateLink': 'Generate New Link',
+      'inviteNoLinks': 'No active invite links',
+      'inviteNoLinksDescription':
+          'Generate a link to invite people to this fellowship.',
+      'inviteUnlimited': 'Unlimited joins',
+      'inviteJoinedSuffix': 'joined',
+      'inviteCopyLink': 'Copy link',
+      'inviteLinkCopied': 'Invite link copied',
+      'inviteCopyCode': 'Copy code',
+      'inviteCodeCopied': 'Invite code copied',
       'lessonsAdvanceGuide': 'Advance to Next Guide',
       'lessonsFinishPath': 'Finish Path',
       'lessonsResetProgress': 'Reset Progress',
@@ -384,6 +398,11 @@ class AppLocalizations {
       'createFellowshipDescLabel': 'Description (optional)',
       'createFellowshipDescHint': 'What will your fellowship study together?',
       'createFellowshipMaxLabel': 'Max Members (2–50)',
+      'createFellowshipWhoCanPostLabel': 'Who can post',
+      'createFellowshipPostEveryone': 'Everyone',
+      'createFellowshipPostAdminsOnly': 'Only admins',
+      'createFellowshipUnlimitedLabel': 'Unlimited members',
+      'createFellowshipUnlimitedHint': 'No cap on how many people can join',
       'createFellowshipButton': 'Create Fellowship',
       'createFellowshipSuccess': 'Fellowship created!',
       'createFellowshipFailed': 'Failed to create fellowship.',
@@ -829,6 +848,7 @@ class AppLocalizations {
       'feedLoadError': 'कुछ गलत हो गया।',
       'feedRetry': 'पुनः प्रयास',
       'feedEmpty': 'अभी कोई पोस्ट नहीं।\nपहले साझा करें!',
+      'feedEmptyReadOnly': 'अभी कोई पोस्ट नहीं।\nअपडेट के लिए जल्द ही देखें।',
       'postTypePrayer': 'प्रार्थना',
       'postTypePraise': 'स्तुति',
       'postTypeQuestion': 'प्रश्न',
@@ -881,6 +901,19 @@ class AppLocalizations {
       'inviteGenerating': 'आमंत्रण बना रहे हैं...',
       'inviteShareCode': 'यह कोड साझा करें',
       'inviteExpires': '7 दिनों में समाप्त',
+      'inviteManageTitle': 'आमंत्रण लिंक',
+      'inviteManageSubtitle':
+          'सक्रिय लिंक वाला कोई भी व्यक्ति शामिल हो सकता है। लिंक रद्द करके उसे निष्क्रिय करें।',
+      'inviteGenerateLink': 'नया लिंक बनाएं',
+      'inviteNoLinks': 'कोई सक्रिय आमंत्रण लिंक नहीं',
+      'inviteNoLinksDescription':
+          'इस फ़ेलोशिप में लोगों को आमंत्रित करने के लिए एक लिंक बनाएं।',
+      'inviteUnlimited': 'असीमित जुड़ाव',
+      'inviteJoinedSuffix': 'शामिल हुए',
+      'inviteCopyLink': 'लिंक कॉपी करें',
+      'inviteLinkCopied': 'आमंत्रण लिंक कॉपी किया गया',
+      'inviteCopyCode': 'कोड कॉपी करें',
+      'inviteCodeCopied': 'आमंत्रण कोड कॉपी किया गया',
       'lessonsAdvanceGuide': 'अगले गाइड पर जाएं',
       'lessonsFinishPath': 'पाठ पूर्ण करें',
       'lessonsResetProgress': 'प्रगति रीसेट करें',
@@ -938,6 +971,11 @@ class AppLocalizations {
       'createFellowshipDescLabel': 'विवरण (वैकल्पिक)',
       'createFellowshipDescHint': 'आपकी संगति मिलकर क्या अध्ययन करेगी?',
       'createFellowshipMaxLabel': 'अधिकतम सदस्य (2–50)',
+      'createFellowshipWhoCanPostLabel': 'कौन पोस्ट कर सकता है',
+      'createFellowshipPostEveryone': 'सभी',
+      'createFellowshipPostAdminsOnly': 'केवल एडमिन',
+      'createFellowshipUnlimitedLabel': 'असीमित सदस्य',
+      'createFellowshipUnlimitedHint': 'शामिल होने वालों की कोई सीमा नहीं',
       'createFellowshipButton': 'संगति बनाएं',
       'createFellowshipSuccess': 'संगति बन गई!',
       'createFellowshipFailed': 'संगति बनाना विफल।',
@@ -1383,6 +1421,8 @@ class AppLocalizations {
       'feedLoadError': 'എന്തോ തകരാറുണ്ടായി.',
       'feedRetry': 'വീണ്ടും ശ്രമിക്കുക',
       'feedEmpty': 'ഇതുവരെ പോസ്റ്റുകൾ ഇല്ല.\nആദ്യം പങ്കുവെക്കൂ!',
+      'feedEmptyReadOnly':
+          'ഇതുവരെ പോസ്റ്റുകൾ ഇല്ല.\nഅപ്ഡേറ്റുകൾക്കായി ഉടൻ പരിശോധിക്കൂ.',
       'postTypePrayer': 'പ്രാർഥന',
       'postTypePraise': 'സ്തുതി',
       'postTypeQuestion': 'ചോദ്യം',
@@ -1436,6 +1476,19 @@ class AppLocalizations {
       'inviteGenerating': 'ക്ഷണം സൃഷ്ടിക്കുന്നു...',
       'inviteShareCode': 'ഈ കോഡ് പങ്കിടുക',
       'inviteExpires': '7 ദിവസത്തിൽ കാലഹരണം',
+      'inviteManageTitle': 'ക്ഷണ ലിങ്കുകൾ',
+      'inviteManageSubtitle':
+          'സജീവ ലിങ്ക് ഉള്ള ആർക്കും ചേരാം. ലിങ്ക് റദ്ദാക്കി അത് നിർജ്ജീവമാക്കുക.',
+      'inviteGenerateLink': 'പുതിയ ലിങ്ക് സൃഷ്ടിക്കുക',
+      'inviteNoLinks': 'സജീവ ക്ഷണ ലിങ്കുകൾ ഇല്ല',
+      'inviteNoLinksDescription':
+          'ഈ കൂട്ടായ്മയിലേക്ക് ആളുകളെ ക്ഷണിക്കാൻ ഒരു ലിങ്ക് സൃഷ്ടിക്കുക.',
+      'inviteUnlimited': 'പരിധിയില്ലാത്ത ചേരൽ',
+      'inviteJoinedSuffix': 'ചേർന്നു',
+      'inviteCopyLink': 'ലിങ്ക് പകർത്തുക',
+      'inviteLinkCopied': 'ക്ഷണ ലിങ്ക് പകർത്തി',
+      'inviteCopyCode': 'കോഡ് പകർത്തുക',
+      'inviteCodeCopied': 'ക്ഷണ കോഡ് പകർത്തി',
       'lessonsAdvanceGuide': 'അടുത്ത ഗൈഡിലേക്ക് മുന്നേറുക',
       'lessonsFinishPath': 'പഠനം പൂർത്തിയാക്കുക',
       'lessonsResetProgress': 'പുരോഗതി പുനഃക്രമീകരിക്കുക',
@@ -1495,6 +1548,11 @@ class AppLocalizations {
       'createFellowshipDescLabel': 'വിവരണം (ഐച്ഛികം)',
       'createFellowshipDescHint': 'നിങ്ങളുടെ കൂട്ടായ്മ എന്ത് പഠിക്കും?',
       'createFellowshipMaxLabel': 'പരമാവധി അംഗങ്ങൾ (2–50)',
+      'createFellowshipWhoCanPostLabel': 'ആർക്ക് പോസ്റ്റ് ചെയ്യാം',
+      'createFellowshipPostEveryone': 'എല്ലാവരും',
+      'createFellowshipPostAdminsOnly': 'അഡ്മിൻ മാത്രം',
+      'createFellowshipUnlimitedLabel': 'പരിധിയില്ലാത്ത അംഗങ്ങൾ',
+      'createFellowshipUnlimitedHint': 'ചേരാനാകുന്നവരുടെ എണ്ണത്തിന് പരിധിയില്ല',
       'createFellowshipButton': 'കൂട്ടായ്മ ഉണ്ടാക്കുക',
       'createFellowshipSuccess': 'കൂട്ടായ്മ ഉണ്ടായി!',
       'createFellowshipFailed': 'കൂട്ടായ്മ ഉണ്ടാക്കാൻ കഴിഞ്ഞില്ല.',
@@ -1911,6 +1969,8 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['feedLoadError']!;
   String get feedRetry => _localizedValues[locale.languageCode]!['feedRetry']!;
   String get feedEmpty => _localizedValues[locale.languageCode]!['feedEmpty']!;
+  String get feedEmptyReadOnly =>
+      _localizedValues[locale.languageCode]!['feedEmptyReadOnly']!;
   String get postTypePrayer =>
       _localizedValues[locale.languageCode]!['postTypePrayer']!;
   String get postTypePraise =>
@@ -1987,6 +2047,28 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['membersInviteComingSoon']!;
   String get membersCopy =>
       _localizedValues[locale.languageCode]!['membersCopy']!;
+  String get inviteManageTitle =>
+      _localizedValues[locale.languageCode]!['inviteManageTitle']!;
+  String get inviteManageSubtitle =>
+      _localizedValues[locale.languageCode]!['inviteManageSubtitle']!;
+  String get inviteGenerateLink =>
+      _localizedValues[locale.languageCode]!['inviteGenerateLink']!;
+  String get inviteNoLinks =>
+      _localizedValues[locale.languageCode]!['inviteNoLinks']!;
+  String get inviteNoLinksDescription =>
+      _localizedValues[locale.languageCode]!['inviteNoLinksDescription']!;
+  String get inviteUnlimited =>
+      _localizedValues[locale.languageCode]!['inviteUnlimited']!;
+  String get inviteJoinedSuffix =>
+      _localizedValues[locale.languageCode]!['inviteJoinedSuffix']!;
+  String get inviteCopyLink =>
+      _localizedValues[locale.languageCode]!['inviteCopyLink']!;
+  String get inviteLinkCopied =>
+      _localizedValues[locale.languageCode]!['inviteLinkCopied']!;
+  String get inviteCopyCode =>
+      _localizedValues[locale.languageCode]!['inviteCopyCode']!;
+  String get inviteCodeCopied =>
+      _localizedValues[locale.languageCode]!['inviteCodeCopied']!;
 
   // Leave / Mute / Invite / Lessons — additional keys
   String get leaveFellowshipTitle =>
@@ -2104,6 +2186,16 @@ class AppLocalizations {
       _localizedValues[locale.languageCode]!['createFellowshipDescHint']!;
   String get createFellowshipMaxLabel =>
       _localizedValues[locale.languageCode]!['createFellowshipMaxLabel']!;
+  String get createFellowshipWhoCanPostLabel => _localizedValues[
+      locale.languageCode]!['createFellowshipWhoCanPostLabel']!;
+  String get createFellowshipPostEveryone =>
+      _localizedValues[locale.languageCode]!['createFellowshipPostEveryone']!;
+  String get createFellowshipPostAdminsOnly =>
+      _localizedValues[locale.languageCode]!['createFellowshipPostAdminsOnly']!;
+  String get createFellowshipUnlimitedLabel =>
+      _localizedValues[locale.languageCode]!['createFellowshipUnlimitedLabel']!;
+  String get createFellowshipUnlimitedHint =>
+      _localizedValues[locale.languageCode]!['createFellowshipUnlimitedHint']!;
   String get createFellowshipButton =>
       _localizedValues[locale.languageCode]!['createFellowshipButton']!;
   String get createFellowshipSuccess =>

--- a/frontend/lib/features/community/data/datasources/community_remote_datasource.dart
+++ b/frontend/lib/features/community/data/datasources/community_remote_datasource.dart
@@ -88,6 +88,8 @@ abstract class CommunityRemoteDatasource {
     int? maxMembers,
     bool isPublic = false,
     String language = 'en',
+    String postingPermission = 'all_members',
+    bool unlimitedMembers = false,
   });
 
   /// Sets (or replaces) the active learning path for [fellowshipId].
@@ -815,6 +817,8 @@ class CommunityRemoteDatasourceImpl implements CommunityRemoteDatasource {
     int? maxMembers,
     bool isPublic = false,
     String language = 'en',
+    String postingPermission = 'all_members',
+    bool unlimitedMembers = false,
   }) async {
     try {
       final url = '$_baseUrl$_fellowshipCreateEndpoint';
@@ -822,11 +826,14 @@ class CommunityRemoteDatasourceImpl implements CommunityRemoteDatasource {
       if (description != null && description.isNotEmpty) {
         bodyMap['description'] = description;
       }
-      if (maxMembers != null) {
+      if (unlimitedMembers) {
+        bodyMap['max_members'] = null; // explicit null = unlimited (admin only)
+      } else if (maxMembers != null) {
         bodyMap['max_members'] = maxMembers;
       }
       bodyMap['is_public'] = isPublic;
       bodyMap['language'] = language;
+      bodyMap['posting_permission'] = postingPermission;
       final body = jsonEncode(bodyMap);
 
       final headers = await _httpService.createHeaders();

--- a/frontend/lib/features/community/data/models/fellowship_model.dart
+++ b/frontend/lib/features/community/data/models/fellowship_model.dart
@@ -36,6 +36,9 @@ class FellowshipModel {
   /// Whether the fellowship is publicly discoverable.
   final bool isPublic;
 
+  /// Who is allowed to post: `'all_members'` or `'mentor_only'`.
+  final String postingPermission;
+
   const FellowshipModel({
     required this.id,
     required this.name,
@@ -47,6 +50,7 @@ class FellowshipModel {
     this.currentStudy,
     this.mentorName,
     this.isPublic = false,
+    this.postingPermission = 'all_members',
   });
 
   /// Creates a [FellowshipModel] from a JSON map (API response).
@@ -66,6 +70,7 @@ class FellowshipModel {
           : null,
       mentorName: json['mentor_name'] as String?,
       isPublic: json['is_public'] as bool? ?? false,
+      postingPermission: json['posting_permission'] as String? ?? 'all_members',
     );
   }
 
@@ -81,5 +86,6 @@ class FellowshipModel {
         currentStudy: currentStudy?.toEntity(),
         mentorName: mentorName,
         isPublic: isPublic,
+        postingPermission: postingPermission,
       );
 }

--- a/frontend/lib/features/community/data/repositories/community_repository_impl.dart
+++ b/frontend/lib/features/community/data/repositories/community_repository_impl.dart
@@ -264,6 +264,8 @@ class CommunityRepositoryImpl implements CommunityRepository {
     int? maxMembers,
     bool isPublic = false,
     String language = 'en',
+    String postingPermission = 'all_members',
+    bool unlimitedMembers = false,
   }) async {
     try {
       await _datasource.createFellowship(
@@ -272,6 +274,8 @@ class CommunityRepositoryImpl implements CommunityRepository {
         maxMembers: maxMembers,
         isPublic: isPublic,
         language: language,
+        postingPermission: postingPermission,
+        unlimitedMembers: unlimitedMembers,
       );
       return const Right(null);
     } on NetworkException catch (e) {

--- a/frontend/lib/features/community/domain/entities/fellowship_entity.dart
+++ b/frontend/lib/features/community/domain/entities/fellowship_entity.dart
@@ -41,6 +41,10 @@ class FellowshipEntity extends Equatable {
   /// Whether the fellowship is publicly discoverable.
   final bool isPublic;
 
+  /// Who is allowed to post in the feed: `'all_members'` (mentor + members)
+  /// or `'mentor_only'` (only the mentor).
+  final String postingPermission;
+
   const FellowshipEntity({
     required this.id,
     required this.name,
@@ -52,7 +56,12 @@ class FellowshipEntity extends Equatable {
     this.currentStudy,
     this.mentorName,
     this.isPublic = false,
+    this.postingPermission = 'all_members',
   });
+
+  /// True when the current user is allowed to create posts in this fellowship.
+  bool get canCurrentUserPost =>
+      postingPermission != 'mentor_only' || userRole == 'mentor';
 
   @override
   List<Object?> get props => [
@@ -66,5 +75,6 @@ class FellowshipEntity extends Equatable {
         currentStudy,
         mentorName,
         isPublic,
+        postingPermission,
       ];
 }

--- a/frontend/lib/features/community/domain/repositories/community_repository.dart
+++ b/frontend/lib/features/community/domain/repositories/community_repository.dart
@@ -104,6 +104,8 @@ abstract class CommunityRepository {
     int? maxMembers,
     bool isPublic = false,
     String language = 'en',
+    String postingPermission = 'all_members',
+    bool unlimitedMembers = false,
   });
 
   /// Sets (or replaces) the active learning path for [fellowshipId].

--- a/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_bloc.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_bloc.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../../core/di/injection_container.dart';
+import '../../../../../core/services/language_preference_service.dart';
 import '../../../../../features/community/domain/entities/fellowship_comment_entity.dart';
 import '../../../../../features/community/domain/entities/fellowship_post_entity.dart';
 import '../../../../../features/community/domain/repositories/community_repository.dart';
@@ -21,6 +23,7 @@ class FellowshipFeedBloc
       : _repository = repository,
         super(const FellowshipFeedState.initial()) {
     on<FellowshipFeedInitialized>(_onInitialized);
+    on<FellowshipFeedContextRequested>(_onContextRequested);
     on<FellowshipFeedLoadRequested>(_onLoadRequested);
     on<FellowshipFeedLoadMoreRequested>(_onLoadMoreRequested);
     on<FellowshipPostCreateRequested>(_onPostCreateRequested);
@@ -40,7 +43,38 @@ class FellowshipFeedBloc
     emit(state.copyWith(
       isMentor: event.isMentor,
       currentUserId: event.currentUserId,
+      postingPermission: event.postingPermission,
+      postingContextResolved: event.postingContextResolved,
     ));
+  }
+
+  /// Fetches authoritative posting context from the server and updates the
+  /// posting permission + mentor flag. Self-correcting: the optimistic values
+  /// passed to [FellowshipFeedInitialized] may be stale or absent (deep link /
+  /// web refresh), so this overrides them once the network responds.
+  Future<void> _onContextRequested(
+    FellowshipFeedContextRequested event,
+    Emitter<FellowshipFeedState> emit,
+  ) async {
+    final lang =
+        await sl<LanguagePreferenceService>().getStudyContentLanguage();
+    final result =
+        await _repository.getFellowship(event.fellowshipId, lang.code);
+
+    result.fold(
+      // On failure, fall back to whatever optimistic values we have but still
+      // mark resolved so the button isn't hidden forever.
+      (_) => emit(state.copyWith(postingContextResolved: true)),
+      (data) {
+        final role = data['caller_role'] as String?;
+        final permission = data['posting_permission'] as String?;
+        emit(state.copyWith(
+          postingPermission: permission ?? state.postingPermission,
+          isMentor: role != null ? role == 'mentor' : state.isMentor,
+          postingContextResolved: true,
+        ));
+      },
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_event.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_event.dart
@@ -14,13 +14,37 @@ class FellowshipFeedInitialized extends FellowshipFeedEvent {
   final bool isMentor;
   final String? currentUserId;
 
+  /// Who may post: `'all_members'` or `'mentor_only'`.
+  final String postingPermission;
+
+  /// True when [postingPermission]/[isMentor] came from a known source (a
+  /// passed-in entity), so the post button can show without waiting for the
+  /// server. False when they're defaults (deep link / refresh).
+  final bool postingContextResolved;
+
   const FellowshipFeedInitialized({
     required this.isMentor,
     this.currentUserId,
+    this.postingPermission = 'all_members',
+    this.postingContextResolved = false,
   });
 
   @override
-  List<Object?> get props => [isMentor, currentUserId];
+  List<Object?> get props =>
+      [isMentor, currentUserId, postingPermission, postingContextResolved];
+}
+
+/// Fetches authoritative posting context (posting_permission + caller role)
+/// from the server. Used so FAB/empty-state gating is correct even when the
+/// screen was opened without a passed-in [FellowshipEntity] (deep link, web
+/// refresh).
+class FellowshipFeedContextRequested extends FellowshipFeedEvent {
+  final String fellowshipId;
+
+  const FellowshipFeedContextRequested({required this.fellowshipId});
+
+  @override
+  List<Object?> get props => [fellowshipId];
 }
 
 /// Loads the first page of posts for the given fellowship, discarding any

--- a/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_state.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_feed/fellowship_feed_state.dart
@@ -42,6 +42,15 @@ class FellowshipFeedState extends Equatable {
   /// The current user's Supabase auth UID. Used to gate the delete button.
   final String? currentUserId;
 
+  /// Who may post: `'all_members'` or `'mentor_only'`. Drives FAB visibility.
+  final String postingPermission;
+
+  /// True once posting context (permission + role) is known — either supplied
+  /// by a passed-in entity or fetched from the server. The post button stays
+  /// hidden until this is true so refresh/deep-link doesn't briefly flash a
+  /// button the user may not be allowed to use.
+  final bool postingContextResolved;
+
   // ── Comments state ─────────────────────────────────────────────────────────
 
   /// The post whose comments are currently loaded (set when sheet opens).
@@ -72,6 +81,8 @@ class FellowshipFeedState extends Equatable {
     this.submitting = false,
     this.isMentor = false,
     this.currentUserId,
+    this.postingPermission = 'all_members',
+    this.postingContextResolved = false,
     this.activePostId,
     this.comments = const [],
     this.commentsStatus = FellowshipCommentsStatus.initial,
@@ -83,6 +94,16 @@ class FellowshipFeedState extends Equatable {
   /// Returns the initial state (used as the BLoC seed value).
   const FellowshipFeedState.initial() : this();
 
+  /// True when the current user is allowed to create posts: either posting is
+  /// open to all members, or the user is the mentor.
+  bool get canPost => postingPermission != 'mentor_only' || isMentor;
+
+  /// Whether the post button (FAB / "Post something") should be shown: posting
+  /// context must be resolved AND the user must be allowed to post. Gating on
+  /// [postingContextResolved] avoids flashing the button on refresh/deep-link
+  /// before the server confirms permissions.
+  bool get canShowPostButton => postingContextResolved && canPost;
+
   @override
   List<Object?> get props => [
         status,
@@ -93,6 +114,8 @@ class FellowshipFeedState extends Equatable {
         submitting,
         isMentor,
         currentUserId,
+        postingPermission,
+        postingContextResolved,
         activePostId,
         comments,
         commentsStatus,
@@ -113,6 +136,8 @@ class FellowshipFeedState extends Equatable {
     bool? submitting,
     bool? isMentor,
     String? currentUserId,
+    String? postingPermission,
+    bool? postingContextResolved,
     String? activePostId,
     List<FellowshipCommentEntity>? comments,
     FellowshipCommentsStatus? commentsStatus,
@@ -130,6 +155,9 @@ class FellowshipFeedState extends Equatable {
       submitting: submitting ?? this.submitting,
       isMentor: isMentor ?? this.isMentor,
       currentUserId: currentUserId ?? this.currentUserId,
+      postingPermission: postingPermission ?? this.postingPermission,
+      postingContextResolved:
+          postingContextResolved ?? this.postingContextResolved,
       activePostId: activePostId ?? this.activePostId,
       comments: comments ?? this.comments,
       commentsStatus: commentsStatus ?? this.commentsStatus,

--- a/frontend/lib/features/community/presentation/bloc/fellowship_list/fellowship_list_bloc.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_list/fellowship_list_bloc.dart
@@ -69,6 +69,8 @@ class FellowshipListBloc
       maxMembers: event.maxMembers,
       isPublic: event.isPublic,
       language: event.language,
+      postingPermission: event.postingPermission,
+      unlimitedMembers: event.unlimitedMembers,
     );
 
     await result.fold(

--- a/frontend/lib/features/community/presentation/bloc/fellowship_list/fellowship_list_event.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_list/fellowship_list_event.dart
@@ -32,15 +32,30 @@ class FellowshipCreateRequested extends FellowshipListEvent {
   final bool isPublic;
   final String language;
 
+  /// 'all_members' (mentor + members can post) or 'mentor_only' (only mentor).
+  final String postingPermission;
+
+  /// When true, sends an unlimited member cap (app-admin only).
+  final bool unlimitedMembers;
+
   const FellowshipCreateRequested({
     required this.name,
     this.description,
     this.maxMembers,
     this.isPublic = false,
     this.language = 'en',
+    this.postingPermission = 'all_members',
+    this.unlimitedMembers = false,
   });
 
   @override
-  List<Object?> get props =>
-      [name, description, maxMembers, isPublic, language];
+  List<Object?> get props => [
+        name,
+        description,
+        maxMembers,
+        isPublic,
+        language,
+        postingPermission,
+        unlimitedMembers
+      ];
 }

--- a/frontend/lib/features/community/presentation/bloc/fellowship_members/fellowship_members_bloc.dart
+++ b/frontend/lib/features/community/presentation/bloc/fellowship_members/fellowship_members_bloc.dart
@@ -90,13 +90,17 @@ class FellowshipMembersBloc
         inviteStatus: FellowshipInviteStatus.failure,
         inviteError: failure.message,
       )),
-      (data) => emit(state.copyWith(
-        inviteStatus: FellowshipInviteStatus.success,
-        inviteToken: data['token'] as String?,
-        inviteId: data['id'] as String?,
-        inviteJoinUrl: data['join_url'] as String?,
-        clearInviteError: true,
-      )),
+      (data) {
+        emit(state.copyWith(
+          inviteStatus: FellowshipInviteStatus.success,
+          inviteToken: data['token'] as String?,
+          inviteId: data['id'] as String?,
+          inviteJoinUrl: data['join_url'] as String?,
+          clearInviteError: true,
+        ));
+        // Refresh the full list so the new link appears in the manage screen.
+        add(const FellowshipInvitesListRequested());
+      },
     );
   }
 

--- a/frontend/lib/features/community/presentation/screens/create_fellowship_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/create_fellowship_screen.dart
@@ -35,6 +35,8 @@ class _CreateFellowshipScreenState extends State<CreateFellowshipScreen> {
   bool _hasName = false;
   bool _isPublic = false;
   String _language = 'en';
+  String _postingPermission = 'all_members';
+  bool _unlimitedMembers = false;
 
   @override
   void initState() {
@@ -65,9 +67,11 @@ class _CreateFellowshipScreenState extends State<CreateFellowshipScreen> {
           FellowshipCreateRequested(
             name: name,
             description: desc.isNotEmpty ? desc : null,
-            maxMembers: maxRaw,
+            maxMembers: _unlimitedMembers ? null : maxRaw,
             isPublic: _isPublic,
             language: _language,
+            postingPermission: _postingPermission,
+            unlimitedMembers: _unlimitedMembers,
           ),
         );
   }
@@ -84,8 +88,13 @@ class _CreateFellowshipScreenState extends State<CreateFellowshipScreen> {
         hasName: _hasName,
         isPublic: _isPublic,
         language: _language,
+        postingPermission: _postingPermission,
+        unlimitedMembers: _unlimitedMembers,
         onIsPublicChanged: (v) => setState(() => _isPublic = v),
         onLanguageChanged: (v) => setState(() => _language = v),
+        onPostingPermissionChanged: (v) =>
+            setState(() => _postingPermission = v),
+        onUnlimitedChanged: (v) => setState(() => _unlimitedMembers = v),
         onCreatePressed: _onCreatePressed,
       ),
     );
@@ -104,8 +113,12 @@ class _CreateFellowshipConsumer extends StatelessWidget {
   final bool hasName;
   final bool isPublic;
   final String language;
+  final String postingPermission;
+  final bool unlimitedMembers;
   final ValueChanged<bool> onIsPublicChanged;
   final ValueChanged<String> onLanguageChanged;
+  final ValueChanged<String> onPostingPermissionChanged;
+  final ValueChanged<bool> onUnlimitedChanged;
   final void Function(BuildContext) onCreatePressed;
 
   const _CreateFellowshipConsumer({
@@ -116,8 +129,12 @@ class _CreateFellowshipConsumer extends StatelessWidget {
     required this.hasName,
     required this.isPublic,
     required this.language,
+    required this.postingPermission,
+    required this.unlimitedMembers,
     required this.onIsPublicChanged,
     required this.onLanguageChanged,
+    required this.onPostingPermissionChanged,
+    required this.onUnlimitedChanged,
     required this.onCreatePressed,
   });
 
@@ -160,8 +177,12 @@ class _CreateFellowshipConsumer extends StatelessWidget {
               hasName: hasName,
               isPublic: isPublic,
               language: language,
+              postingPermission: postingPermission,
+              unlimitedMembers: unlimitedMembers,
               onIsPublicChanged: onIsPublicChanged,
               onLanguageChanged: onLanguageChanged,
+              onPostingPermissionChanged: onPostingPermissionChanged,
+              onUnlimitedChanged: onUnlimitedChanged,
               onCreatePressed: () => onCreatePressed(context),
             ),
             if (isLoading) const _LoadingOverlay(),
@@ -185,8 +206,12 @@ class _CreateFellowshipBody extends StatelessWidget {
   final bool hasName;
   final bool isPublic;
   final String language;
+  final String postingPermission;
+  final bool unlimitedMembers;
   final ValueChanged<bool> onIsPublicChanged;
   final ValueChanged<String> onLanguageChanged;
+  final ValueChanged<String> onPostingPermissionChanged;
+  final ValueChanged<bool> onUnlimitedChanged;
   final VoidCallback onCreatePressed;
 
   const _CreateFellowshipBody({
@@ -198,8 +223,12 @@ class _CreateFellowshipBody extends StatelessWidget {
     required this.hasName,
     required this.isPublic,
     required this.language,
+    required this.postingPermission,
+    required this.unlimitedMembers,
     required this.onIsPublicChanged,
     required this.onLanguageChanged,
+    required this.onPostingPermissionChanged,
+    required this.onUnlimitedChanged,
     required this.onCreatePressed,
   });
 
@@ -352,35 +381,118 @@ class _CreateFellowshipBody extends StatelessWidget {
 
                 const SizedBox(height: 20),
 
-                // ── Max members field ────────────────────────────────────────
-                _FieldLabel(label: l10n.createFellowshipMaxLabel),
+                // ── Max members (+ admin-only unlimited toggle) ──────────────
+                BlocBuilder<AuthBloc, auth_states.AuthState>(
+                  builder: (context, authState) {
+                    final isAdmin =
+                        authState is auth_states.AuthenticatedState &&
+                            authState.isAdmin;
+                    final hideMaxField = isAdmin && unlimitedMembers;
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (!hideMaxField) ...[
+                          _FieldLabel(label: l10n.createFellowshipMaxLabel),
+                          const SizedBox(height: 8),
+                          TextFormField(
+                            controller: maxController,
+                            enabled: !isLoading,
+                            textInputAction: TextInputAction.done,
+                            keyboardType: TextInputType.number,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly
+                            ],
+                            style: TextStyle(
+                              fontFamily: 'Inter',
+                              fontSize: 15,
+                              color: context.appTextPrimary,
+                            ),
+                            decoration: _inputDecoration(
+                              context: context,
+                              hintText: '12',
+                              prefixIcon: Icons.people_rounded,
+                            ),
+                            validator: (v) {
+                              if (hideMaxField) return null;
+                              final n = int.tryParse(v?.trim() ?? '');
+                              if (n == null || n < 2 || n > 50) {
+                                return l10n.createFellowshipMaxError;
+                              }
+                              return null;
+                            },
+                            onFieldSubmitted: (_) {
+                              if (!isLoading && hasName) onCreatePressed();
+                            },
+                          ),
+                        ],
+                        // Unlimited members — admin only, grouped with the cap.
+                        if (isAdmin) ...[
+                          const SizedBox(height: 12),
+                          Row(
+                            children: [
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      l10n.createFellowshipUnlimitedLabel,
+                                      style: TextStyle(
+                                        fontFamily: 'Inter',
+                                        fontSize: 15,
+                                        fontWeight: FontWeight.w600,
+                                        color: context.appTextPrimary,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      l10n.createFellowshipUnlimitedHint,
+                                      style: TextStyle(
+                                        fontFamily: 'Inter',
+                                        fontSize: 13,
+                                        color: context.appTextSecondary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              Switch(
+                                value: unlimitedMembers,
+                                activeColor:
+                                    Theme.of(context).colorScheme.primary,
+                                onChanged:
+                                    isLoading ? null : onUnlimitedChanged,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    );
+                  },
+                ),
+
+                const SizedBox(height: 20),
+
+                // ── Who can post (any creator can choose) ────────────────────
+                _FieldLabel(label: l10n.createFellowshipWhoCanPostLabel),
                 const SizedBox(height: 8),
-                TextFormField(
-                  controller: maxController,
-                  enabled: !isLoading,
-                  textInputAction: TextInputAction.done,
-                  keyboardType: TextInputType.number,
-                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 15,
-                    color: context.appTextPrimary,
-                  ),
-                  decoration: _inputDecoration(
-                    context: context,
-                    hintText: '12',
-                    prefixIcon: Icons.people_rounded,
-                  ),
-                  validator: (v) {
-                    final n = int.tryParse(v?.trim() ?? '');
-                    if (n == null || n < 2 || n > 50) {
-                      return l10n.createFellowshipMaxError;
-                    }
-                    return null;
-                  },
-                  onFieldSubmitted: (_) {
-                    if (!isLoading && hasName) onCreatePressed();
-                  },
+                SegmentedButton<String>(
+                  segments: [
+                    ButtonSegment(
+                      value: 'all_members',
+                      label: Text(l10n.createFellowshipPostEveryone),
+                      icon: const Icon(Icons.groups_rounded, size: 18),
+                    ),
+                    ButtonSegment(
+                      value: 'mentor_only',
+                      label: Text(l10n.createFellowshipPostAdminsOnly),
+                      icon: const Icon(Icons.shield_rounded, size: 18),
+                    ),
+                  ],
+                  selected: {postingPermission},
+                  showSelectedIcon: false,
+                  onSelectionChanged: isLoading
+                      ? null
+                      : (s) => onPostingPermissionChanged(s.first),
                 ),
 
                 // ── Admin-only fields ─────────────────────────────────────────

--- a/frontend/lib/features/community/presentation/screens/fellowship_feed_tab_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/fellowship_feed_tab_screen.dart
@@ -100,19 +100,27 @@ class _FellowshipFeedViewState extends State<_FellowshipFeedView> {
     final l10n = AppLocalizations.of(context)!;
     return Scaffold(
       backgroundColor: context.appScaffold,
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: _openCreatePostSheet,
-        backgroundColor: context.appInteractive,
-        foregroundColor: Colors.white,
-        icon: const Icon(Icons.add),
-        label: Text(
-          l10n.feedNewPost,
-          style: const TextStyle(
-            fontFamily: 'Inter',
-            fontWeight: FontWeight.w600,
-            fontSize: 14,
-          ),
-        ),
+      floatingActionButton:
+          BlocBuilder<FellowshipFeedBloc, FellowshipFeedState>(
+        buildWhen: (prev, curr) =>
+            prev.canShowPostButton != curr.canShowPostButton,
+        builder: (context, state) {
+          if (!state.canShowPostButton) return const SizedBox.shrink();
+          return FloatingActionButton.extended(
+            onPressed: _openCreatePostSheet,
+            backgroundColor: context.appInteractive,
+            foregroundColor: Colors.white,
+            icon: const Icon(Icons.add),
+            label: Text(
+              l10n.feedNewPost,
+              style: const TextStyle(
+                fontFamily: 'Inter',
+                fontWeight: FontWeight.w600,
+                fontSize: 14,
+              ),
+            ),
+          );
+        },
       ),
       body: BlocBuilder<FellowshipFeedBloc, FellowshipFeedState>(
         builder: (context, state) {
@@ -205,7 +213,9 @@ class _FellowshipFeedViewState extends State<_FellowshipFeedView> {
                         ),
                         const SizedBox(height: 16),
                         Text(
-                          l10n.feedEmpty,
+                          state.canPost
+                              ? l10n.feedEmpty
+                              : l10n.feedEmptyReadOnly,
                           textAlign: TextAlign.center,
                           style: TextStyle(
                             fontFamily: 'Inter',

--- a/frontend/lib/features/community/presentation/screens/fellowship_home_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/fellowship_home_screen.dart
@@ -80,6 +80,15 @@ class _FellowshipHomeScreenState extends State<FellowshipHomeScreen> {
             ..add(FellowshipFeedInitialized(
               isMentor: isMentor,
               currentUserId: currentUserId,
+              postingPermission: fellowship?.postingPermission ?? 'all_members',
+              // Known immediately when the entity was passed; otherwise wait
+              // for the server (avoids flashing the post button on refresh).
+              postingContextResolved: fellowship != null,
+            ))
+            // Authoritative posting context — corrects FAB/empty-state gating
+            // when the entity wasn't passed (deep link / web refresh).
+            ..add(FellowshipFeedContextRequested(
+              fellowshipId: widget.fellowshipId,
             ))
             ..add(FellowshipFeedLoadRequested(
               fellowshipId: widget.fellowshipId,
@@ -402,30 +411,39 @@ class _FellowshipHomeContent extends StatelessWidget {
       ],
       child: Scaffold(
         backgroundColor: context.appScaffold,
-        floatingActionButton: FloatingActionButton.extended(
-          onPressed: () {
-            final feedBloc = context.read<FellowshipFeedBloc>();
-            showModalBottomSheet<void>(
-              context: context,
-              isScrollControlled: true,
-              backgroundColor: Colors.transparent,
-              builder: (_) => BlocProvider.value(
-                value: feedBloc,
-                child: FellowshipCreatePostSheet(fellowshipId: fellowshipId),
+        floatingActionButton:
+            BlocBuilder<FellowshipFeedBloc, FellowshipFeedState>(
+          buildWhen: (prev, curr) =>
+              prev.canShowPostButton != curr.canShowPostButton,
+          builder: (context, feedState) {
+            if (!feedState.canShowPostButton) return const SizedBox.shrink();
+            return FloatingActionButton.extended(
+              onPressed: () {
+                final feedBloc = context.read<FellowshipFeedBloc>();
+                showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  backgroundColor: Colors.transparent,
+                  builder: (_) => BlocProvider.value(
+                    value: feedBloc,
+                    child:
+                        FellowshipCreatePostSheet(fellowshipId: fellowshipId),
+                  ),
+                );
+              },
+              backgroundColor: context.appInteractive,
+              foregroundColor: Colors.white,
+              icon: const Icon(Icons.add),
+              label: Text(
+                l10n.feedNewPost,
+                style: const TextStyle(
+                  fontFamily: 'Inter',
+                  fontWeight: FontWeight.w600,
+                  fontSize: 14,
+                ),
               ),
             );
           },
-          backgroundColor: context.appInteractive,
-          foregroundColor: Colors.white,
-          icon: const Icon(Icons.add),
-          label: Text(
-            l10n.feedNewPost,
-            style: const TextStyle(
-              fontFamily: 'Inter',
-              fontWeight: FontWeight.w600,
-              fontSize: 14,
-            ),
-          ),
         ),
         appBar: AppBar(
           backgroundColor: context.appScaffold,
@@ -861,7 +879,7 @@ class _FeedPreviewSection extends StatelessWidget {
                           size: 36, color: context.appTextTertiary),
                       const SizedBox(height: 8),
                       Text(
-                        l10n.feedEmpty,
+                        state.canPost ? l10n.feedEmpty : l10n.feedEmptyReadOnly,
                         textAlign: TextAlign.center,
                         style: TextStyle(
                           fontFamily: 'Inter',
@@ -869,20 +887,22 @@ class _FeedPreviewSection extends StatelessWidget {
                           color: context.appTextSecondary,
                         ),
                       ),
-                      const SizedBox(height: 12),
-                      OutlinedButton.icon(
-                        onPressed: onViewAll,
-                        icon: const Icon(Icons.add, size: 16),
-                        label: Text(l10n.feedPostSomething),
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor:
-                              Theme.of(context).colorScheme.primary,
-                          side: BorderSide(
-                              color: Theme.of(context).colorScheme.primary),
-                          shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10)),
+                      if (state.canShowPostButton) ...[
+                        const SizedBox(height: 12),
+                        OutlinedButton.icon(
+                          onPressed: onViewAll,
+                          icon: const Icon(Icons.add, size: 16),
+                          label: Text(l10n.feedPostSomething),
+                          style: OutlinedButton.styleFrom(
+                            foregroundColor:
+                                Theme.of(context).colorScheme.primary,
+                            side: BorderSide(
+                                color: Theme.of(context).colorScheme.primary),
+                            shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(10)),
+                          ),
                         ),
-                      ),
+                      ],
                     ]),
                   ),
                 );

--- a/frontend/lib/features/community/presentation/screens/fellowship_invites_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/fellowship_invites_screen.dart
@@ -1,0 +1,463 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../../../../core/localization/app_localizations.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../bloc/fellowship_members/fellowship_members_bloc.dart';
+import '../bloc/fellowship_members/fellowship_members_event.dart';
+import '../bloc/fellowship_members/fellowship_members_state.dart';
+
+/// Full-screen invite-link management for fellowship mentors.
+///
+/// Lists every active invite link with its usage count and expiry, and lets
+/// the mentor generate new reusable links, copy/share them, or revoke them.
+///
+/// Reuses the [FellowshipMembersBloc] provided by [FellowshipHomeScreen] —
+/// push this screen with a `BlocProvider.value` wrapping that BLoC.
+class FellowshipInvitesScreen extends StatefulWidget {
+  /// The ID of the fellowship whose invite links are managed.
+  final String fellowshipId;
+
+  /// Display name of the fellowship, used in the share message.
+  final String? fellowshipName;
+
+  const FellowshipInvitesScreen({
+    required this.fellowshipId,
+    this.fellowshipName,
+    super.key,
+  });
+
+  @override
+  State<FellowshipInvitesScreen> createState() =>
+      _FellowshipInvitesScreenState();
+}
+
+class _FellowshipInvitesScreenState extends State<FellowshipInvitesScreen> {
+  @override
+  void initState() {
+    super.initState();
+    // Load the active invite links when the screen opens.
+    context
+        .read<FellowshipMembersBloc>()
+        .add(const FellowshipInvitesListRequested());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return Scaffold(
+      backgroundColor: context.appScaffold,
+      appBar: AppBar(
+        backgroundColor: context.appScaffold,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        title: Text(
+          l10n.inviteManageTitle,
+          style: TextStyle(
+            fontFamily: 'Poppins',
+            fontSize: 18,
+            fontWeight: FontWeight.w700,
+            color: context.appTextPrimary,
+          ),
+        ),
+      ),
+      body: BlocBuilder<FellowshipMembersBloc, FellowshipMembersState>(
+        buildWhen: (prev, curr) =>
+            prev.invitesList != curr.invitesList ||
+            prev.invitesListStatus != curr.invitesListStatus ||
+            prev.inviteStatus != curr.inviteStatus,
+        builder: (context, state) {
+          final isLoading =
+              state.invitesListStatus == FellowshipInvitesListStatus.loading &&
+                  state.invitesList.isEmpty;
+
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                child: Text(
+                  l10n.inviteManageSubtitle,
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 13,
+                    color: context.appTextSecondary,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: isLoading
+                    ? const Center(child: CircularProgressIndicator())
+                    : state.invitesList.isEmpty
+                        ? _EmptyLinks(l10n: l10n)
+                        : ListView.separated(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                            itemCount: state.invitesList.length,
+                            separatorBuilder: (_, __) =>
+                                const SizedBox(height: 12),
+                            itemBuilder: (_, i) => _InviteCard(
+                              invite: state.invitesList[i],
+                              fellowshipName: widget.fellowshipName,
+                            ),
+                          ),
+              ),
+              _GenerateBar(
+                generating:
+                    state.inviteStatus == FellowshipInviteStatus.loading,
+                error: state.inviteStatus == FellowshipInviteStatus.failure
+                    ? state.inviteError
+                    : null,
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Invite card — one active link
+// ---------------------------------------------------------------------------
+
+class _InviteCard extends StatelessWidget {
+  final Map<String, dynamic> invite;
+  final String? fellowshipName;
+
+  const _InviteCard({required this.invite, this.fellowshipName});
+
+  String get _token => invite['token'] as String? ?? '';
+
+  String get _joinUrl =>
+      (invite['join_url'] as String?) ??
+      'https://app.disciplefy.in/fellowship/join/$_token';
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final primary = Theme.of(context).colorScheme.primary;
+    final useCount = (invite['use_count'] as num?)?.toInt() ?? 0;
+    final maxUses = (invite['max_uses'] as num?)?.toInt();
+
+    final usageLabel = maxUses == null
+        ? '$useCount ${l10n.inviteJoinedSuffix} · ${l10n.inviteUnlimited}'
+        : '$useCount / $maxUses';
+
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: context.appSurface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: context.appBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Code + copy-code ───────────────────────────────────────────
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  _token.toUpperCase(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 22,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 3,
+                    color: primary,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _CopyIconButton(
+                text: _token,
+                tooltip: l10n.inviteCopyCode,
+                copiedMessage: l10n.inviteCodeCopied,
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          // ── Full link (visible for reference; shared via Invite) ────────
+          Text(
+            _joinUrl,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              fontFamily: 'Inter',
+              fontSize: 12,
+              color: context.appTextTertiary,
+            ),
+          ),
+          const SizedBox(height: 10),
+          // ── Usage + expiry ─────────────────────────────────────────────
+          Row(
+            children: [
+              Icon(Icons.group_outlined, size: 14, color: primary),
+              const SizedBox(width: 4),
+              Text(
+                usageLabel,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  color: context.appTextSecondary,
+                ),
+              ),
+              const SizedBox(width: 12),
+              Icon(Icons.schedule_rounded,
+                  size: 13, color: context.appTextTertiary),
+              const SizedBox(width: 4),
+              Text(
+                l10n.inviteExpires,
+                style: TextStyle(
+                  fontFamily: 'Inter',
+                  fontSize: 12,
+                  color: context.appTextTertiary,
+                ),
+              ),
+            ],
+          ),
+          const Divider(height: 22),
+          // ── Actions ────────────────────────────────────────────────────
+          Row(
+            children: [
+              _TextAction(
+                icon: Icons.share_outlined,
+                label: l10n.membersInvite,
+                color: primary,
+                onTap: () {
+                  final name = fellowshipName?.isNotEmpty == true
+                      ? fellowshipName!
+                      : 'my fellowship';
+                  Share.share('Join $name on Disciplefy:\n$_joinUrl');
+                },
+              ),
+              const Spacer(),
+              _TextAction(
+                icon: Icons.link_off_rounded,
+                label: l10n.inviteRevoke,
+                color: AppColors.error,
+                onTap: () {
+                  final inviteId = invite['id'] as String? ?? '';
+                  context.read<FellowshipMembersBloc>().add(
+                        FellowshipInviteRevokeRequested(inviteId: inviteId),
+                      );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generate-link bar (bottom)
+// ---------------------------------------------------------------------------
+
+class _GenerateBar extends StatelessWidget {
+  final bool generating;
+  final String? error;
+
+  const _GenerateBar({required this.generating, this.error});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (error != null)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: Text(
+                  error!,
+                  style: const TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 13,
+                    color: AppColors.error,
+                  ),
+                ),
+              ),
+            SizedBox(
+              width: double.infinity,
+              height: 50,
+              child: ElevatedButton.icon(
+                onPressed: generating
+                    ? null
+                    : () => context.read<FellowshipMembersBloc>().add(
+                          const FellowshipMembersInviteRequested(),
+                        ),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: context.appInteractive,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                icon: generating
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: Colors.white,
+                        ),
+                      )
+                    : const Icon(Icons.add_link_rounded),
+                label: Text(
+                  l10n.inviteGenerateLink,
+                  style: const TextStyle(
+                    fontFamily: 'Inter',
+                    fontSize: 15,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+class _EmptyLinks extends StatelessWidget {
+  final AppLocalizations l10n;
+
+  const _EmptyLinks({required this.l10n});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.link_rounded, size: 56, color: context.appTextTertiary),
+            const SizedBox(height: 16),
+            Text(
+              l10n.inviteNoLinks,
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+                color: context.appTextSecondary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              l10n.inviteNoLinksDescription,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontFamily: 'Inter',
+                fontSize: 14,
+                color: context.appTextTertiary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small action helpers
+// ---------------------------------------------------------------------------
+
+class _TextAction extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onTap;
+
+  const _TextAction({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton.icon(
+      onPressed: onTap,
+      style: TextButton.styleFrom(
+        foregroundColor: color,
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+      ),
+      icon: Icon(icon, size: 18),
+      label: Text(
+        label,
+        style: const TextStyle(
+          fontFamily: 'Inter',
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _CopyIconButton extends StatefulWidget {
+  final String text;
+  final String tooltip;
+  final String copiedMessage;
+
+  const _CopyIconButton({
+    required this.text,
+    required this.tooltip,
+    required this.copiedMessage,
+  });
+
+  @override
+  State<_CopyIconButton> createState() => _CopyIconButtonState();
+}
+
+class _CopyIconButtonState extends State<_CopyIconButton> {
+  bool _copied = false;
+
+  Future<void> _copy() async {
+    await Clipboard.setData(ClipboardData(text: widget.text));
+    if (!mounted) return;
+    setState(() => _copied = true);
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(SnackBar(
+        content: Text(widget.copiedMessage),
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ));
+    await Future<void>.delayed(const Duration(seconds: 2));
+    if (!mounted) return;
+    setState(() => _copied = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      onPressed: _copy,
+      tooltip: widget.tooltip,
+      icon: Icon(
+        _copied ? Icons.check_circle_outline : Icons.copy_outlined,
+        color:
+            _copied ? AppColors.success : Theme.of(context).colorScheme.primary,
+        size: 22,
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/community/presentation/screens/fellowship_members_tab_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/fellowship_members_tab_screen.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:share_plus/share_plus.dart';
 
 import '../../../../core/localization/app_localizations.dart';
 import '../../../../core/theme/app_colors.dart';
@@ -11,6 +9,7 @@ import '../../../../features/study_topics/presentation/bloc/learning_paths_state
 import '../bloc/fellowship_members/fellowship_members_bloc.dart';
 import '../bloc/fellowship_members/fellowship_members_event.dart';
 import '../bloc/fellowship_members/fellowship_members_state.dart';
+import 'fellowship_invites_screen.dart';
 
 /// Displays the member list for a fellowship and provides an invite action.
 ///
@@ -38,7 +37,7 @@ class FellowshipMembersTabScreen extends StatelessWidget {
         builder: (context, state) {
           if (!state.isMentor) return const SizedBox.shrink();
           return FloatingActionButton.extended(
-            onPressed: () => _showInviteSheet(context, fellowshipName),
+            onPressed: () => _openInviteManagement(context, fellowshipName),
             backgroundColor: context.appInteractive,
             foregroundColor: AppColors.onGradient,
             icon: const Icon(Icons.person_add_outlined),
@@ -89,19 +88,17 @@ class FellowshipMembersTabScreen extends StatelessWidget {
     );
   }
 
-  void _showInviteSheet(BuildContext context, String? fellowshipName) {
+  void _openInviteManagement(BuildContext context, String? fellowshipName) {
     final bloc = context.read<FellowshipMembersBloc>();
-    // Load the active invites list when opening the sheet.
-    bloc.add(const FellowshipInvitesListRequested());
-    showModalBottomSheet<void>(
-      context: context,
-      isScrollControlled: true,
-      shape: const RoundedRectangleBorder(
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      builder: (_) => BlocProvider.value(
-        value: bloc,
-        child: _InviteSheet(fellowshipName: fellowshipName),
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => BlocProvider.value(
+          value: bloc,
+          child: FellowshipInvitesScreen(
+            fellowshipId: fellowshipId,
+            fellowshipName: fellowshipName,
+          ),
+        ),
       ),
     );
   }
@@ -622,387 +619,6 @@ class _ErrorView extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Invite bottom sheet
-// ---------------------------------------------------------------------------
-
-class _InviteSheet extends StatelessWidget {
-  final String? fellowshipName;
-  const _InviteSheet({this.fellowshipName});
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-
-    return BlocBuilder<FellowshipMembersBloc, FellowshipMembersState>(
-      buildWhen: (prev, curr) =>
-          prev.inviteStatus != curr.inviteStatus ||
-          prev.inviteToken != curr.inviteToken ||
-          prev.invitesListStatus != curr.invitesListStatus ||
-          prev.invitesList != curr.invitesList,
-      builder: (context, state) {
-        return SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(24, 20, 24, 24),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // Drag handle
-                Center(
-                  child: Container(
-                    width: 40,
-                    height: 4,
-                    decoration: BoxDecoration(
-                      color: context.appBorder,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 20),
-                // Title
-                Text(
-                  l10n.membersInviteTitle,
-                  style: TextStyle(
-                    fontFamily: 'Poppins',
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
-                    color: context.appTextPrimary,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  l10n.membersInviteSubtitle,
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 14,
-                    color: context.appTextSecondary,
-                  ),
-                ),
-                const SizedBox(height: 20),
-
-                // ── State-driven content ──────────────────────────────
-                if (state.inviteStatus == FellowshipInviteStatus.loading ||
-                    state.invitesListStatus ==
-                        FellowshipInvitesListStatus.loading)
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 20),
-                      child: CircularProgressIndicator(
-                        color: Theme.of(context).colorScheme.primary,
-                      ),
-                    ),
-                  )
-                // Freshly generated invite
-                else if (state.inviteStatus == FellowshipInviteStatus.success &&
-                    state.inviteToken != null)
-                  _InviteTokenRow(
-                    token: state.inviteToken!,
-                    inviteId: state.inviteId,
-                    expiresLabel: l10n.inviteExpires,
-                    fellowshipName: fellowshipName,
-                  )
-                // Already has an active code — show it, hide the generate button
-                else if (state.invitesList.isNotEmpty)
-                  _InviteTokenRow(
-                    token: state.invitesList.first['token'] as String? ?? '',
-                    inviteId: state.invitesList.first['id'] as String?,
-                    expiresLabel: l10n.inviteExpires,
-                    fellowshipName: fellowshipName,
-                  )
-                else ...[
-                  // No active codes → show generate button
-                  if (state.inviteStatus == FellowshipInviteStatus.failure &&
-                      state.inviteError != null)
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 12),
-                      child: Text(
-                        state.inviteError!,
-                        style: const TextStyle(
-                          fontFamily: 'Inter',
-                          fontSize: 13,
-                          color: AppColors.error,
-                        ),
-                      ),
-                    ),
-                  SizedBox(
-                    width: double.infinity,
-                    height: 48,
-                    child: ElevatedButton.icon(
-                      onPressed: () =>
-                          context.read<FellowshipMembersBloc>().add(
-                                const FellowshipMembersInviteRequested(),
-                              ),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: context.appInteractive,
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                      ),
-                      icon: const Icon(Icons.link_rounded),
-                      label: Text(
-                        l10n.membersInvite,
-                        style: const TextStyle(
-                          fontFamily: 'Inter',
-                          fontSize: 15,
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Active invite row — shows token + revoke button
-// ---------------------------------------------------------------------------
-
-class _ActiveInviteRow extends StatelessWidget {
-  final Map<String, dynamic> invite;
-
-  const _ActiveInviteRow({required this.invite});
-
-  @override
-  Widget build(BuildContext context) {
-    final l10n = AppLocalizations.of(context)!;
-    final token = invite['token'] as String? ?? '';
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              token,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontFamily: 'Inter',
-                fontSize: 13,
-                color: context.appTextPrimary,
-                letterSpacing: 1,
-              ),
-            ),
-          ),
-          const SizedBox(width: 8),
-          _CopyButton(text: token),
-          TextButton(
-            onPressed: () {
-              final inviteId = invite['id'] as String? ?? '';
-              context.read<FellowshipMembersBloc>().add(
-                    FellowshipInviteRevokeRequested(inviteId: inviteId),
-                  );
-            },
-            style: TextButton.styleFrom(
-              foregroundColor: AppColors.error,
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-            ),
-            child: Text(
-              l10n.inviteRevoke,
-              style: const TextStyle(
-                fontFamily: 'Inter',
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Invite token row (shows token + copy button + expiry note)
-// ---------------------------------------------------------------------------
-
-class _InviteTokenRow extends StatelessWidget {
-  final String token;
-  final String? inviteId;
-  final String expiresLabel;
-  final String? fellowshipName;
-
-  const _InviteTokenRow({
-    required this.token,
-    required this.expiresLabel,
-    this.inviteId,
-    this.fellowshipName,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final isDark = Theme.of(context).brightness == Brightness.dark;
-    final primary = Theme.of(context).colorScheme.primary;
-    final letters = token.toUpperCase().split('');
-    final l10n = AppLocalizations.of(context)!;
-
-    return Column(
-      children: [
-        // Letter tiles
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: List.generate(letters.length, (i) {
-            return Container(
-              margin: i < letters.length - 1
-                  ? const EdgeInsets.only(right: 8)
-                  : null,
-              width: 46,
-              height: 56,
-              decoration: BoxDecoration(
-                color: isDark
-                    ? primary.withOpacity(0.12)
-                    : primary.withOpacity(0.08),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  color: primary.withOpacity(0.35),
-                  width: 1.5,
-                ),
-              ),
-              alignment: Alignment.center,
-              child: Text(
-                letters[i],
-                style: TextStyle(
-                  fontFamily: 'Inter',
-                  fontSize: 26,
-                  fontWeight: FontWeight.w700,
-                  color: primary,
-                  height: 1,
-                ),
-              ),
-            );
-          }),
-        ),
-        const SizedBox(height: 14),
-        // Copy + share + expiry + revoke row
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            _CopyButton(text: token),
-            const SizedBox(width: 8),
-            _ShareLinkButton(token: token, fellowshipName: fellowshipName),
-            const SizedBox(width: 16),
-            Icon(Icons.schedule_rounded,
-                size: 13, color: context.appTextTertiary),
-            const SizedBox(width: 4),
-            Text(
-              expiresLabel,
-              style: TextStyle(
-                fontFamily: 'Inter',
-                fontSize: 12,
-                color: context.appTextTertiary,
-              ),
-            ),
-            if (inviteId != null) ...[
-              const SizedBox(width: 16),
-              GestureDetector(
-                onTap: () => context.read<FellowshipMembersBloc>().add(
-                      FellowshipInviteRevokeRequested(inviteId: inviteId!),
-                    ),
-                child: Text(
-                  l10n.inviteRevoke,
-                  style: TextStyle(
-                    fontFamily: 'Inter',
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: AppColors.error,
-                  ),
-                ),
-              ),
-            ],
-          ],
-        ),
-      ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Copy button
-// ---------------------------------------------------------------------------
-
-class _CopyButton extends StatefulWidget {
-  final String text;
-
-  const _CopyButton({required this.text});
-
-  @override
-  State<_CopyButton> createState() => _CopyButtonState();
-}
-
-class _CopyButtonState extends State<_CopyButton> {
-  bool _copied = false;
-
-  Future<void> _copy() async {
-    await Clipboard.setData(ClipboardData(text: widget.text));
-    if (!mounted) return;
-    setState(() => _copied = true);
-    await Future<void>.delayed(const Duration(seconds: 2));
-    if (!mounted) return;
-    setState(() => _copied = false);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return AnimatedSwitcher(
-      duration: const Duration(milliseconds: 200),
-      child: _copied
-          ? const Icon(
-              Icons.check_circle_outline,
-              key: ValueKey('check'),
-              color: AppColors.success,
-              size: 28,
-            )
-          : IconButton(
-              key: const ValueKey('copy'),
-              onPressed: _copy,
-              tooltip: AppLocalizations.of(context)!.membersCopy,
-              icon: Icon(
-                Icons.copy_outlined,
-                color: Theme.of(context).colorScheme.primary,
-                size: 24,
-              ),
-            ),
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Share link button
-// ---------------------------------------------------------------------------
-
-class _ShareLinkButton extends StatelessWidget {
-  final String token;
-  final String? fellowshipName;
-
-  const _ShareLinkButton({required this.token, this.fellowshipName});
-
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      onPressed: () {
-        final url = 'https://app.disciplefy.in/fellowship/join/$token';
-        final name = fellowshipName?.isNotEmpty == true
-            ? fellowshipName!
-            : 'my fellowship';
-        Share.share('Join $name on Disciplefy:\n$url');
-      },
-      tooltip: 'Share invite link',
-      icon: Icon(
-        Icons.share_outlined,
-        color: Theme.of(context).colorScheme.primary,
-        size: 24,
       ),
     );
   }


### PR DESCRIPTION
## Summary
Adds three fellowship capabilities and tightens the related UX:

- **Posting permissions** — fellowships can restrict posting to the mentor only (`mentor_only`) or allow all members (`all_members`). Enforced server-side in `fellowship-posts` (403 for non-mentors when `mentor_only`).
- **Unlimited members** — app-admins can create fellowships with no member cap (`max_members = NULL`). Gated to admins in both backend and the create UI.
- **Reusable invite links** — invites now carry an optional `max_uses` (NULL = unlimited) and track `use_count`, replacing single-use links. Added a full invite-management screen (list links with usage/expiry, generate, copy code, share link, revoke).

## Frontend UX
- Post button (FABs + "Post something") is hidden when the viewer can't post; gated on an authoritative server fetch so it doesn't flash on web refresh / deep-link.
- Empty-feed copy adapts ("Be the first to share!" vs "Check back soon for updates.").
- Create screen groups the Max Members field with the admin-only Unlimited toggle and hides the field when Unlimited is on.
- New keys localized in en/hi/ml.

## Migration
`20260613100000_fellowship_permissions_and_reusable_invites.sql` — adds `posting_permission`, makes `max_members` nullable, adds `max_uses`/`use_count`, backfills, and rebuilds invite indexes. Requires `supabase db push` before deploy.

## Validation
`flutter analyze` and `deno check` clean on all touched files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reusable invite links with configurable usage caps and manual revocation
  * Fellowship-level posting permission controls (all members or mentors/admins only)
  * Unlimited membership capacity option for fellowships
  * Dedicated invite link management screen with copy, share, and revoke actions
  * Contextual empty feed messaging reflecting posting permissions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->