### PR TITLE
API.Bible compliance + admin kill-switches, App Store paywall fix, and supporting changes

### DIFF
--- a/admin-web/app/(dashboard)/system-config/page.tsx
+++ b/admin-web/app/(dashboard)/system-config/page.tsx
@@ -339,6 +339,43 @@ export default function SystemConfigPage() {
           </div>
         </div>
 
+        {/* Purge Cached Bible Content */}
+        <div className="rounded-lg border border-red-200 bg-white p-6 shadow-sm dark:border-red-800 dark:bg-gray-800">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                🗑️ Purge Cached Bible Content
+              </h3>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Deletes all cached daily verses and blanks API.Bible-sourced memory-verse text.
+                Use after disabling &quot;Bible API — content&quot;. Irreversible (content re-fetches on re-enable).
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={async () => {
+              if (!confirm('Permanently delete cached API.Bible content? This cannot be undone.')) return
+              try {
+                const res = await fetch('/api/admin/system/purge-bible-content', {
+                  method: 'POST',
+                  credentials: 'include',
+                })
+                const json = await res.json()
+                if (json.success) {
+                  toast.success(`Purged ${json.deleted_cache_rows} cache rows, ${json.blanked_memory_verses} memory verses`)
+                } else {
+                  toast.error(json.error ?? 'Purge failed')
+                }
+              } catch {
+                toast.error('Purge failed — network error')
+              }
+            }}
+            className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+          >
+            Purge cached Bible content
+          </button>
+        </div>
+
         {/* App Version Control */}
         <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
           <div className="flex items-center justify-between mb-4">

--- a/admin-web/app/api/admin/system/purge-bible-content/route.ts
+++ b/admin-web/app/api/admin/system/purge-bible-content/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createAdminClient } from '@/lib/supabase/admin'
+
+/**
+ * POST - Purge cached Bible content (daily_verses_cache + API.Bible-sourced memory_verses)
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Verify user authentication
+    const supabaseUser = await createClient()
+    const { data: { user }, error: userError } = await supabaseUser.auth.getUser()
+
+    if (userError || !user) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    // Verify admin status
+    const supabaseAdmin = await createAdminClient()
+    const { data: profile } = await supabaseAdmin
+      .from('user_profiles')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single()
+
+    if (!profile?.is_admin) {
+      return NextResponse.json(
+        { error: 'Unauthorized - Admin access required' },
+        { status: 403 }
+      )
+    }
+
+    // Execute purge
+    const { data, error: rpcError } = await supabaseAdmin.rpc('purge_bible_content')
+
+    if (rpcError) {
+      console.error('[PurgeBibleContent] RPC error:', rpcError)
+      return NextResponse.json({ error: rpcError.message }, { status: 500 })
+    }
+
+    const row = Array.isArray(data) ? data[0] : data
+    return NextResponse.json({
+      success: true,
+      deleted_cache_rows: row?.deleted_cache_rows ?? 0,
+      blanked_memory_verses: row?.blanked_memory_verses ?? 0,
+      purged_by: user.email,
+    })
+  } catch (error) {
+    console.error('[PurgeBibleContent] POST error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/backend/supabase/functions/_shared/services/bible-api-service.ts
+++ b/backend/supabase/functions/_shared/services/bible-api-service.ts
@@ -62,6 +62,9 @@ export interface BibleVerse {
   text: string;
   translation: string;
   language: string;
+  // API.Bible FUMS v3 token for this request, to be reported client-side
+  // (Fair Use Management System). Absent for cache hits / non-live fetches.
+  fumsToken?: string;
 }
 
 export interface BibleApiError {
@@ -232,6 +235,7 @@ export async function fetchBibleVerse(
     'include-titles': 'false',        // No section titles/headings
     'include-chapter-numbers': 'false', // No chapter numbers
     'include-verse-numbers': 'false', // No verse numbers
+    'fums-version': '3',              // Request FUMS v3 token (meta.fumsToken) for usage reporting
   });
 
   const url = `https://api.scripture.api.bible/v1/bibles/${bibleId}/verses/${verseId}?${params.toString()}`;
@@ -267,6 +271,7 @@ export async function fetchBibleVerse(
         text: verseText,
         translation: getTranslationName(language),
         language,
+        fumsToken: data.meta?.fumsToken,
       };
     } catch (error) {
       console.error(`[Bible API] Error fetching verse ${reference} (${language}):`, error);
@@ -532,9 +537,9 @@ export async function cacheVerses(
   const supabase = createClient(supabaseUrl, supabaseKey);
 
   const dateKey = verseDate.toISOString().split('T')[0];
-  // Cache for 6 months (same as daily verse cache)
+  // API.Bible Terms require cached content be refreshed at least every 30 days.
   const expiresAt = new Date();
-  expiresAt.setMonth(expiresAt.getMonth() + 6);
+  expiresAt.setDate(expiresAt.getDate() + 30);
 
   const verseData = {
     reference: verses.en.reference,

--- a/backend/supabase/functions/_shared/services/bible-availability.test.ts
+++ b/backend/supabase/functions/_shared/services/bible-availability.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from 'https://deno.land/std@0.208.0/assert/mod.ts'
+import { featureFlagEnabled, flagEnabled } from './bible-availability.ts'
+
+Deno.test('flagEnabled: undefined flag -> enabled (fail-open)', () => {
+  assertEquals(flagEnabled(undefined), true)
+})
+
+Deno.test('flagEnabled: null flag -> enabled', () => {
+  assertEquals(flagEnabled(null), true)
+})
+
+Deno.test('flagEnabled: is_enabled true -> enabled', () => {
+  assertEquals(flagEnabled({ is_enabled: true }), true)
+})
+
+Deno.test('flagEnabled: is_enabled false -> disabled', () => {
+  assertEquals(flagEnabled({ is_enabled: false }), false)
+})
+
+Deno.test('flagEnabled: missing is_enabled -> enabled', () => {
+  assertEquals(flagEnabled({}), true)
+})
+
+// featureFlagEnabled maps the FeatureFlag camelCase `isEnabled` field. These
+// guard the snake_case conversion — a regression (e.g. passing the flag
+// straight to flagEnabled) would read `is_enabled` as undefined and wrongly
+// report a disabled flag as enabled.
+Deno.test('featureFlagEnabled: undefined flag -> enabled (fail-open)', () => {
+  assertEquals(featureFlagEnabled(undefined), true)
+})
+
+Deno.test('featureFlagEnabled: null flag -> enabled', () => {
+  assertEquals(featureFlagEnabled(null), true)
+})
+
+Deno.test('featureFlagEnabled: isEnabled true -> enabled', () => {
+  assertEquals(featureFlagEnabled({ isEnabled: true }), true)
+})
+
+Deno.test('featureFlagEnabled: isEnabled false -> disabled', () => {
+  assertEquals(featureFlagEnabled({ isEnabled: false }), false)
+})
+
+Deno.test('featureFlagEnabled: missing isEnabled -> enabled', () => {
+  assertEquals(featureFlagEnabled({}), true)
+})

--- a/backend/supabase/functions/_shared/services/bible-availability.ts
+++ b/backend/supabase/functions/_shared/services/bible-availability.ts
@@ -1,0 +1,31 @@
+import { getFeatureFlag } from './feature-flag-service.ts'
+
+export const BIBLE_API_CALLS_FLAG = 'bible_api_calls_enabled'
+export const BIBLE_CONTENT_FLAG = 'bible_content_enabled'
+
+/**
+ * Kill-switch read semantics: a flag is ENABLED unless an admin has explicitly
+ * set it disabled. Missing/undefined flag => enabled (fail-open) so a transient
+ * flag-read miss never takes Bible features down.
+ *
+ * `flagEnabled` operates on a snake_case `{ is_enabled }` shape (easy to unit-test).
+ */
+export function flagEnabled(flag: { is_enabled?: boolean } | undefined | null): boolean {
+  return flag?.is_enabled !== false
+}
+
+/**
+ * Kill-switch decision for a `FeatureFlag` as returned by feature-flag-service,
+ * whose enabled field is camelCase `isEnabled`. Maps it onto `flagEnabled`.
+ */
+export function featureFlagEnabled(flag: { isEnabled?: boolean } | undefined | null): boolean {
+  return flagEnabled(flag ? { is_enabled: flag.isEnabled } : undefined)
+}
+
+export async function isBibleApiCallsEnabled(): Promise<boolean> {
+  return featureFlagEnabled(await getFeatureFlag(BIBLE_API_CALLS_FLAG))
+}
+
+export async function isBibleContentEnabled(): Promise<boolean> {
+  return featureFlagEnabled(await getFeatureFlag(BIBLE_CONTENT_FLAG))
+}

--- a/backend/supabase/functions/_shared/services/iap-config-service.ts
+++ b/backend/supabase/functions/_shared/services/iap-config-service.ts
@@ -56,9 +56,17 @@ function getConfigFromEnvVars(provider: IAPProvider, environment: IAPEnvironment
       return { provider, environment, serviceAccountEmail: email, serviceAccountKey: key, packageName }
     }
   } else if (provider === 'apple_appstore') {
-    const sharedSecret = Deno.env.get(`APPLE_${envSuffix}_SHARED_SECRET`)
-    const bundleDefault = 'com.disciplefy.bible_study'
-    const bundleId = Deno.env.get(`APPLE_${envSuffix}_BUNDLE_ID`) ?? bundleDefault
+    // Prefer env-suffixed names; fall back to the un-suffixed APPLE_SHARED_SECRET /
+    // APPLE_BUNDLE_ID that the deploy workflow actually sets. The app-specific
+    // shared secret is the same for sandbox and production (the 21007 fallback in
+    // the provider handles sandbox receipts), so the un-suffixed value is valid
+    // for both environments.
+    const sharedSecret = Deno.env.get(`APPLE_${envSuffix}_SHARED_SECRET`) ??
+      Deno.env.get('APPLE_SHARED_SECRET')
+    const bundleDefault = 'com.disciplefy.biblestudy'
+    const bundleId = Deno.env.get(`APPLE_${envSuffix}_BUNDLE_ID`) ??
+      Deno.env.get('APPLE_BUNDLE_ID') ??
+      bundleDefault
 
     if (sharedSecret) {
       console.log(`[IAP_CONFIG] Source: ENV_VARS | Provider: ${provider} | Env: ${environment} | Bundle: ${bundleId}`)

--- a/backend/supabase/functions/cleanup-expired-verse-cache/index.ts
+++ b/backend/supabase/functions/cleanup-expired-verse-cache/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Cleanup Expired Verse Cache - Scheduled Background Job
+ *
+ * Deletes daily_verses_cache rows whose 30-day TTL has elapsed. The read paths
+ * already skip expired rows (so stale content is never served), but expired rows
+ * otherwise linger in the table. API.Bible's content-recency terms require cached
+ * content to be refreshed or removed at least every 30 days — this enforces removal.
+ *
+ * Schedule: daily via external scheduler / pg_cron (e.g. `0 3 * * *`).
+ */
+
+import { createServiceRoleFunction } from '../_shared/core/function-factory.ts'
+
+createServiceRoleFunction(async (_req, supabase) => {
+  const now = new Date().toISOString()
+  console.log('[CLEANUP-VERSE-CACHE] Deleting daily_verses_cache rows expired before', now)
+
+  const { data, error } = await supabase
+    .from('daily_verses_cache')
+    .delete()
+    .lt('expires_at', now)
+    .select('id')
+
+  if (error) {
+    console.error('[CLEANUP-VERSE-CACHE] Delete failed:', error)
+    return { success: false, error: error.message, deleted_count: 0 }
+  }
+
+  const deleted_count = data?.length ?? 0
+  console.log(`[CLEANUP-VERSE-CACHE] ✅ Deleted ${deleted_count} expired rows`)
+
+  return { success: true, deleted_count, timestamp: now }
+}, {
+  allowedMethods: ['POST', 'GET']
+})

--- a/backend/supabase/functions/daily-verse/daily-verse-service.ts
+++ b/backend/supabase/functions/daily-verse/daily-verse-service.ts
@@ -1,5 +1,6 @@
 // Supabase client is now injected via DI container - no need to import createClient
 import { LLMService } from '../_shared/services/llm-service.ts'
+import { isBibleApiCallsEnabled } from '../_shared/services/bible-availability.ts'
 
 /**
  * Daily Verse Service
@@ -137,6 +138,14 @@ export class DailyVerseService {
       }
 
       console.log(`No cached verse found, generating new verse for date: ${dateKey}`)
+
+      // Operational kill-switch: skip API.Bible calls, use deterministic fallback.
+      if (!(await isBibleApiCallsEnabled())) {
+        console.warn('[DailyVerse] bible_api_calls_enabled is OFF — using fallback verse, no API.Bible call')
+        const fallback = this.getFallbackVerse(targetDate)
+        await this.cacheVerse(dateKey, fallback)
+        return { ...fallback, fromCache: false }
+      }
 
       // Generate new verse for the date with language preference
       const newVerse = await this.generateDailyVerse(targetDate, language)
@@ -346,6 +355,9 @@ export class DailyVerseService {
         .select('uuid, verse_data')
         .eq('date_key', dateKey)
         .eq('is_active', true)
+        // API.Bible content-recency: skip entries older than their 30-day TTL
+        // so they are regenerated (and re-fetched) instead of served stale.
+        .gt('expires_at', new Date().toISOString())
         .single()
 
       if (error) {
@@ -447,11 +459,12 @@ export class DailyVerseService {
   }
 
   /**
-   * Get cache expiration date (60 days from now)
+   * Get cache expiration date.
+   * API.Bible Terms require cached content be refreshed at least every 30 days.
    */
   private getExpirationDate(): string {
     const expirationDate = new Date()
-    expirationDate.setDate(expirationDate.getDate() + 60)
+    expirationDate.setDate(expirationDate.getDate() + 30)
     return expirationDate.toISOString()
   }
 

--- a/backend/supabase/functions/daily-verse/index.ts
+++ b/backend/supabase/functions/daily-verse/index.ts
@@ -13,6 +13,7 @@ import { ApiSuccessResponse } from '../_shared/types/index.ts'
 import { ServiceContainer } from '../_shared/core/services.ts'
 import { checkMaintenanceMode } from '../_shared/middleware/maintenance-middleware.ts'
 import { DailyVerseService } from './daily-verse-service.ts'
+import { isBibleContentEnabled } from '../_shared/services/bible-availability.ts'
 
 // Lazy singleton — created once per worker lifetime, not at module load
 let _dailyVerseService: DailyVerseService | null = null
@@ -55,6 +56,11 @@ interface DailyVerseApiResponse extends ApiSuccessResponse<DailyVerseData> {}
 async function handleDailyVerse(req: Request, services: ServiceContainer): Promise<Response> {
   // Check maintenance mode FIRST
   await checkMaintenanceMode(req, services)
+
+  // Compliance kill-switch: do not serve API.Bible content at all.
+  if (!(await isBibleContentEnabled())) {
+    throw new AppError('BIBLE_CONTENT_DISABLED', 'Bible content is currently unavailable.', 503)
+  }
 
   // Parse query parameters
   const url = new URL(req.url)

--- a/backend/supabase/functions/fetch-verse/index.ts
+++ b/backend/supabase/functions/fetch-verse/index.ts
@@ -16,6 +16,7 @@ import { ApiSuccessResponse } from '../_shared/types/index.ts'
 import { ServiceContainer } from '../_shared/core/services.ts'
 import { fetchWithTimeout } from '../_shared/services/bible-api-service.ts'
 import { checkMaintenanceMode } from '../_shared/middleware/maintenance-middleware.ts'
+import { isBibleContentEnabled, isBibleApiCallsEnabled } from '../_shared/services/bible-availability.ts'
 import { HINDI_BOOK_NAMES, MALAYALAM_BOOK_NAMES, LOCALIZED_VARIANTS_TO_ENGLISH } from '../_shared/utils/bible-book-normalizer.ts'
 
 /**
@@ -44,6 +45,7 @@ interface FetchVerseResponse extends ApiSuccessResponse<{
   verses?: VerseItem[]  // Per-verse breakdown for ranges (absent for single verses)
   translation: string
   language: string
+  fumsTokens?: string[]  // API.Bible FUMS v3 tokens to report client-side
 }> {}
 
 // Bible book name mappings to API.Bible book codes
@@ -190,6 +192,7 @@ function buildVerseUrl(bibleId: string, verseId: string): string {
     'include-titles': 'false',        // No section titles/headings
     'include-chapter-numbers': 'false', // No chapter numbers
     'include-verse-numbers': 'false', // No verse numbers
+    'fums-version': '3',              // FUMS v3 token (meta.fumsToken) for usage reporting
   })
   return `${baseUrl}?${params.toString()}`
 }
@@ -203,6 +206,15 @@ async function handleFetchVerse(
 ): Promise<Response> {
   // Check maintenance mode FIRST
   await checkMaintenanceMode(req, services)
+
+  // API.Bible kill switches. Compliance first (content blocked entirely),
+  // then operational (no fallback here, so we cannot serve at all).
+  if (!(await isBibleContentEnabled())) {
+    throw new AppError('BIBLE_CONTENT_DISABLED', 'Bible content is currently unavailable.', 503)
+  }
+  if (!(await isBibleApiCallsEnabled())) {
+    throw new AppError('BIBLE_API_DISABLED', 'Bible lookups are temporarily unavailable.', 503)
+  }
 
   // Parse and validate request body
   const body = await req.json() as FetchVerseRequest
@@ -237,6 +249,8 @@ async function handleFetchVerse(
   let verses: VerseItem[] | undefined
   let reference: string
   let localizedReference: string
+  // FUMS v3 tokens collected from each API.Bible response (reported client-side)
+  const fumsTokens: string[] = []
 
   // Check if this is a chapter-only request (verse_start: 1, verse_end: 999)
   const isChapterOnly = body.verse_start === 1 && body.verse_end === 999
@@ -255,6 +269,7 @@ async function handleFetchVerse(
       'include-titles': 'false',
       'include-chapter-numbers': 'false',
       'include-verse-numbers': 'false',
+      'fums-version': '3',
     })
 
     const response = await fetchWithTimeout(
@@ -271,6 +286,7 @@ async function handleFetchVerse(
 
     const data = await response.json()
     verseText = cleanVerseText(data.data.content)
+    if (data.meta?.fumsToken) fumsTokens.push(data.meta.fumsToken)
   } else if (body.verse_end && body.verse_end > body.verse_start) {
     // Fetch verse range
     reference = `${englishBookName} ${body.chapter}:${body.verse_start}-${body.verse_end}`
@@ -296,6 +312,7 @@ async function handleFetchVerse(
           if (response.ok) {
             const data = await response.json()
             const text = cleanVerseText(data.data.content)
+            if (data.meta?.fumsToken) fumsTokens.push(data.meta.fumsToken)
             if (text) return { number: v, text } as VerseItem
           }
           return null
@@ -339,6 +356,7 @@ async function handleFetchVerse(
 
     const data = await response.json()
     verseText = cleanVerseText(data.data.content)
+    if (data.meta?.fumsToken) fumsTokens.push(data.meta.fumsToken)
   }
 
   const responseData: FetchVerseResponse = {
@@ -350,6 +368,8 @@ async function handleFetchVerse(
       ...(verses ? { verses } : {}),
       translation: getTranslationName(body.language),
       language: body.language,
+      // API.Bible FUMS v3 tokens to be reported client-side (Fair Use Mgmt).
+      ...(fumsTokens.length ? { fumsTokens } : {}),
     }
   }
 

--- a/backend/supabase/functions/refresh-stale-memory-verses/index.ts
+++ b/backend/supabase/functions/refresh-stale-memory-verses/index.ts
@@ -1,0 +1,90 @@
+/**
+ * Refresh Stale Memory Verses - Scheduled Background Job
+ *
+ * API.Bible's terms require stored content to be refreshed at least every 30 days.
+ * memory_verses with source_type = 'daily_verse' hold API.Bible verse text, so this
+ * job re-fetches the text for any such row whose verse_text was last synced more
+ * than 30 days ago, and stamps verse_text_synced_at. manual / ai_generated rows are
+ * not API.Bible content and are left untouched.
+ *
+ * Processes a bounded batch per run; remaining rows are picked up on the next run.
+ * Schedule: daily via external scheduler / pg_cron (e.g. `0 4 * * *`).
+ */
+
+import { createServiceRoleFunction } from '../_shared/core/function-factory.ts'
+import { fetchBibleVerse } from '../_shared/services/bible-api-service.ts'
+import { isBibleApiCallsEnabled } from '../_shared/services/bible-availability.ts'
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000
+const BATCH_LIMIT = 200
+
+createServiceRoleFunction(async (_req, supabase) => {
+  if (!(await isBibleApiCallsEnabled())) {
+    console.log('[REFRESH-MEMORY-VERSES] bible_api_calls_enabled is OFF — skipping run')
+    return { success: true, skipped: true, reason: 'bible_api_calls_enabled is off', refreshed_count: 0, failed_count: 0 }
+  }
+
+  const cutoff = new Date(Date.now() - THIRTY_DAYS_MS).toISOString()
+  console.log('[REFRESH-MEMORY-VERSES] Refreshing daily_verse rows synced before', cutoff)
+
+  const { data: stale, error } = await supabase
+    .from('memory_verses')
+    .select('id, verse_reference, language')
+    .eq('source_type', 'daily_verse')
+    .lt('verse_text_synced_at', cutoff)
+    .order('verse_text_synced_at', { ascending: true })
+    .limit(BATCH_LIMIT)
+
+  if (error) {
+    console.error('[REFRESH-MEMORY-VERSES] Query failed:', error)
+    return { success: false, error: error.message, refreshed_count: 0, failed_count: 0 }
+  }
+
+  let refreshed = 0
+  let failed = 0
+
+  for (const row of stale ?? []) {
+    const language = row.language as 'en' | 'hi' | 'ml'
+    if (language !== 'en' && language !== 'hi' && language !== 'ml') {
+      failed++
+      console.warn(`[REFRESH-MEMORY-VERSES] Skipping ${row.id}: unsupported language "${row.language}"`)
+      continue
+    }
+
+    try {
+      const verse = await fetchBibleVerse(row.verse_reference, language)
+      if (!verse.text) throw new Error('empty verse text')
+
+      const { error: updateError } = await supabase
+        .from('memory_verses')
+        .update({
+          verse_text: verse.text,
+          verse_text_synced_at: new Date().toISOString(),
+        })
+        .eq('id', row.id)
+
+      if (updateError) throw updateError
+      refreshed++
+    } catch (e) {
+      // Leave the row untouched so it is retried on the next run.
+      failed++
+      console.error(
+        `[REFRESH-MEMORY-VERSES] Failed for ${row.id} (${row.verse_reference}/${language}):`,
+        e instanceof Error ? e.message : String(e)
+      )
+    }
+  }
+
+  console.log(`[REFRESH-MEMORY-VERSES] ✅ Refreshed ${refreshed}, failed ${failed}, scanned ${stale?.length ?? 0}`)
+
+  return {
+    success: true,
+    refreshed_count: refreshed,
+    failed_count: failed,
+    scanned_count: stale?.length ?? 0,
+    batch_limit: BATCH_LIMIT,
+    timestamp: new Date().toISOString(),
+  }
+}, {
+  allowedMethods: ['POST', 'GET']
+})

--- a/backend/supabase/migrations/20260617000000_api_bible_cache_30day_recency.sql
+++ b/backend/supabase/migrations/20260617000000_api_bible_cache_30day_recency.sql
@@ -1,0 +1,15 @@
+-- API.Bible content-recency compliance.
+--
+-- API.Bible Terms require any cached content to be refreshed at least every
+-- 30 days. The daily_verses_cache previously stored fetched verse text with a
+-- 6-month (bible-api-service) / 60-day (daily-verse-service) TTL, which exceeds
+-- that limit. New writes now use a 30-day TTL in code; this migration brings
+-- EXISTING rows into compliance.
+--
+-- Cap each row's expiry to (created_at + 30 days):
+--   * rows cached >30 days ago  -> expires_at moves into the past -> treated as
+--     a cache miss on next read -> regenerated and re-fetched fresh.
+--   * rows cached <30 days ago  -> expiry capped to 30 days from when cached.
+UPDATE daily_verses_cache
+SET expires_at = LEAST(expires_at, created_at + INTERVAL '30 days')
+WHERE expires_at > created_at + INTERVAL '30 days';

--- a/backend/supabase/migrations/20260617000001_memory_verse_text_sync_tracking.sql
+++ b/backend/supabase/migrations/20260617000001_memory_verse_text_sync_tracking.sql
@@ -1,0 +1,22 @@
+-- API.Bible content-recency compliance for memory_verses.
+--
+-- memory_verses sourced from the daily verse (source_type = 'daily_verse') store
+-- API.Bible verse text indefinitely. API.Bible's terms require stored content to
+-- be refreshed at least every 30 days. Track when each row's verse_text was last
+-- synced from API.Bible so a scheduled job (refresh-stale-memory-verses) can
+-- re-fetch rows older than 30 days.
+--
+-- manual / ai_generated rows are NOT API.Bible content and are never refreshed.
+
+ALTER TABLE memory_verses
+  ADD COLUMN IF NOT EXISTS verse_text_synced_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+-- Baseline existing rows to their last-updated time. Rows already older than
+-- 30 days become immediately eligible for refresh on the next job run.
+UPDATE memory_verses
+SET verse_text_synced_at = COALESCE(updated_at, created_at);
+
+-- Efficiently locate API.Bible-sourced rows that need refreshing.
+CREATE INDEX IF NOT EXISTS idx_memory_verses_stale_text
+  ON memory_verses (verse_text_synced_at)
+  WHERE source_type = 'daily_verse';

--- a/backend/supabase/migrations/20260617000002_schedule_recency_jobs.sql
+++ b/backend/supabase/migrations/20260617000002_schedule_recency_jobs.sql
@@ -1,0 +1,57 @@
+-- Schedule API.Bible content-recency background jobs via pg_cron (Supabase backend).
+--
+-- Two jobs:
+--   1. cleanup-expired-verse-cache  — keyless pure-SQL DELETE of expired cache rows.
+--   2. refresh-stale-memory-verses  — HTTP call (pg_net) to the edge function that
+--      re-fetches API.Bible text for daily_verse memory rows older than 30 days.
+--
+-- Guarded so a missing extension (e.g. on a local `supabase db reset`) only raises a
+-- NOTICE instead of failing the migration. No secrets are committed: job 2 reads the
+-- project URL and service-role key from Vault at run time, so those two secrets must
+-- exist for it to fire:
+--   select vault.create_secret('https://<PROJECT_REF>.supabase.co', 'project_url');
+--   select vault.create_secret('<SERVICE_ROLE_KEY>', 'service_role_key');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    RAISE NOTICE 'pg_cron not installed; skipping recency cron scheduling. Enable pg_cron, then re-run this migration.';
+    RETURN;
+  END IF;
+
+  -- Job 1: delete expired daily_verses_cache rows daily at 03:00 UTC (keyless).
+  PERFORM cron.schedule(
+    'cleanup-expired-verse-cache',
+    '0 3 * * *',
+    $job$DELETE FROM daily_verses_cache WHERE expires_at < now()$job$
+  );
+  RAISE NOTICE 'Scheduled cron job: cleanup-expired-verse-cache';
+
+  -- Job 2: refresh stale memory_verses daily at 04:00 UTC (needs pg_net + Vault secrets).
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_net') THEN
+    PERFORM cron.schedule(
+      'refresh-stale-memory-verses',
+      '0 4 * * *',
+      $job$
+      SELECT net.http_post(
+        url := (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'project_url')
+               || '/functions/v1/refresh-stale-memory-verses',
+        headers := jsonb_build_object(
+          'Content-Type', 'application/json',
+          'Authorization', 'Bearer ' ||
+            (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'service_role_key')
+        ),
+        body := '{}'::jsonb
+      );
+      $job$
+    );
+    RAISE NOTICE 'Scheduled cron job: refresh-stale-memory-verses (requires Vault secrets project_url + service_role_key)';
+  ELSE
+    RAISE NOTICE 'pg_net not installed; skipping refresh-stale-memory-verses schedule. Enable pg_net and re-run.';
+  END IF;
+END
+$$;
+
+-- To remove:
+--   SELECT cron.unschedule('cleanup-expired-verse-cache');
+--   SELECT cron.unschedule('refresh-stale-memory-verses');

--- a/backend/supabase/migrations/20260618000000_bible_api_kill_switches.sql
+++ b/backend/supabase/migrations/20260618000000_bible_api_kill_switches.sql
@@ -1,0 +1,44 @@
+-- Bible-API admin kill switches + purge function.
+-- Two kill-switch feature flags (default enabled) and an atomic purge routine
+-- for removing cached API.Bible content at rest (compliance).
+
+INSERT INTO public.feature_flags
+  (feature_key, feature_name, description, is_enabled, display_mode, enabled_for_plans, rollout_percentage, metadata)
+VALUES
+  ('bible_api_calls_enabled', 'Bible API — calls',
+   'Operational switch. When OFF, the backend makes no new calls to API.Bible (serves cache + fallbacks).',
+   true, 'hide', ARRAY['free','standard','plus','premium'], 100,
+   '{"category":"kill_switches","critical":true}'::jsonb),
+  ('bible_content_enabled', 'Bible API — content',
+   'Compliance kill-switch. When OFF, API.Bible content is not served or shown (hides verse surfaces, blocks endpoints).',
+   true, 'hide', ARRAY['free','standard','plus','premium'], 100,
+   '{"category":"kill_switches","critical":true}'::jsonb)
+ON CONFLICT (feature_key) DO NOTHING;
+
+-- Atomic purge of cached API.Bible content at rest.
+CREATE OR REPLACE FUNCTION public.purge_bible_content()
+RETURNS TABLE(deleted_cache_rows integer, blanked_memory_verses integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted integer;
+  v_blanked integer;
+BEGIN
+  DELETE FROM daily_verses_cache;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  UPDATE memory_verses
+  SET verse_text = '',
+      verse_text_synced_at = 'epoch'::timestamptz,
+      updated_at = now()
+  WHERE source_type = 'daily_verse' AND verse_text <> '';
+  GET DIAGNOSTICS v_blanked = ROW_COUNT;
+
+  RETURN QUERY SELECT v_deleted, v_blanked;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.purge_bible_content() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.purge_bible_content() TO service_role;

--- a/docs/plans/App_Wide_RAG_Strategy.md
+++ b/docs/plans/App_Wide_RAG_Strategy.md
@@ -1,0 +1,205 @@
+# App-Wide RAG Strategy
+
+**Status:** Proposed
+**Owner:** TBD
+**Last updated:** 2026-06-17
+**Companion to:** `docs/plans/Voice_Discipler_RAG_Enhancement_Plan.md`
+**Related:** `docs/internal/LLM_Development_Guide.md`, `docs/architecture/Data Model.md`
+
+---
+
+## 1. Purpose
+
+This document looks beyond Voice Discipler and asks: **where else in Disciplefy is Retrieval-Augmented Generation (RAG) worth it?** It inventories every LLM/content surface, identifies a **shared retrieval substrate** that amortizes across multiple features, and ranks each surface as a RAG candidate with explicit decision gates.
+
+Voice Discipler has its own detailed phase plan (companion doc). This doc is the umbrella: it shows that the substrate built for Voice should be reused, not rebuilt, for the other strong candidates.
+
+---
+
+## 2. Key finding
+
+**Disciplefy is generation-heavy and retrieval-light.** Multiple features call the LLM but inject almost no grounding, and several let the model **invent scripture from memory** — a direct credibility risk for a Bible app.
+
+Two facts reframe the whole question:
+
+1. **No retrieval infra exists yet.** No `pgvector`, no embeddings; search is hash-based cache lookup only. Building the substrate is a one-time cost.
+2. **The substrate is a shared asset.** The two expensive pieces — a **curated theological KB** and a **verse-text retrieval/validation layer** — are reusable across at least 3–4 surfaces. This changes the ROI: a KB that's marginal for Voice *alone* clears the bar once Voice + Study Followup + Deep/Sermon generation all use it.
+
+> **Reframe:** The question isn't "where else do we add RAG?" It's "build the retrieval substrate once, then light up each surface."
+
+---
+
+## 3. LLM / content surface inventory
+
+| Feature | LLM-driven? | Current grounding | RAG candidate | Notes |
+|---|---|---|---|---|
+| **Study Followup** (`study-followup`) | ✅ | Study guide + last 10 msgs; no external retrieval | **STRONG** | Text twin of Voice Discipler |
+| **Study Generation — Deep/Sermon** (`study-generate-v2`) | ✅ | User input + mode only; invents related verses | **STRONG** | Long-form, scholarly; latency-tolerant |
+| **Study Generation — Standard/Lectio/Quick** | ✅ | Same | Weak | Don't need scholarly depth |
+| **Admin Study Generator** (`admin-study-generator`) | ✅ | Same as v2 | **STRONG** | Library seeding; quality matters most |
+| **Daily Verse** (`daily-verse`) | ✅ | Recent-30-day DB exclusion; LLM *selects* verse | **Not RAG** | Fix selection with curated pool, not embeddings |
+| **Voice Discipler** (`voice-conversation`) | ✅ | Study guide + profile + last 10 msgs | **STRONG** | See companion doc |
+| Memory Verses (`*-memory-*`) | ❌ | SM-2 algorithm | Weak/future | Optional struggle hints only |
+| Fellowship posts/comments | ❌ | User content | Weak/future | Thread summarization someday |
+| Learning Paths / Continue Learning | ❌ | Curated DB | N/A | Recommender, not RAG |
+| Recommended Topics / Suggested Verses | ❌ | Curated DB | N/A | Pure serving |
+| Fetch Verse | ❌ | API.Bible direct | N/A | Already retrieval |
+
+**Corpora that exist to retrieve against:** `study_guides`, `recommended_topics` (+ translations), `suggested_verses` (+ translations), `learning_paths`, `conversation_messages`, `memory_verses`, fellowship content. **Missing:** any commentary/confession corpus, and full Bible verse text at rest.
+
+**Vector status:** ❌ no `pgvector`, ❌ no embeddings anywhere. Text search = GIN indexes (some commented out) + hash cache.
+
+---
+
+## 4. The shared retrieval substrate
+
+Build these **once**; every strong candidate consumes them. Mirrors the architecture in the Voice plan §4.
+
+### 4.1 Verse-text retrieval & validation
+- Deterministic lookup of real verse text in the user's translation (ESV `en` / IRV `hi` / POC `ml`) via the existing `fetch-verse` path + `bible-book-normalizer.ts`.
+- Two jobs: (a) **inject** verse text where the model should quote; (b) **validate** LLM-emitted references (`passage`, `related_verses`) against the real Bible and drop/flag invented ones.
+- **Not really RAG** — no embeddings. Highest trust-per-effort. Reuses code that already exists.
+
+### 4.2 Curated theological KB (the real RAG part)
+- `pgvector` store of **theologically reviewed** chunks: confessions/catechisms (public domain), filtered public-domain commentaries, your own approved material.
+- Embeddings: see §4.5 for the encoder decision. ⚠️ Whatever the provider, embeddings depend on an external API → cache corpus embeddings, embed only the live query, **fail open** to no-retrieval on embedding error.
+- Every source **human/doctrinally reviewed before ingestion** (use the `paul-the-apostle` agent + reviewer). This is the non-skippable cost.
+
+### 4.3 Per-user memory (narrower reuse)
+- Semantic recall of a user's own `study_guides` + past `conversation_messages` / voice messages, filtered by `user_id` (RLS-enforced).
+- Reused only by Voice + Study Followup. Retention-gated.
+
+### 4.4 Cross-cutting rules (per `LLM_Development_Guide.md`)
+- Sanitize queries before embedding (`security-validator.ts`).
+- Never log raw input, chunks, or embeddings — metadata only.
+- Retrieved grounding never overrides the 5-Solas system-prompt framework; the KB is curated to align, the prompt is the backstop.
+- Respect cost ceilings ($15/day, $100/month) via existing cost-tracking.
+
+### 4.5 Encoder & vector store decision (docs-backed)
+
+**Vector store — settled: Supabase `pgvector` + HNSW index, cosine distance.**
+- Supabase explicitly recommends HNSW as the default (built on empty tables, recall stays stable as data grows; IVFFlat degrades on distribution shift and needs rebuilds). [[Supabase HNSW](https://supabase.com/docs/guides/ai/vector-indexes/hnsw-indexes)]
+- Use `vector_cosine_ops` (`<=>`) — candidate encoders output unit-normalized vectors.
+- **Hard limit:** the `vector` index caps at 2,000 dims (`halfvec` → 4,000). Keep embeddings ≤1,536. (Rules out OpenAI `3-large` at its 3,072 default unless down-projected.)
+- No new infra — it's already the database. Optionally use Supabase "automatic embeddings" (triggers + pgmq + pg_cron + pg_net) to keep vectors fresh on content change.
+
+**Encoder — recommended: Cohere `embed-v4.0`; self-host `bge-m3` as the no-API-cost alternative.**
+
+The deciding factor is **Malayalam** (low-resource Indic). Only two candidates confirm it in official docs:
+
+| Model | Malayalam | Max tok | Dims | Hosting | Text price |
+|---|---|---|---|---|---|
+| **Cohere `embed-v4.0`** (recommended) | "100+ langs" (v3.0 lists `ml` explicitly) | 128k | 256/512/1024/1536 | Managed API | **$0.12 / 1M** |
+| Cohere `embed-multilingual-v3.0` | ✅ `ml` listed explicitly | 512 | 1024 | Managed API | ~$0.10 / 1M |
+| **BAAI `bge-m3`** (self-host alt) | ✅ maintainer-confirmed | 8,192 | 1024 | Self-host (GPU) | $0 / token |
+| OpenAI `3-small` | ❌ unconfirmed | 8,192 | 1536 | Managed | $0.02 / 1M |
+
+- **Do not default to OpenAI** despite it being our LLM provider: its docs publish no language list and never name Malayalam/Hindi/Indic. For a Malayalam-core Bible app that's an unverified quality bet. Only use it if a Malayalam eval proves acceptable recall.
+- `bge-m3` is the strongest technical fit (8k tokens, hybrid dense+sparse+ColBERT, free) but **cannot run in Supabase Edge Functions** (Deno, no GPU) — it needs a separate GPU inference service. Choose only if willing to run inference.
+- Sources: [Cohere supported-languages (`ml`)](https://github.com/cohere-ai/cohere-developer-experience/blob/main/fern/pages/text-embeddings/multilingual-language-models/supported-languages.mdx), [Embed v4.0 specs/price](https://vercel.com/ai-gateway/models/embed-v4.0), [bge-m3 maintainer confirmation](https://huggingface.co/BAAI/bge-m3/discussions/29), [OpenAI embeddings](https://developers.openai.com/api/docs/guides/embeddings).
+
+**Non-negotiables:**
+1. **Run a Malayalam retrieval eval before locking in.** Stated coverage ≠ proven quality. Embed ~30 Malayalam query/passage pairs, measure recall@5 across the top 2 candidates, decide on evidence.
+2. **Keep the encoder swappable.** Store `model_name` + `dimensions` with every vector (dims differ 1024 vs 1536 → a switch means re-embedding). Hide it behind the `RetrievalService`.
+
+### 4.6 Cost model (Cohere `embed-v4.0`, $0.12 / 1M text tokens)
+
+The encoder bill is **negligible** — a quality decision, not a cost one. Image/output tokens are unused.
+
+**One-time ingestion:**
+
+| Corpus | ~Tokens | Cost |
+|---|---|---|
+| Curated KB (confessions + commentaries) | ~5M | ~$0.60 |
+| All study guides (~10k × ~1.5k tok) | ~15M | ~$1.80 |
+| Full Bible × 3 translations (Phase D only) | ~2–3M | ~$0.30 |
+| Re-embed everything once | ~25M | ~$3 |
+
+**Ongoing query embedding** (~50–100 tok/query):
+
+| Queries/mo | Tokens | Cost/mo |
+|---|---|---|
+| 10k | ~1M | $0.12 |
+| 100k | ~10M | $1.20 |
+| 1M | ~100M | $12 |
+
+**Bottom line:** realistically **< $5/mo** + a few dollars one-time until ~1M queries/mo — well inside the $15/day / $100/month ceilings. The real costs are human KB review and ingestion ops, not embeddings. (Cohere also offers dedicated instances at ~$2,500–3,250/mo — ignore unless very high sustained throughput or data-residency SLAs are needed. The $0.12/1M serverless rate differs if routed via Bedrock/Azure — re-verify there.)
+
+---
+
+## 5. Per-surface phases
+
+Ordered by ROI. Each phase is independently shippable and evidence-gated.
+
+### Phase A — Verse grounding & validation (cross-cutting, ship first)
+**Substrate:** §4.1 only. No vector store.
+- **A1.** Voice Discipler verse-text injection (= Voice plan Phase 1).
+- **A2.** Study-generation **reference validation**: verify LLM-emitted `passage`/`related_verses` against real verse text; drop or correct invented references before saving to `study_guides`.
+- **A3.** Study Followup verse-text injection.
+
+**Why first:** Kills the single worst failure mode app-wide — a Bible app citing scripture that doesn't say what the model claims. Low effort, reuses `fetch-verse` + normalizer. **No decision gate — ship it.**
+
+**Metric:** sampled misquote / invented-reference rate → ~0; added latency < 80 ms p95 on live paths.
+
+---
+
+### Phase B — Curated KB grounding (gated, high reuse)
+**Substrate:** §4.2.
+- **B1.** Stand up `pgvector` + KB ingestion + reviewed corpus.
+- **B2.** Wire KB retrieval into **Study Followup** (closest twin to Voice; highest reuse).
+- **B3.** Wire KB retrieval into **Study Generation Deep + Sermon** (and **Admin generator**) — inject commentary / historical background / real cross-references; latency-tolerant since cache-backed.
+- **B4.** Wire KB retrieval into **Voice Discipler** (= Voice plan Phase 2a).
+
+**Effort:** Medium–High (ingestion, ongoing doctrinal review, eval harness). The KB is permanent operational surface.
+
+**Decision gate (measure before building):**
+- Pull ≥ 50 real transcripts/guides across Study Followup + Deep/Sermon output. Count actual doctrinal/accuracy errors and weak/invented content the prompt failed to prevent.
+- If the rate is materially non-zero across surfaces → build (cost amortizes over 3–4 surfaces, so the bar is lower than for Voice alone).
+- If the prompt already holds everywhere → defer.
+
+**Metric:** doctrinal-error + invented-content rate ↓; sermon-application quality ↑ (human-rated); latency budget held on live paths.
+
+---
+
+### Phase C — Per-user memory (gated, narrow reuse)
+**Substrate:** §4.3. Applies to Voice (Voice plan Phase 2b) + Study Followup only.
+
+**Decision gate:** median studies-per-user and conversation length high enough that semantic recall has real content. If users have little history → defer to retention stage.
+
+---
+
+### Phase D — Topical semantic Bible search (lowest ROI, gated)
+Embed the Bible per translation; semantic verse search for open-ended questions. Benefits Voice + Study Followup + topical study generation. Most of the value is already reachable via Phase A (LLM names passages → fetch text). **Defer** until transcripts show meaningful volume of poorly-handled topical questions. (= Voice plan Phase 3.)
+
+---
+
+## 6. Explicitly NOT RAG (fix differently or skip)
+
+- **Daily Verse** — the bug is "LLM *selects* a verse and can hallucinate." Fix = retrieve from a **curated, themed verse pool with rotation** (deterministic). No embeddings. Treat as a correctness fix, not a RAG project. Can reuse `suggested_verses` with seasonal/thematic tags.
+- **Learning-path / topic recommendations** — embeddings could power "similar topic" suggestions, but that's a **recommender**, premature; out of scope here.
+- **Memory-verse hints / fellowship thread summarization** — speculative future LLM features, not retrieval problems.
+- **Topics, Suggested Verses, Fetch Verse, Learning Paths, Fellowship serving** — no LLM; pure curated-DB/API. N/A.
+
+---
+
+## 7. Recommendation summary
+
+| Phase | Scope | Worth it? | Gate |
+|---|---|---|---|
+| **A** Verse grounding/validation | Voice, Study Followup, Study Gen | **Yes — ship now** | None |
+| **B** Curated KB | Study Followup, Deep/Sermon, Admin, Voice | **Likely yes** (amortized over 3–4 surfaces) | Measure error rate on ≥50 samples |
+| **C** Per-user memory | Voice, Study Followup | Retention-gated | Measure history-per-user |
+| **D** Topical Bible search | Voice, Study Followup, Study Gen | Lowest ROI; defer | Evidence of topical-question gaps |
+| — Daily Verse fix | Daily Verse | Yes, but **not RAG** | None |
+
+**Bottom line:** Build the substrate once; reuse everywhere. Phase A is unconditional and app-wide. Phase B's economics are *better* than the Voice-only doc implies because the KB serves Study Followup + Deep/Sermon generation too — but it's still gated on measuring the real error rate. Everything else is either narrow (C), low-ROI (D), or not actually a RAG problem (Daily Verse, recommendations).
+
+---
+
+## 8. Open questions
+
+- What is the measured doctrinal-error / invented-reference rate **today** across study generation + followup? (Blocks Phase B.)
+- Licensing: which translations can we store full verse text at rest vs. fetch-on-demand?
+- Who owns ongoing theological review of the KB corpus?
+- Do we embed per-language separately or adopt a multilingual embedding model?
+- Should reference *validation* (Phase A2) hard-block saving an invented reference, or flag-and-correct?

--- a/docs/plans/Voice_Discipler_RAG_Enhancement_Plan.md
+++ b/docs/plans/Voice_Discipler_RAG_Enhancement_Plan.md
@@ -1,0 +1,240 @@
+# Voice Discipler — RAG Enhancement Plan
+
+**Status:** Proposed
+**Owner:** TBD
+**Last updated:** 2026-06-17
+**Related:** `docs/specs/AI_Study_Buddy_Voice_Specification.md`, `docs/internal/LLM_Development_Guide.md`
+
+---
+
+## 1. Purpose
+
+Voice Discipler is a voice-based conversational Bible-discipleship feature (STT → LLM → TTS, streamed over SSE, EN/HI/ML, 5-Solas-constrained). This document specifies how Retrieval-Augmented Generation (RAG) can improve answer accuracy, theological grounding, and personalization — **and where it is *not* worth it.**
+
+This is a phased plan. Each phase is independently shippable and gated by evidence. Do **not** treat "add RAG" as one project; the value is highly uneven across phases.
+
+---
+
+## 2. Current state (baseline)
+
+Today the feature does **context injection, not retrieval**. It stuffs fixed context into the system prompt with no semantic search:
+
+| Context source | Where | Notes |
+|---|---|---|
+| Linked study guide | `voice-conversation-repository.ts` → `getStudyContext()` | Only when `related_study_guide_id` is set |
+| User profile (interests, maturity) | `getUserContext()` | Static, coarse |
+| Last ~10 messages of *current* conversation | `getConversationHistory()` | No cross-session recall |
+| `related_scripture` | conversation row | Reference string, not verse text |
+
+Key gaps:
+
+- **Scripture references are extracted but verse text is never fed back to the model** (`BibleBookNormalizer.extractScriptureReferences()` in `voice-conversation/index.ts`). The model quotes from memory → misquote risk.
+- **No retrieval over the user's own past studies/conversations** — data is stored but never semantically recalled.
+- **No vetted theological corpus** — orthodoxy relies entirely on the system prompt holding.
+
+### Relevant files
+
+**Backend**
+- `backend/supabase/functions/voice-conversation/index.ts` — SSE handler, quota, normalization
+- `backend/supabase/functions/_shared/services/voice-streaming-service.ts` — LLM streaming (OpenAI primary `gpt-4.1-mini` / `gpt-4o-mini`; Anthropic fallback `claude-haiku-4-5`)
+- `backend/supabase/functions/_shared/repositories/voice-conversation-repository.ts` — context assembly + persistence
+- `backend/supabase/functions/_shared/prompts/voice-conversation-prompts.ts` — multi-language system prompts with `{{maturity_level}}`, `{{current_study}}`, `{{recent_topics}}` slots
+- `backend/supabase/functions/_shared/utils/bible-book-normalizer.ts` — reference extraction/normalization
+- `backend/supabase/migrations/20260119000500_voice_system.sql` — voice schema
+
+**Frontend** (no changes required for any phase — retrieval is server-side)
+- `frontend/lib/features/voice_buddy/`
+
+---
+
+## 3. Goals / Non-goals
+
+### Goals
+- Eliminate scripture misquotes by grounding in real verse text.
+- Strengthen doctrinal safety with retrievable, vetted grounding (defense-in-depth over the prompt).
+- Enable cross-session personalized discipleship ("last week you studied grace…").
+- Preserve voice latency and the 2–4 sentence / 50–80 word response shape.
+
+### Non-goals
+- Replacing the system-prompt theological framework (RAG augments, never overrides the 5-Solas constraints).
+- Long, essay-style answers. Retrieved context informs short spoken replies; it is not read aloud verbatim.
+- Frontend/UX changes. STT/TTS, BLoC, and pages are unaffected.
+
+---
+
+## 4. Shared architecture
+
+All phases reuse one retrieval substrate. Infra already exists — **Supabase ships `pgvector`**.
+
+### 4.1 Components
+
+1. **Embedding provider.** OpenAI `text-embedding-3-small` (1536-dim) — cheap, fast, already an OpenAI shop.
+   - ⚠️ **Provider coupling:** Anthropic has no embeddings API, so the Claude fallback path cannot embed. Retrieval depends on OpenAI being reachable. Mitigation: cache all corpus embeddings; only the live query embeds per turn; on OpenAI embedding failure, **degrade gracefully to no-retrieval** (today's behavior) rather than erroring.
+   - Alternative if provider parity matters later: Voyage AI (`voyage-3`).
+
+2. **Vector store.** `pgvector` tables in Supabase with HNSW or IVFFlat indexes. One logical store, multiple source types (verses, KB chunks, study guides, conversation messages).
+
+3. **Retrieval hook.** A single `RetrievalService` invoked in `voice-streaming-service.ts` **before** the LLM call. It embeds the user's transcribed message, runs per-source ANN search, assembles a compact `{{retrieved_context}}` block, and injects it into the existing prompt template.
+
+4. **Ingestion pipelines.** Offline/background jobs (service-role Edge Functions or scripts) that chunk + embed source content and upsert vectors. Re-embed on content change.
+
+### 4.2 Prompt integration
+
+Add one new slot to each language template in `voice-conversation-prompts.ts`:
+
+```
+RETRIEVED GROUNDING (use only if relevant; never read verbatim; cite full canonical book names):
+{{retrieved_context}}
+```
+
+Rules baked into the prompt:
+- Retrieved text is **grounding, not script** — synthesize, stay at 50–80 words.
+- If retrieved grounding conflicts with the 5-Solas framework, the framework wins (the KB is curated to align, so this is a backstop).
+- Never expose raw chunks, sources, or that retrieval happened.
+
+### 4.3 Latency budget
+
+Voice is latency-sensitive (streamed, turn-taking). Target retrieval overhead **< 150 ms p95**.
+
+- Run query-embed + ANN search **in parallel** with existing per-turn work (quota check, normalization setup).
+- `top_k` small: **3–5 chunks total** across sources. Answers are 50–80 words; more context just adds latency and dilution.
+- Cache corpus embeddings; never re-embed static content per turn.
+- **Gate retrieval**: skip for chit-chat/greetings (cheap heuristic or classifier) so only substantive turns pay the cost.
+- Fail open: retrieval error/timeout → proceed with no retrieval (never block the response).
+
+### 4.4 Security & LLM rules (per `LLM_Development_Guide.md`)
+
+- Sanitize the query before embedding (reuse `security-validator.ts`).
+- Never log raw user input, raw chunks, or embeddings — metadata only.
+- Curated KB content must be theologically reviewed before ingestion (see Phase 2).
+- Retrieval must not leak another user's data — per-user sources filter by `user_id` in SQL, enforced by RLS.
+
+---
+
+## 5. Phases
+
+> Phases are ordered by ROI. Each has an explicit **decision gate** — do not start a phase until its gate passes.
+
+### Phase 1 — Verse-text grounding (ship first, unconditionally)
+
+**Problem:** A *Bible* app whose voice mentor misquotes the Bible. The model cites references from memory.
+
+**This is barely RAG** — no vector store, no embeddings. It's deterministic lookup. Listed as Phase 1 because it delivers most of the trust win for the least cost and de-risks the prompt-integration plumbing the later phases reuse.
+
+**Approach:**
+1. After the user message arrives (and/or after the model drafts a reply), extract candidate references with the existing `BibleBookNormalizer.extractScriptureReferences()`.
+2. For passages in play, fetch **actual verse text** in the user's translation (ESV `en`, IRV `hi`, POC `ml`) via the existing verse-fetch path (`fetch-verse` / bible-api service).
+3. Optionally add a small static **cross-reference table** (e.g., Treasury of Scripture Knowledge subset) to pull 1–2 related passages.
+4. Inject verse text into `{{retrieved_context}}`.
+
+**Effort:** Low (days). Reuses extraction + verse fetch already in the codebase.
+
+**Risks:** Reference extraction recall; verse-fetch latency (cache hot verses). Both bounded.
+
+**Decision gate:** None — ship it. The failure mode it fixes (misquoting scripture) is unacceptable for this product regardless of metrics.
+
+**Success metric:** Misquote rate (sampled transcripts) drops to ~0 for cited passages; added latency < 80 ms p95.
+
+---
+
+### Phase 2 — Curated theological KB + per-user memory (gated)
+
+Two retrieval sources that *are* real RAG. Bundled because they share ingestion + retrieval plumbing, but each is independently gated.
+
+#### 2a. Curated theological knowledge base
+
+**Problem it solves:** Doctrinal drift. The product's moat is "theologically safe." A vetted, retrievable corpus is the most durable guardrail — defense-in-depth beyond the prompt.
+
+**Corpus (must be theologically reviewed before ingestion):**
+- Reformed/evangelical confessions & catechisms (e.g., Westminster, Heidelberg) — public domain.
+- Trusted public-domain commentaries, filtered for orthodoxy.
+- Your own approved study material.
+
+**Pipeline:**
+1. Curate + **human theological review** of every source (use the `paul-the-apostle` doctrinal-review agent / human reviewer). This is the expensive, non-skippable step.
+2. Chunk (~200–400 tokens, semantic boundaries), embed, upsert to `kb_chunks` vector table with `source`, `tradition`, `tags`.
+3. At query time, retrieve top 2–3 KB chunks; inject as grounding.
+
+#### 2b. Per-user past studies & conversations
+
+**Problem it solves:** Real personalized discipleship — the feature's premise. Recall the user's own `study_guides` and past `voice_conversation_messages` semantically, beyond the current conversation's last 10 turns.
+
+**Pipeline:**
+1. Backfill-embed existing `study_guides` (summary/context/interpretation) and assistant/user messages per user.
+2. On new study-guide creation and conversation message save, embed + upsert (hook into existing save paths).
+3. At query time, ANN search filtered by `user_id` (RLS-enforced); retrieve top 1–2.
+
+**Effort:** Medium–High. Ingestion pipelines, re-embedding, eval harness, corpus maintenance. **Not a weekend.**
+
+**Risks:**
+- KB orthodoxy review is ongoing labor.
+- Per-user value scales with how much history a user has — thin for new/low-engagement users.
+- Vector store becomes permanent operational surface (re-embedding, index tuning, cost).
+
+**Decision gate (both must be measured first):**
+- **KB (2a):** Pull ≥ 50 real transcripts; count actual doctrinal/accuracy errors the prompt failed to prevent. If the rate is materially non-zero → build. If the prompt already holds → **defer**; you'd be insuring against a problem you don't have.
+- **Memory (2b):** Measure median studies-per-user and conversation length. If most users have little history, recall retrieves thin gruel → **defer to retention stage.**
+
+**Success metrics:** Doctrinal-error rate ↓ (2a); user-reported "it remembered / felt personal" + retention lift (2b); latency budget still met.
+
+---
+
+### Phase 3 — Topical semantic Bible search (lowest ROI, gated)
+
+**Problem it solves:** Open-ended spoken questions ("what does the Bible say about anxiety?") where wording ≠ verse wording, so keyword/reference matching fails.
+
+**Approach:**
+1. Embed the whole Bible (per translation) into `verse_embeddings`.
+2. At query time, detect topical/open questions; semantic-search verses; retrieve top 3–5; inject text (overlaps Phase 1 injection).
+
+**Effort:** Medium (embed full Bible × 3 translations; tune retrieval quality; detect when to trigger).
+
+**Why last:** A large share of the value is already reachable by letting the LLM name passages + Phase 1 fetching their text. The marginal lift over Phases 1–2 is small relative to cost.
+
+**Decision gate:** Only after Phases 1–2 are live and transcripts show a meaningful volume of open-ended topical questions that current handling answers poorly.
+
+**Success metric:** Improved answer relevance on a labeled set of topical questions vs. the Phase 1 baseline.
+
+---
+
+## 6. Cross-cutting concerns
+
+### 6.1 Cost
+- Query embeddings: one small embedding per substantive turn — negligible.
+- Corpus embeddings: one-time + on-change. Bible ×3 + KB is bounded; per-user grows with usage.
+- Track under existing cost-tracking service; respect the $15/day, $100/month ceilings.
+
+### 6.2 Evaluation (build before Phase 2)
+- A **golden transcript set** with labeled expected behavior (correct citation, orthodox answer, relevant recall).
+- Offline retrieval eval: recall@k, citation accuracy.
+- Online: doctrinal-error rate (sampled), misquote rate, latency p50/p95, helpfulness rating (already captured in `voice_conversations.was_helpful`/`rating`).
+
+### 6.3 Failure modes / graceful degradation
+- Embedding API down → no-retrieval fallback (today's behavior).
+- Retrieval timeout (> budget) → proceed without it.
+- Empty/low-similarity results → inject nothing; never force irrelevant context.
+
+### 6.4 Multi-language
+- Embed and retrieve per language where possible (EN/HI/ML). KB may be English-primary initially; verses use the per-language translation. Avoid cross-language retrieval that injects English chunks into a Malayalam reply unless translated.
+
+---
+
+## 7. Recommendation summary
+
+| Phase | What | Worth it? | Gate |
+|---|---|---|---|
+| 1 | Verse-text grounding | **Yes — ship now** | None |
+| 2a | Curated theological KB | **Only if** transcripts show real doctrinal errors | Measure error rate on ≥50 transcripts |
+| 2b | Per-user studies/convo recall | **Only if** users have enough history | Measure studies-per-user, convo length |
+| 3 | Topical semantic Bible search | Lowest ROI; defer | After 1–2 + evidence of topical-question gaps |
+
+**Bottom line:** RAG is worth it in slices, not as a monolith. Phase 1 is unconditional. Phases 2–3 are evidence-gated — without the transcript and engagement data, full RAG risks being a solution waiting for a problem. The current ceiling on Voice Discipler's value may be STT/TTS quality, latency, and the free-tier offering 0 conversations more than retrieval grounding; weigh RAG against those.
+
+---
+
+## 8. Open questions
+
+- Which translations/editions are licensing-clear for storing full verse text at rest (vs. fetch-on-demand)?
+- Who owns ongoing theological review of the KB corpus?
+- Do we embed per-language separately or use a multilingual embedding model?
+- What's the actual measured doctrinal-error rate today? (Blocks the Phase 2a decision.)

--- a/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/frontend/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -77,9 +77,6 @@
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">
       </LocationScenarioReference>
-      <StoreKitConfigurationFileReference
-         identifier = "../Disciplefy.storekit">
-      </StoreKitConfigurationFileReference>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Profile"

--- a/frontend/lib/core/constants/bible_translation_citation.dart
+++ b/frontend/lib/core/constants/bible_translation_citation.dart
@@ -1,0 +1,12 @@
+/// API.Bible in-context citation helper.
+///
+/// Returns the translation abbreviation to show next to a verse reference:
+/// English = King James Version (KJV); Hindi/Malayalam = Indian Revised Version
+/// (IRV). Returns an empty string for unknown languages so callers can omit the
+/// citation. Full copyright notices live in the Bible Attribution screen.
+String bibleTranslationAbbr(String languageCode) {
+  final code = languageCode.toLowerCase();
+  if (code.startsWith('en')) return 'KJV';
+  if (code.startsWith('hi') || code.startsWith('ml')) return 'IRV';
+  return '';
+}

--- a/frontend/lib/core/i18n/app_translations.dart
+++ b/frontend/lib/core/i18n/app_translations.dart
@@ -1215,6 +1215,8 @@ class AppTranslations {
       'upgrade_button': 'Upgrade to Premium',
       'terms_agree':
           'By subscribing, you agree to our Terms of Service and Privacy Policy',
+      'terms_of_use': 'Terms of Use (EULA)',
+      'privacy_policy': 'Privacy Policy',
       'secure_payment': 'Secure payment via Razorpay',
       'subscription_created':
           'Subscription created! Opening payment authorization...',
@@ -1584,7 +1586,7 @@ class AppTranslations {
       'word_bank': 'Word Bank',
       'word_bank_desc': 'Tap words in the correct order to build the verse',
       'audio': 'Audio Practice',
-      'audio_desc': 'Listen and repeat with text-to-speech',
+      'audio_desc': 'Read the verse, then recite it aloud',
       'type_it_out': 'Type It Out',
       'type_it_out_desc': 'Type the entire verse from memory',
     },
@@ -1629,6 +1631,7 @@ class AppTranslations {
       'copied': 'Verse copied to clipboard',
       'could_not_load': 'Could not load verse text',
       'could_not_parse': 'Could not parse reference',
+      'content_unavailable': 'Bible content is temporarily unavailable.',
       'added_to_memory': 'Added to Memory Verses',
       'failed_to_add': 'Failed to add verse',
     },
@@ -1730,6 +1733,7 @@ class AppTranslations {
     // Audio Practice (Short Keys)
     'audio': {
       'listen_carefully': 'Listen carefully to the verse',
+      'read_carefully': 'Read and memorize the verse',
       'played': 'Played',
       'times': 'times',
       'time': 'time',
@@ -3202,6 +3206,8 @@ class AppTranslations {
       'upgrade_button': 'प्रीमियम में अपग्रेड करें',
       'terms_agree':
           'सब्सक्राइब करके, आप हमारी सेवा की शर्तों और गोपनीयता नीति से सहमत हैं',
+      'terms_of_use': 'उपयोग की शर्तें (EULA)',
+      'privacy_policy': 'गोपनीयता नीति',
       'secure_payment': 'Razorpay द्वारा सुरक्षित भुगतान',
       'subscription_created':
           'सब्सक्रिप्शन बनाया गया! भुगतान प्राधिकरण खोल रहे हैं...',
@@ -3573,7 +3579,7 @@ class AppTranslations {
       'word_bank': 'शब्द भंडार',
       'word_bank_desc': 'वचन बनाने के लिए शब्दों को सही क्रम में टैप करें',
       'audio': 'ऑडियो अभ्यास',
-      'audio_desc': 'टेक्स्ट-टू-स्पीच के साथ सुनें और दोहराएं',
+      'audio_desc': 'वचन पढ़ें, फिर उसे ज़ोर से बोलें',
       'type_it_out': 'टाइप करें',
       'type_it_out_desc': 'याद से पूरा वचन टाइप करें',
     },
@@ -3618,6 +3624,7 @@ class AppTranslations {
       'copied': 'आयत कॉपी हो गई',
       'could_not_load': 'आयत लोड नहीं हो सकी',
       'could_not_parse': 'संदर्भ समझ नहीं आया',
+      'content_unavailable': 'बाइबल सामग्री अस्थायी रूप से अनुपलब्ध है।',
       'added_to_memory': 'स्मृति वचनों में जोड़ा गया',
       'failed_to_add': 'आयत जोड़ने में विफल',
     },
@@ -3708,6 +3715,7 @@ class AppTranslations {
     },
     'audio': {
       'listen_carefully': 'वचन को ध्यान से सुनें',
+      'read_carefully': 'वचन को पढ़ें और याद करें',
       'played': 'चलाया',
       'times': 'बार',
       'time': 'बार',
@@ -5213,6 +5221,8 @@ class AppTranslations {
       'upgrade_button': 'പ്രീമിയത്തിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക',
       'terms_agree':
           'സബ്‌സ്‌ക്രൈബ് ചെയ്യുന്നതിലൂടെ, നിങ്ങൾ ഞങ്ങളുടെ സേവന നിബന്ധനകളും സ്വകാര്യതാ നയവും അംഗീകരിക്കുന്നു',
+      'terms_of_use': 'ഉപയോഗ നിബന്ധനകൾ (EULA)',
+      'privacy_policy': 'സ്വകാര്യതാ നയം',
       'secure_payment': 'Razorpay വഴി സുരക്ഷിത പേയ്‌മെന്റ്',
       'subscription_created': 'സബ്‌സ്‌ക്രിപ്‌ഷൻ സൃഷ്ടിച്ചു',
       'subscription_activated': 'സബ്‌സ്‌ക്രിപ്‌ഷൻ സജീവമാക്കി!',
@@ -5648,8 +5658,7 @@ class AppTranslations {
       'word_bank_desc':
           'വചനം നിർമ്മിക്കാൻ വാക്കുകൾ ശരിയായ ക്രമത്തിൽ ടാപ്പ് ചെയ്യുക',
       'audio': 'ഓഡിയോ പരിശീലനം',
-      'audio_desc':
-          'ടെക്സ്റ്റ്-ടു-സ്പീച്ച് ഉപയോഗിച്ച് കേൾക്കുകയും ആവർത്തിക്കുകയും ചെയ്യുക',
+      'audio_desc': 'വാക്യം വായിക്കുക, പിന്നെ ഉറക്കെ പറയുക',
       'type_it_out': 'ടൈപ്പ് ചെയ്യുക',
       'type_it_out_desc': 'ഓർമ്മയിൽ നിന്ന് മുഴുവൻ വചനവും ടൈപ്പ് ചെയ്യുക',
     },
@@ -5694,6 +5703,7 @@ class AppTranslations {
       'copied': 'വചനം കോപ്പി ചെയ്തു',
       'could_not_load': 'വചനം ലോഡ് ചെയ്യാനായില്ല',
       'could_not_parse': 'റഫറൻസ് മനസ്സിലായില്ല',
+      'content_unavailable': 'ബൈബിൾ ഉള്ളടക്കം താൽക്കാലികമായി ലഭ്യമല്ല.',
       'added_to_memory': 'മെമ്മറി വചനങ്ങളിൽ ചേർത്തു',
       'failed_to_add': 'വചനം ചേർക്കാനായില്ല',
     },
@@ -5785,6 +5795,7 @@ class AppTranslations {
     },
     'audio': {
       'listen_carefully': 'വചനം ശ്രദ്ധയോടെ കേൾക്കുക',
+      'read_carefully': 'വാക്യം വായിച്ച് മനഃപാഠമാക്കുക',
       'played': 'പ്ലേ ചെയ്തു',
       'times': 'തവണ',
       'time': 'തവണ',

--- a/frontend/lib/core/i18n/translation_keys.dart
+++ b/frontend/lib/core/i18n/translation_keys.dart
@@ -717,6 +717,8 @@ class TranslationKeys {
   static const premiumPriority = 'premium.priority';
   static const premiumUpgradeButton = 'premium.upgrade_button';
   static const premiumTermsAgree = 'premium.terms_agree';
+  static const subscriptionTermsOfUse = 'premium.terms_of_use';
+  static const subscriptionPrivacyPolicy = 'premium.privacy_policy';
   static const premiumSecurePayment = 'premium.secure_payment';
   static const premiumSubscriptionCreated = 'premium.subscription_created';
   static const premiumSubscriptionActivated = 'premium.subscription_activated';
@@ -1260,6 +1262,7 @@ class TranslationKeys {
   static const verseSheetCopied = 'verse_sheet.copied';
   static const verseSheetCouldNotLoad = 'verse_sheet.could_not_load';
   static const verseSheetCouldNotParse = 'verse_sheet.could_not_parse';
+  static const verseSheetContentUnavailable = 'verse_sheet.content_unavailable';
   static const verseSheetAddedToMemory = 'verse_sheet.added_to_memory';
   static const verseSheetFailedToAdd = 'verse_sheet.failed_to_add';
 
@@ -1487,6 +1490,7 @@ class TranslationKeys {
   static const audioPracticeSpeechError = 'audio_practice.speech_error';
   // Additional audio keys used in audio_practice_page.dart
   static const audioListenCarefully = 'audio.listen_carefully';
+  static const audioReadCarefully = 'audio.read_carefully';
   static const audioPlayed = 'audio.played';
   static const audioTimes = 'audio.times';
   static const audioTime = 'audio.time';

--- a/frontend/lib/core/localization/app_localizations.dart
+++ b/frontend/lib/core/localization/app_localizations.dart
@@ -591,9 +591,9 @@ class AppLocalizations {
       'walkthrough.practice_word_scramble.submit.title': 'Submit',
       'walkthrough.practice_word_scramble.submit.desc':
           'Submit once all phrases are placed to see your accuracy and record progress.',
-      'walkthrough.practice_audio.title': 'Listen & Speak',
+      'walkthrough.practice_audio.title': 'Read & Speak',
       'walkthrough.practice_audio.desc':
-          'Tap play to hear the verse, then tap the mic to speak it back.',
+          'Read the verse to memorize it, then tap the mic to speak it back.',
       'walkthrough.practice_type_it_out.title': 'Type It from Memory',
       'walkthrough.practice_type_it_out.desc':
           'Type the complete verse from memory — word for word.',
@@ -1162,9 +1162,9 @@ class AppLocalizations {
       'walkthrough.practice_word_scramble.submit.title': 'सबमिट करें',
       'walkthrough.practice_word_scramble.submit.desc':
           'सभी वाक्यांश रखने के बाद सबमिट करें — सटीकता और प्रगति देखें।',
-      'walkthrough.practice_audio.title': 'सुनें और बोलें',
+      'walkthrough.practice_audio.title': 'पढ़ें और बोलें',
       'walkthrough.practice_audio.desc':
-          'वचन सुनने के लिए प्ले दबाएं, फिर माइक से बोलें।',
+          'वचन को याद करने के लिए पढ़ें, फिर माइक से बोलें।',
       'walkthrough.practice_type_it_out.title': 'याद करके टाइप करें',
       'walkthrough.practice_type_it_out.desc':
           'पूरा वचन याद करके शब्द-दर-शब्द टाइप करें।',
@@ -1742,9 +1742,9 @@ class AppLocalizations {
       'walkthrough.practice_word_scramble.submit.title': 'സമർപ്പിക്കുക',
       'walkthrough.practice_word_scramble.submit.desc':
           'എല്ലാ ഫ്രേസുകളും ശരിയായ സ്ഥലത്ത് വെച്ചതിനു ശേഷം സമർപ്പിക്കുക.',
-      'walkthrough.practice_audio.title': 'കേൾക്കുക & പറയുക',
+      'walkthrough.practice_audio.title': 'വായിക്കുക & പറയുക',
       'walkthrough.practice_audio.desc':
-          'വചനം കേൾക്കാൻ പ്ലേ ടാപ്പ് ചെയ്യുക, പിന്നെ മൈക്കിൽ പറയുക.',
+          'വാക്യം മനഃപാഠമാക്കാൻ വായിക്കുക, പിന്നെ മൈക്കിൽ പറയുക.',
       'walkthrough.practice_type_it_out.title': 'ഓർമ്മിച്ച് ടൈപ്പ് ചെയ്യുക',
       'walkthrough.practice_type_it_out.desc':
           'മുഴുവൻ വചനം ഓർമ്മിച്ച് വാക്ക്-വഴി-വാക്ക് ടൈപ്പ് ചെയ്യുക.',

--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -27,6 +27,7 @@ import '../../features/study_generation/presentation/pages/generate_study_screen
 import '../navigation/study_navigator.dart';
 import '../di/injection_container.dart';
 import '../../features/saved_guides/presentation/pages/saved_screen.dart';
+import '../../features/settings/presentation/pages/bible_attribution_screen.dart';
 import '../../features/settings/presentation/pages/settings_screen.dart';
 import '../../features/settings/presentation/pages/offline_guides_screen.dart';
 import '../../features/notifications/presentation/pages/notification_settings_screen.dart';
@@ -347,6 +348,14 @@ class AppRouter {
         name: 'settings',
         pageBuilder: (context, state) => slideUpTransitionPage(
           child: const MaxWidthWrapper(child: SettingsScreen()),
+          state: state,
+        ),
+      ),
+      GoRoute(
+        path: AppRoutes.bibleAttribution,
+        name: 'bibleAttribution',
+        pageBuilder: (context, state) => slideUpTransitionPage(
+          child: const MaxWidthWrapper(child: BibleAttributionScreen()),
           state: state,
         ),
       ),

--- a/frontend/lib/core/router/app_routes.dart
+++ b/frontend/lib/core/router/app_routes.dart
@@ -15,6 +15,7 @@ class AppRoutes {
   static const String studyGuide = '/study-guide';
   static const String studyGuideV2 = '/study-guide-v2';
   static const String settings = '/settings';
+  static const String bibleAttribution = '/settings/bible-attribution';
   static const String notificationSettings = '/notification-settings';
   static const String saved = '/saved';
   static const String studyTopics = '/study-topics';

--- a/frontend/lib/core/services/fums_service.dart
+++ b/frontend/lib/core/services/fums_service.dart
@@ -1,0 +1,62 @@
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uuid/uuid.dart';
+
+import '../utils/logger.dart';
+
+/// API.Bible FUMS (Fair Use Management System) reporter.
+///
+/// API.Bible requires webapps to report a FUMS token for each Scripture view so
+/// usage can be profiled back to copyright holders. Our verse fetches happen in
+/// the backend, which returns the FUMS v3 token(s) in the response; this service
+/// reports them from the client via the documented HTTP endpoint:
+///   `https://fums.api.bible/f3?t={token}&dId={deviceId}&sId={sessionId}`
+///
+/// Reporting is best-effort and must never block or fail a verse display. On web,
+/// a CORS error is expected when reading the response — the request still reaches
+/// FUMS, so we simply swallow the error.
+class FumsService {
+  FumsService._();
+  static final FumsService instance = FumsService._();
+
+  static const String _endpoint = 'https://fums.api.bible/f3';
+  static const String _deviceIdKey = 'fums_device_id';
+
+  /// Regenerated each app session.
+  final String _sessionId = const Uuid().v4();
+
+  String? _deviceId;
+
+  /// Persistent, anonymous device id (no PII). Generated once and stored.
+  Future<String> _getDeviceId() async {
+    if (_deviceId != null) return _deviceId!;
+    final prefs = await SharedPreferences.getInstance();
+    var id = prefs.getString(_deviceIdKey);
+    if (id == null) {
+      id = const Uuid().v4();
+      await prefs.setString(_deviceIdKey, id);
+    }
+    _deviceId = id;
+    return id;
+  }
+
+  /// Reports one or more FUMS tokens (e.g. from a fetch-verse response).
+  Future<void> trackView(List<String> tokens) async {
+    if (tokens.isEmpty) return;
+    try {
+      final deviceId = await _getDeviceId();
+      for (final token in tokens) {
+        if (token.isEmpty) continue;
+        final uri = Uri.parse(_endpoint).replace(queryParameters: {
+          't': token,
+          'dId': deviceId,
+          'sId': _sessionId,
+        });
+        // Fire-and-forget; ignore failures (incl. expected web CORS read errors).
+        http.get(uri).then((_) {}, onError: (Object _) {});
+      }
+    } catch (e) {
+      Logger.debug('FUMS trackView skipped: $e');
+    }
+  }
+}

--- a/frontend/lib/core/services/iap_service.dart
+++ b/frontend/lib/core/services/iap_service.dart
@@ -281,7 +281,7 @@ class IAPService {
   /// Extract receipt data for backend validation
   ///
   /// Throws [Exception] if receipt data cannot be extracted.
-  String getReceiptData(PurchaseDetails purchase) {
+  Future<String> getReceiptData(PurchaseDetails purchase) async {
     try {
       if (Platform.isAndroid) {
         final androidPurchase = purchase as GooglePlayPurchaseDetails;
@@ -291,8 +291,12 @@ class IAPService {
         }
         return receipt;
       } else if (Platform.isIOS) {
-        final iosPurchase = purchase as AppStorePurchaseDetails;
-        final receipt = iosPurchase.verificationData.serverVerificationData;
+        // On iOS 15+ the plugin uses StoreKit 2, so PurchaseDetails is an
+        // SK2PurchaseDetails whose serverVerificationData is a JWS — which the
+        // backend's legacy verifyReceipt API does not accept. Use the base64
+        // App Store receipt instead; verifyReceipt validates it under both
+        // StoreKit 1 and StoreKit 2.
+        final receipt = await SKReceiptManager.retrieveReceiptData();
         if (receipt.isEmpty) {
           throw Exception('App Store receipt data is empty');
         }
@@ -316,8 +320,9 @@ class IAPService {
       final androidPurchase = purchase as GooglePlayPurchaseDetails;
       return androidPurchase.billingClientPurchase.orderId;
     } else if (Platform.isIOS) {
-      final iosPurchase = purchase as AppStorePurchaseDetails;
-      return iosPurchase.skPaymentTransaction.transactionIdentifier ?? '';
+      // Base-class purchaseID is the transaction id under both StoreKit 1 and 2
+      // (SK2PurchaseDetails has no skPaymentTransaction).
+      return purchase.purchaseID ?? '';
     }
 
     return '';

--- a/frontend/lib/core/services/system_config_service.dart
+++ b/frontend/lib/core/services/system_config_service.dart
@@ -263,6 +263,15 @@ class SystemConfigService extends ChangeNotifier {
     return feature?.enabled ?? true;
   }
 
+  /// Whether API.Bible content surfaces are enabled (admin kill switch).
+  /// Returns true if the flag is missing (safe default — keeps content visible).
+  /// When false: daily-verse card, scripture verse sheet, and daily_verse-sourced
+  /// memory verses must not show API-fetched verse text.
+  bool get isBibleContentEnabled {
+    final feature = _config?.featureFlags['bible_content_enabled'];
+    return feature?.enabled ?? true;
+  }
+
   // Private helper methods
 
   bool _shouldRefresh() {

--- a/frontend/lib/features/daily_verse/presentation/widgets/daily_verse_card.dart
+++ b/frontend/lib/features/daily_verse/presentation/widgets/daily_verse_card.dart
@@ -12,6 +12,7 @@ import '../../../../core/utils/ui_utils.dart';
 import '../../../../core/extensions/translation_extension.dart';
 import '../../../../core/i18n/translation_keys.dart';
 import '../../../../core/di/injection_container.dart';
+import '../../../../core/router/app_routes.dart';
 import '../../domain/entities/daily_verse_entity.dart';
 import '../../domain/entities/daily_verse_streak.dart';
 import '../../../memory_verses/presentation/bloc/memory_verse_bloc.dart';
@@ -45,6 +46,11 @@ class DailyVerseCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Hide the entire card when the bible_content_enabled kill-switch is off.
+    if (!sl<SystemConfigService>().isBibleContentEnabled) {
+      return const SizedBox.shrink();
+    }
+
     return BlocBuilder<DailyVerseBloc, DailyVerseState>(
       builder: (context, state) => Container(
         margin: margin ?? const EdgeInsets.symmetric(horizontal: 20),
@@ -143,14 +149,18 @@ class DailyVerseCard extends StatelessWidget {
 
               const SizedBox(height: 16),
 
-              // Verse reference
-              Text(
-                state.verse.getReferenceText(state.currentLanguage),
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.w700,
-                  fontSize: 16,
-                  letterSpacing: 0.5,
+              // Verse reference + translation citation (taps to copyright page)
+              GestureDetector(
+                onTap: () => context.push(AppRoutes.bibleAttribution),
+                child: Text(
+                  '${state.verse.getReferenceText(state.currentLanguage)} '
+                  '(${_translationAbbr(state.currentLanguage)})',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 16,
+                    letterSpacing: 0.5,
+                  ),
                 ),
               ),
 
@@ -596,9 +606,23 @@ class DailyVerseCard extends StatelessWidget {
     );
   }
 
+  /// API.Bible translation abbreviation for in-context citation.
+  /// English = King James Version (KJV); Hindi/Malayalam = Indian Revised Version (IRV).
+  String _translationAbbr(VerseLanguage language) {
+    switch (language) {
+      case VerseLanguage.english:
+        return 'KJV';
+      case VerseLanguage.hindi:
+      case VerseLanguage.malayalam:
+        return 'IRV';
+    }
+  }
+
   void _copyVerseToClipboard(BuildContext context, DailyVerseLoaded state) {
+    final ref = state.verse.getReferenceText(state.currentLanguage);
+    final abbr = _translationAbbr(state.currentLanguage);
     final text =
-        '${state.verse.getReferenceText(state.currentLanguage)}\n\n${state.currentVerseText}';
+        '$ref ($abbr)\n\n${state.currentVerseText}\n\nScripture provided by API.Bible';
     Clipboard.setData(ClipboardData(text: text));
 
     final theme = Theme.of(context);
@@ -624,8 +648,10 @@ class DailyVerseCard extends StatelessWidget {
         : Platform.isAndroid
             ? '📱 https://play.google.com/store/apps/details?id=com.disciplefy.bible_study'
             : '🌐 https://app.disciplefy.in/';
+    final ref = state.verse.getReferenceText(state.currentLanguage);
+    final abbr = _translationAbbr(state.currentLanguage);
     final text =
-        '${state.verse.getReferenceText(state.currentLanguage)}\n\n${state.currentVerseText}\n\n— Shared from Disciplefy: Bible Study App\n$appLink';
+        '$ref ($abbr)\n\n${state.currentVerseText}\n\nScripture provided by API.Bible\n\n— Shared from Disciplefy: Bible Study App\n$appLink';
     Share.share(text);
   }
 }

--- a/frontend/lib/features/memory_verses/data/datasources/memory_verse_remote_datasource.dart
+++ b/frontend/lib/features/memory_verses/data/datasources/memory_verse_remote_datasource.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import '../../../../core/config/app_config.dart';
 import '../../../../core/error/api_error_handler.dart';
 import '../../../../core/error/exceptions.dart';
+import '../../../../core/services/fums_service.dart';
 import '../../../../core/services/http_service.dart';
 import '../models/memory_verse_model.dart';
 import '../models/review_statistics_model.dart';
@@ -366,6 +367,13 @@ class MemoryVerseRemoteDataSource {
         final data = jsonData['data'] as Map<String, dynamic>;
 
         _errorHandler.logSuccess('Verse text fetched successfully');
+
+        // API.Bible FUMS: report usage tokens for this live verse fetch.
+        if (data['fumsTokens'] is List) {
+          FumsService.instance.trackView(
+            (data['fumsTokens'] as List).map((t) => t.toString()).toList(),
+          );
+        }
 
         return {
           'text': data['text'] as String,

--- a/frontend/lib/features/memory_verses/presentation/pages/audio_practice_page.dart
+++ b/frontend/lib/features/memory_verses/presentation/pages/audio_practice_page.dart
@@ -18,7 +18,6 @@ import '../bloc/memory_verse_event.dart';
 import '../bloc/memory_verse_state.dart';
 import '../utils/quality_calculator.dart';
 import '../widgets/timer_badge.dart';
-import '../../../voice_buddy/data/services/tts_service.dart';
 import '../../../voice_buddy/data/services/speech_service.dart';
 import '../../../walkthrough/domain/walkthrough_screen.dart';
 import '../../../walkthrough/domain/walkthrough_repository.dart';
@@ -28,7 +27,7 @@ import '../../../walkthrough/presentation/walkthrough_tooltip.dart';
 /// Audio Practice Page for Memory Verses.
 ///
 /// Two-phase practice mode:
-/// 1. **Listening Phase**: User listens to the verse via TTS
+/// 1. **Reading Phase**: User reads the verse text on screen to memorize it
 /// 2. **Speaking Phase**: User speaks the verse, speech-to-text compares to original
 ///
 /// Scoring based on transcription accuracy compared to original verse text.
@@ -49,16 +48,10 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
   MemoryVerseEntity? currentVerse;
 
   // Services
-  final TTSService _ttsService = TTSService();
   final SpeechService _speechService = SpeechService();
 
   // Phase management
-  AudioPhase _currentPhase = AudioPhase.listening;
-
-  // Listening phase state
-  double _playbackSpeed = 1.0;
-  int _timesPlayed = 0;
-  bool _isPlaying = false;
+  AudioPhase _currentPhase = AudioPhase.reading;
 
   // Speaking phase state
   bool _isRecording = false;
@@ -73,7 +66,8 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
   // Practice tracking
   Timer? _practiceTimer;
   int _elapsedSeconds = 0;
-  int _hintsUsed = 0;
+  // No hints in reading mode; the verse is shown for memorization.
+  final int _hintsUsed = 0;
 
   // Walkthrough
   BuildContext? _showcaseContext;
@@ -105,8 +99,6 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
   @override
   void dispose() {
     _practiceTimer?.cancel();
-    _ttsService.stop();
-    _ttsService.dispose();
     _speechService.stopListening();
     _speechService.dispose();
     super.dispose();
@@ -135,7 +127,6 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
   }
 
   Future<void> _initializeServices() async {
-    await _ttsService.initialize();
     await _speechService.initialize();
   }
 
@@ -156,43 +147,6 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
       return 'ml-IN';
     }
     return 'en-US';
-  }
-
-  Future<void> _playVerse() async {
-    if (currentVerse == null || _isPlaying) return;
-
-    setState(() => _isPlaying = true);
-
-    // First play is free, subsequent plays count as hints
-    if (_timesPlayed > 0) {
-      _hintsUsed++;
-    }
-    _timesPlayed++;
-
-    final languageCode = _getLanguageCode();
-    // Speak verse text first, then reference at the end
-    final textToSpeak =
-        '${currentVerse!.verseText}. ${currentVerse!.verseReference}';
-
-    await _ttsService.speakWithSettings(
-      text: textToSpeak,
-      languageCode: languageCode,
-      speakingRate: _playbackSpeed,
-      onComplete: () {
-        if (mounted) {
-          setState(() => _isPlaying = false);
-        }
-      },
-    );
-  }
-
-  Future<void> _stopPlayback() async {
-    await _ttsService.stop();
-    setState(() => _isPlaying = false);
-  }
-
-  void _changeSpeed(double speed) {
-    setState(() => _playbackSpeed = speed);
   }
 
   void _proceedToSpeaking() {
@@ -586,7 +540,7 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
         // Main Content
         Expanded(
           child: switch (_currentPhase) {
-            AudioPhase.listening => _buildListeningPhase(theme),
+            AudioPhase.reading => _buildReadingPhase(theme),
             AudioPhase.speaking => _buildSpeakingPhase(theme),
             AudioPhase.results => _buildResultsPhase(theme),
           },
@@ -603,9 +557,9 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
         children: [
           _buildPhaseChip(
             theme,
-            'Listen',
-            Icons.headphones,
-            _currentPhase == AudioPhase.listening,
+            'Read',
+            Icons.menu_book,
+            _currentPhase == AudioPhase.reading,
             _currentPhase.index >= 0,
           ),
           Container(
@@ -682,15 +636,15 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
     );
   }
 
-  Widget _buildListeningPhase(ThemeData theme) {
-    return Padding(
+  Widget _buildReadingPhase(ThemeData theme) {
+    return SingleChildScrollView(
       padding: const EdgeInsets.all(24),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
           // Instructions
           Text(
-            context.tr(TranslationKeys.audioListenCarefully),
+            context.tr(TranslationKeys.audioReadCarefully),
             style: theme.textTheme.titleMedium?.copyWith(
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -698,7 +652,7 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
           ),
           const SizedBox(height: 32),
 
-          // Play Button
+          // Verse text to read and memorize
           WalkthroughTooltip(
             showcaseKey: ShowcaseKeys.practiceAudio,
             title: AppLocalizations.of(context)!.walkthroughPracticeAudioTitle,
@@ -708,98 +662,33 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
             stepNumber: 1,
             totalSteps: 1,
             onNext: _onNext,
-            child: GestureDetector(
-              onTap: _isPlaying ? _stopPlayback : _playVerse,
-              child: Container(
-                width: 120,
-                height: 120,
-                decoration: BoxDecoration(
-                  color: context.appInteractive,
-                  shape: BoxShape.circle,
-                  boxShadow: [
-                    BoxShadow(
-                      color: context.appInteractive.withAlpha(60),
-                      blurRadius: 20,
-                      spreadRadius: 5,
-                    ),
-                  ],
-                ),
-                child: Icon(
-                  _isPlaying ? Icons.stop : Icons.play_arrow,
-                  color: Colors.white,
-                  size: 64,
-                ),
+            child: Container(
+              width: double.infinity,
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: AppColors.lightBorder),
+              ),
+              child: Text(
+                currentVerse!.verseText,
+                style: theme.textTheme.titleLarge?.copyWith(height: 1.5),
+                textAlign: TextAlign.center,
               ),
             ),
-          ),
-          const SizedBox(height: 24),
-
-          // Play count
-          Text(
-            _timesPlayed > 0
-                ? '${context.tr(TranslationKeys.audioPlayed)} $_timesPlayed ${_timesPlayed > 1 ? context.tr(TranslationKeys.audioTimes) : context.tr(TranslationKeys.audioTime)}'
-                : context.tr(TranslationKeys.audioTapToPlay),
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: AppColors.lightTextSecondary,
-            ),
-          ),
-          const SizedBox(height: 32),
-
-          // Speed Controls
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              _buildSpeedButton(theme, 0.75, '0.75x'),
-              const SizedBox(width: 12),
-              _buildSpeedButton(theme, 1.0, '1x'),
-              const SizedBox(width: 12),
-              _buildSpeedButton(theme, 1.25, '1.25x'),
-            ],
           ),
           const SizedBox(height: 48),
 
           // Proceed Button
-          if (_timesPlayed > 0)
-            ElevatedButton.icon(
-              onPressed: _proceedToSpeaking,
-              icon: const Icon(Icons.arrow_forward),
-              label: Text(context.tr(TranslationKeys.audioReadyToSpeak)),
-              style: ElevatedButton.styleFrom(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
-              ),
+          ElevatedButton.icon(
+            onPressed: _proceedToSpeaking,
+            icon: const Icon(Icons.arrow_forward),
+            label: Text(context.tr(TranslationKeys.audioReadyToSpeak)),
+            style: ElevatedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
             ),
+          ),
         ],
-      ),
-    );
-  }
-
-  Widget _buildSpeedButton(ThemeData theme, double speed, String label) {
-    final isSelected = _playbackSpeed == speed;
-    return InkWell(
-      onTap: () => _changeSpeed(speed),
-      borderRadius: BorderRadius.circular(20),
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        decoration: BoxDecoration(
-          color: isSelected
-              ? theme.colorScheme.primaryContainer
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(20),
-          border: Border.all(
-            color:
-                isSelected ? theme.colorScheme.primary : AppColors.lightBorder,
-          ),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            color: isSelected
-                ? theme.colorScheme.primary
-                : AppColors.lightTextSecondary,
-            fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-          ),
-        ),
       ),
     );
   }
@@ -1180,7 +1069,7 @@ class _AudioPracticePageState extends State<AudioPracticePage> {
 
 /// Phases of audio practice
 enum AudioPhase {
-  listening,
+  reading,
   speaking,
   results,
 }

--- a/frontend/lib/features/memory_verses/presentation/widgets/verse_flip_card.dart
+++ b/frontend/lib/features/memory_verses/presentation/widgets/verse_flip_card.dart
@@ -2,8 +2,11 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import '../../../../core/constants/bible_translation_citation.dart';
+import '../../../../core/di/injection_container.dart';
 import '../../../../core/i18n/translation_keys.dart';
 import '../../../../core/extensions/translation_extension.dart';
+import '../../../../core/services/system_config_service.dart';
 import '../../domain/entities/memory_verse_entity.dart';
 
 /// Animated flip card widget for memory verse review.
@@ -184,6 +187,18 @@ class _VerseFlipCardState extends State<VerseFlipCard>
     );
   }
 
+  /// API.Bible-sourced verses (daily_verse) show the translation citation, e.g.
+  /// "John 3:16 (KJV)". The user's own (manual / ai_generated) verses do not.
+  String _citedReference() {
+    if (widget.verse.sourceType != 'daily_verse') {
+      return widget.verse.verseReference;
+    }
+    final abbr = bibleTranslationAbbr(widget.verse.language);
+    return abbr.isEmpty
+        ? widget.verse.verseReference
+        : '${widget.verse.verseReference} ($abbr)';
+  }
+
   Widget _buildBack(BuildContext context) {
     final theme = Theme.of(context);
     final isDarkMode = theme.brightness == Brightness.dark;
@@ -222,7 +237,7 @@ class _VerseFlipCardState extends State<VerseFlipCard>
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Text(
-                  widget.verse.verseReference,
+                  _citedReference(),
                   style: theme.textTheme.titleLarge?.copyWith(
                     color: theme.colorScheme.primary,
                     fontWeight: FontWeight.bold,
@@ -236,21 +251,45 @@ class _VerseFlipCardState extends State<VerseFlipCard>
             // Verse text - takes up remaining space
             Expanded(
               child: Center(
-                child: SingleChildScrollView(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 24.0, vertical: 16.0),
-                  child: Text(
-                    widget.verse.verseText,
-                    textAlign: TextAlign.center,
-                    style: TextStyle(
-                      fontSize: 26,
-                      height: 1.5,
-                      fontWeight: FontWeight.w500,
-                      color: isDarkMode ? Colors.white : Colors.black87,
-                      letterSpacing: 0.3,
+                child: () {
+                  // Hide API.Bible verse text for daily_verse-sourced verses
+                  // when the bible_content_enabled kill-switch is off.
+                  final hideApiContent =
+                      widget.verse.sourceType == 'daily_verse' &&
+                          !sl<SystemConfigService>().isBibleContentEnabled;
+                  if (hideApiContent) {
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 24.0, vertical: 16.0),
+                      child: Text(
+                        context
+                            .tr(TranslationKeys.verseSheetContentUnavailable),
+                        textAlign: TextAlign.center,
+                        style: TextStyle(
+                          fontSize: 18,
+                          height: 1.5,
+                          fontWeight: FontWeight.w400,
+                          color: isDarkMode ? Colors.white54 : Colors.black45,
+                        ),
+                      ),
+                    );
+                  }
+                  return SingleChildScrollView(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 24.0, vertical: 16.0),
+                    child: Text(
+                      widget.verse.verseText,
+                      textAlign: TextAlign.center,
+                      style: TextStyle(
+                        fontSize: 26,
+                        height: 1.5,
+                        fontWeight: FontWeight.w500,
+                        color: isDarkMode ? Colors.white : Colors.black87,
+                        letterSpacing: 0.3,
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                }(),
               ),
             ),
 

--- a/frontend/lib/features/settings/presentation/pages/bible_attribution_screen.dart
+++ b/frontend/lib/features/settings/presentation/pages/bible_attribution_screen.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../../core/theme/app_colors.dart';
+
+/// Bible copyright & attribution page (API.Bible compliance).
+///
+/// API.Bible's terms require a copyright page that names each translation, its
+/// copyright/licence and IP-holder link, and (on the Starter plan) a visible link
+/// to https://api.bible. In-context citations elsewhere in the app link here.
+class BibleAttributionScreen extends StatelessWidget {
+  const BibleAttributionScreen({super.key});
+
+  static const _apiBibleUrl = 'https://api.bible';
+  static const _vachanUrl = 'https://vachanonline.com';
+  static const _ccBySaUrl = 'https://creativecommons.org/licenses/by-sa/4.0/';
+
+  // Notices are the verbatim `copyright` strings from API.Bible's /bibles metadata.
+  static const List<_Attribution> _attributions = [
+    _Attribution(
+      language: 'English',
+      abbreviation: 'KJV',
+      name: 'King James (Authorised) Version',
+      notice:
+          'PUBLIC DOMAIN except in the United Kingdom, where a Crown Copyright '
+          'applies to printing the KJV.',
+      licenseUrl: null,
+    ),
+    _Attribution(
+      language: 'हिन्दी (Hindi)',
+      abbreviation: 'IRV',
+      name: 'Indian Revised Version (IRV) Hindi — 2019',
+      notice:
+          'Indian Revised Version (IRV) - Hindi (इंडियन रिवाइज्ड वर्जन - हिंदी), '
+          '2019 by Bridge Connectivity Solutions Pvt. Ltd. is licensed under a '
+          'Creative Commons Attribution-ShareAlike 4.0 International License. '
+          'This resource is published originally on VachanOnline.',
+      licenseUrl: _ccBySaUrl,
+    ),
+    _Attribution(
+      language: 'മലയാളം (Malayalam)',
+      abbreviation: 'IRV',
+      name: 'Indian Revised Version (IRV) Malayalam — 2025',
+      notice:
+          'Indian Revised Version (IRV) - Malayalam (ഇന്ത്യന്‍ റിവൈസ്ഡ് വേര്‍ഷന്‍ '
+          '- മലയാളം), 2019 by Bridge Connectivity Solutions Pvt. Ltd. is licensed '
+          'under a Creative Commons Attribution-ShareAlike 4.0 International '
+          'License. This resource is published originally on VachanOnline.',
+      licenseUrl: _ccBySaUrl,
+    ),
+  ];
+
+  Future<void> _launch(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bible Copyright & Attribution')),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text(
+              'Scripture text in Disciplefy is provided by API.Bible. Each '
+              'translation is used under its respective copyright or licence, '
+              'as shown below.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            for (final a in _attributions) ...[
+              _AttributionCard(attribution: a, onLicenseTap: _launch),
+              const SizedBox(height: 12),
+            ],
+            const SizedBox(height: 8),
+            const Divider(),
+            const SizedBox(height: 8),
+            // API.Bible attribution (required visible link on the Starter plan).
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.menu_book_outlined),
+              title: const Text('Scripture provided by API.Bible'),
+              subtitle: const Text(_apiBibleUrl),
+              trailing: const Icon(Icons.open_in_new, size: 18),
+              onTap: () => _launch(_apiBibleUrl),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.public),
+              title: const Text('VachanOnline'),
+              subtitle: const Text(_vachanUrl),
+              trailing: const Icon(Icons.open_in_new, size: 18),
+              onTap: () => _launch(_vachanUrl),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Attribution {
+  final String language;
+  final String abbreviation;
+  final String name;
+  final String notice;
+  final String? licenseUrl;
+
+  const _Attribution({
+    required this.language,
+    required this.abbreviation,
+    required this.name,
+    required this.notice,
+    required this.licenseUrl,
+  });
+}
+
+class _AttributionCard extends StatelessWidget {
+  final _Attribution attribution;
+  final Future<void> Function(String) onLicenseTap;
+
+  const _AttributionCard(
+      {required this.attribution, required this.onLicenseTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppColors.lightBorder),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  attribution.language,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  attribution.abbreviation,
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(attribution.notice, style: theme.textTheme.bodySmall),
+          if (attribution.licenseUrl != null) ...[
+            const SizedBox(height: 8),
+            InkWell(
+              onTap: () => onLicenseTap(attribution.licenseUrl!),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'CC BY-SA 4.0',
+                    style: theme.textTheme.labelMedium?.copyWith(
+                      color: theme.colorScheme.primary,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                  const SizedBox(width: 4),
+                  Icon(Icons.open_in_new,
+                      size: 14, color: theme.colorScheme.primary),
+                ],
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/features/settings/presentation/pages/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_screen.dart
@@ -996,6 +996,19 @@ class _SettingsScreenContentState extends State<_SettingsScreenContent> {
           _buildDivider(),
           _buildSettingsTile(
             context: context,
+            icon: Icons.menu_book_outlined,
+            title: 'Bible Copyright & Attribution',
+            subtitle: 'Scripture provided by API.Bible',
+            trailing: Icon(
+              Icons.arrow_forward_ios,
+              size: 16,
+              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+            ),
+            onTap: () => context.push(AppRoutes.bibleAttribution),
+          ),
+          _buildDivider(),
+          _buildSettingsTile(
+            context: context,
             icon: Icons.privacy_tip_outlined,
             title: context.tr(TranslationKeys.settingsPrivacyPolicy),
             subtitle: context.tr(TranslationKeys.settingsPrivacyPolicySubtitle),

--- a/frontend/lib/features/subscription/presentation/bloc/subscription_bloc.dart
+++ b/frontend/lib/features/subscription/presentation/bloc/subscription_bloc.dart
@@ -821,7 +821,7 @@ class SubscriptionBloc extends Bloc<SubscriptionEvent, SubscriptionState> {
         '✅ [BLOC] IAP Purchase successful, validating receipt with backend');
 
     try {
-      final receiptData = _iapService!.getReceiptData(purchase);
+      final receiptData = await _iapService!.getReceiptData(purchase);
       final provider = PlatformPaymentProviderService.getProvider();
 
       // Call backend to validate receipt and create subscription

--- a/frontend/lib/features/subscription/presentation/pages/plus_upgrade_page.dart
+++ b/frontend/lib/features/subscription/presentation/pages/plus_upgrade_page.dart
@@ -5,6 +5,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/constants/app_fonts.dart';
+import '../widgets/subscription_legal_links.dart';
 import '../../../../core/router/app_routes.dart';
 import '../../../../core/di/injection_container.dart';
 import '../../../../core/extensions/translation_extension.dart';
@@ -749,6 +750,8 @@ class _PlusUpgradePageState extends State<PlusUpgradePage>
           ),
           textAlign: TextAlign.center,
         ),
+        const SizedBox(height: 10),
+        const SubscriptionLegalLinks(),
         const SizedBox(height: 12),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/lib/features/subscription/presentation/pages/premium_upgrade_page.dart
+++ b/frontend/lib/features/subscription/presentation/pages/premium_upgrade_page.dart
@@ -6,6 +6,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/constants/app_fonts.dart';
 import '../../../../core/router/app_routes.dart';
+import '../widgets/subscription_legal_links.dart';
 import '../../../../core/di/injection_container.dart';
 import '../../../../core/i18n/translation_service.dart';
 import '../../../../core/extensions/translation_extension.dart';
@@ -206,8 +207,9 @@ class _PremiumUpgradePageState extends State<PremiumUpgradePage>
             setState(() => _isSubmitting = false);
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text('Something went wrong. Please try again.'),
+                content: Text(state.errorMessage),
                 backgroundColor: AppTheme.errorColor,
+                duration: const Duration(seconds: 8),
               ),
             );
           }
@@ -749,6 +751,8 @@ class _PremiumUpgradePageState extends State<PremiumUpgradePage>
           ),
           textAlign: TextAlign.center,
         ),
+        const SizedBox(height: 10),
+        const SubscriptionLegalLinks(),
         const SizedBox(height: 12),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/lib/features/subscription/presentation/pages/standard_upgrade_page.dart
+++ b/frontend/lib/features/subscription/presentation/pages/standard_upgrade_page.dart
@@ -5,6 +5,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../../../core/constants/app_fonts.dart';
+import '../widgets/subscription_legal_links.dart';
 import '../../../../core/router/app_routes.dart';
 import '../../../../core/di/injection_container.dart';
 import '../../../../core/extensions/translation_extension.dart';
@@ -203,8 +204,9 @@ class _StandardUpgradePageState extends State<StandardUpgradePage>
             setState(() => _isSubmitting = false);
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
-                content: Text('Something went wrong. Please try again.'),
+                content: Text(state.errorMessage),
                 backgroundColor: AppTheme.errorColor,
+                duration: const Duration(seconds: 8),
               ),
             );
           }
@@ -732,6 +734,8 @@ class _StandardUpgradePageState extends State<StandardUpgradePage>
           ),
           textAlign: TextAlign.center,
         ),
+        const SizedBox(height: 10),
+        const SubscriptionLegalLinks(),
         const SizedBox(height: 12),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/frontend/lib/features/subscription/presentation/widgets/standard_subscription_sheet.dart
+++ b/frontend/lib/features/subscription/presentation/widgets/standard_subscription_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'subscription_legal_links.dart';
 import '../../domain/entities/user_subscription_status.dart';
 import '../../../../core/services/pricing_service.dart';
 import '../../../../core/di/injection_container.dart';
@@ -274,6 +275,10 @@ class StandardSubscriptionSheet extends StatelessWidget {
                           ),
                         ),
                 ),
+                const SizedBox(height: 12),
+
+                // Required: functional Terms of Use (EULA) + Privacy Policy links.
+                const SubscriptionLegalLinks(),
                 const SizedBox(height: 12),
 
                 // Trial info or cancel info

--- a/frontend/lib/features/subscription/presentation/widgets/subscription_legal_links.dart
+++ b/frontend/lib/features/subscription/presentation/widgets/subscription_legal_links.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../../core/constants/app_fonts.dart';
+import '../../../../core/extensions/translation_extension.dart';
+import '../../../../core/i18n/translation_keys.dart';
+
+/// Functional Terms of Use (EULA) and Privacy Policy links.
+///
+/// Required on every auto-renewable subscription purchase screen by App Store
+/// Review Guideline 3.1.2(c). These MUST be tappable, working links — a plain
+/// text mention is not sufficient and will be rejected.
+class SubscriptionLegalLinks extends StatelessWidget {
+  const SubscriptionLegalLinks({super.key});
+
+  static const String termsUrl = 'https://www.disciplefy.in/terms';
+  static const String privacyUrl = 'https://www.disciplefy.in/privacy';
+
+  Future<void> _launch(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final linkStyle = AppFonts.inter(
+      fontSize: 12,
+      color: colorScheme.primary,
+      fontWeight: FontWeight.w600,
+    ).copyWith(decoration: TextDecoration.underline);
+    final separatorStyle = AppFonts.inter(
+      fontSize: 12,
+      color: colorScheme.onSurface.withOpacity(0.5),
+    );
+
+    return Wrap(
+      alignment: WrapAlignment.center,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        InkWell(
+          onTap: () => _launch(termsUrl),
+          child: Text(
+            context.tr(TranslationKeys.subscriptionTermsOfUse),
+            style: linkStyle,
+          ),
+        ),
+        Text('    •    ', style: separatorStyle),
+        InkWell(
+          onTap: () => _launch(privacyUrl),
+          child: Text(
+            context.tr(TranslationKeys.subscriptionPrivacyPolicy),
+            style: linkStyle,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -97,9 +97,14 @@ const firebaseMeasurementId = String.fromEnvironment(
 );
 
 void main() async {
+  // Razorpay is the payment provider for web only; mobile (iOS/Android) uses
+  // native IAP (App Store / Google Play) via PlatformPaymentProviderService.
+  // Asserting this unconditionally crashed debug mobile builds run with an env
+  // that omits RAZORPAY_KEY_ID (e.g. .env.production) — the throw happens before
+  // runApp(), leaving the app frozen on the native splash screen.
   assert(
-    PaymentConstants.razorpayKeyId.isNotEmpty,
-    'RAZORPAY_KEY_ID must be set via --dart-define=RAZORPAY_KEY_ID=...',
+    !kIsWeb || PaymentConstants.razorpayKeyId.isNotEmpty,
+    'RAZORPAY_KEY_ID must be set via --dart-define=RAZORPAY_KEY_ID=... for web builds',
   );
 
   WidgetsFlutterBinding.ensureInitialized();

--- a/frontend/lib/shared/widgets/scripture_verse_sheet.dart
+++ b/frontend/lib/shared/widgets/scripture_verse_sheet.dart
@@ -4,10 +4,12 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/constants/bible_books.dart';
+import '../../core/constants/bible_translation_citation.dart';
 import '../../core/extensions/translation_extension.dart';
 import '../../core/i18n/translation_keys.dart';
 import '../../core/router/app_routes.dart';
 import '../../core/services/language_preference_service.dart';
+import '../../core/services/system_config_service.dart';
 import '../../features/memory_verses/data/services/verse_cache_service.dart';
 import '../../features/memory_verses/domain/entities/fetched_verse_entity.dart';
 import '../../features/memory_verses/domain/usecases/fetch_verse_text.dart';
@@ -49,6 +51,7 @@ class _ScriptureVerseSheetState extends State<ScriptureVerseSheet> {
   String? _verseText;
   String? _localizedReference;
   String? _errorMessage;
+  String? _langCode; // language of the fetched verse, for in-context citation
   List<VerseItem>? _verses; // null = single verse, list = range
 
   @override
@@ -58,6 +61,17 @@ class _ScriptureVerseSheetState extends State<ScriptureVerseSheet> {
   }
 
   Future<void> _fetchVerseText() async {
+    // Guard: when the bible_content_enabled kill-switch is off, skip fetching
+    // and show an "unavailable" message instead of verse text.
+    if (!GetIt.instance<SystemConfigService>().isBibleContentEnabled) {
+      setState(() {
+        _isLoading = false;
+        _errorMessage =
+            context.tr(TranslationKeys.verseSheetContentUnavailable);
+      });
+      return;
+    }
+
     final fetchVerseText = GetIt.instance<FetchVerseText>();
     final languageService = GetIt.instance<LanguagePreferenceService>();
     final verseCache = GetIt.instance<VerseCacheService>();
@@ -77,6 +91,7 @@ class _ScriptureVerseSheetState extends State<ScriptureVerseSheet> {
     // over app language, so verse displays in the same language as the study content
     final appLanguage = await languageService.getStudyContentLanguage();
     final langCode = appLanguage.code;
+    _langCode = langCode;
 
     // Check cache first
     final cached = await verseCache.getCachedVerse(
@@ -178,9 +193,21 @@ class _ScriptureVerseSheetState extends State<ScriptureVerseSheet> {
     );
   }
 
+  /// Reference with the API.Bible translation abbreviation appended, e.g.
+  /// "John 3:16 (KJV)". Links to the full copyright page via the citation badge.
+  String _citedReference() {
+    final ref = _localizedReference ?? widget.reference;
+    final abbr = _langCode == null ? '' : bibleTranslationAbbr(_langCode!);
+    return abbr.isEmpty ? ref : '$ref ($abbr)';
+  }
+
   void _copyToClipboard() {
     if (_verseText != null && _localizedReference != null) {
-      final textToCopy = '"$_verseText" - $_localizedReference';
+      final abbr = _langCode == null ? '' : bibleTranslationAbbr(_langCode!);
+      final cited =
+          abbr.isEmpty ? _localizedReference : '$_localizedReference ($abbr)';
+      final textToCopy =
+          '"$_verseText" - $cited\n\nScripture provided by API.Bible';
       Clipboard.setData(ClipboardData(text: textToCopy));
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -241,7 +268,7 @@ class _ScriptureVerseSheetState extends State<ScriptureVerseSheet> {
                         const SizedBox(width: 12),
                         Expanded(
                           child: Text(
-                            _localizedReference ?? widget.reference,
+                            _citedReference(),
                             style: theme.textTheme.titleLarge?.copyWith(
                               fontWeight: FontWeight.w600,
                               color: theme.colorScheme.primary,


### PR DESCRIPTION
## Summary

API.Bible compliance work, an admin kill-switch system for Bible content, the App Store subscription-paywall fix, and supporting fixes/docs.

## What's included

**`feat(bible)`: API.Bible compliance and admin kill-switches**
- **30-day cache recency**: cut `daily_verses_cache` TTL to 30 days, daily-verse read now honours `expires_at`, migration caps existing rows; `cleanup-expired-verse-cache` + `refresh-stale-memory-verses` jobs + pg_cron schedules; `memory_verses.verse_text_synced_at` tracking.
- **FUMS**: backend requests FUMS v3 and returns `meta.fumsToken`; client `FumsService` reports usage on live fetches.
- **Attribution & citations**: Bible Copyright & Attribution screen + in-context "(KJV/IRV)" citations on daily verse, scripture sheet, and daily-verse-sourced memory verses; attribution added to copy/share.
- **Audio practice**: replaced TTS of copyrighted verse text with on-screen text (TTS-of-copyright compliance).
- **Admin kill-switches**: two `feature_flags` (`bible_api_calls_enabled` operational, `bible_content_enabled` compliance) gating `fetch-verse`/`daily-verse`/refresh job; frontend hides Bible surfaces when content is off; admin "Purge cached Bible content" action (`purge_bible_content()` + route + button).

**`fix(subscription)`: paywall legal links** — functional Terms of Use (EULA) + Privacy Policy links on all subscription purchase screens (App Store Review Guideline 3.1.2(c)).

**`fix(payments)`** — gate the Razorpay key assertion to web builds so mobile/IAP builds don't crash on launch.

**`chore(ios)`** — remove the local StoreKit test config from the Runner scheme.

**`docs`** — app-wide RAG strategy + Voice Discipler RAG plan.

## Verification
- `deno test` / `deno check` (backend), admin `lint` + `type-check`, `flutter analyze` + `dart format` — all clean (pre-commit/pre-push hooks passed).
- Bible kill-switch feature reviewed end-to-end (spec compliance + security: purge `SECURITY DEFINER` + grants, admin auth, no API bypass, fail-open reads).

## Operational follow-ups (NOT in this PR — done in dashboards)
- Deploy migrations + functions; enable `pg_cron`/`pg_net` + Vault secrets to activate cron.
- Move API.Bible to a commercial plan; the compliance guide/runbook (gitignored `docs/compliance/`) has the steps.
- Apple resubmission: set Privacy Policy URL + EULA in App Store Connect, finish Paid Apps Agreement, rebuild iOS, reply with screen recording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Bible Copyright & Attribution screen and settings entry.
  * Added admin **“Purge Cached Bible Content”** action to clear cached daily verses and memory-verse text.
  * Added Terms of Use and Privacy Policy links across subscription flows, plus translation citations in verse references/sharing.
* **Bug Fixes**
  * Added Bible content/API kill-switches with “Bible content is temporarily unavailable” messaging.
  * Enforced 30-day Bible cache refresh with scheduled cleanup and stale memory-verse refresh.
* **Documentation**
  * Added RAG strategy planning documents.
* **Chores**
  * Updated receipt handling to support async iOS receipt extraction.
* **Tests**
  * Added tests for feature-flag fail-open behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->