### PR TITLE
fix(iap): idempotent subscription upsert for re-delivered purchase callbacks

### DIFF
--- a/backend/supabase/functions/_shared/services/receipt-validation-service.ts
+++ b/backend/supabase/functions/_shared/services/receipt-validation-service.ts
@@ -116,9 +116,14 @@ export async function validateAndProcessReceipt(
       throw new Error(`Subscription plan '${request.planCode}' not found — cannot create subscription without valid plan`)
     }
 
+    // Upsert (not insert): StoreKit/Google Play re-deliver the same purchase
+    // update multiple times. A plain insert collides on the unique
+    // provider_subscription_id and surfaces a spurious "something went wrong"
+    // even though the first call already activated the subscription. Upserting on
+    // provider_subscription_id makes re-delivery idempotent.
     const { data: subscription, error: subError } = await supabase
       .from('subscriptions')
-      .insert({
+      .upsert({
         user_id: request.userId,
         plan_id: planRow.id,
         plan_type: request.productId.includes('yearly')
@@ -133,8 +138,9 @@ export async function validateAndProcessReceipt(
         is_iap_subscription: true,
         iap_receipt_id: receiptRecord.id,
         iap_product_id: request.productId,
-        iap_original_transaction_id: originalTransactionId
-      })
+        iap_original_transaction_id: originalTransactionId,
+        updated_at: new Date().toISOString()
+      }, { onConflict: 'provider_subscription_id' })
       .select()
       .single()
 


### PR DESCRIPTION
## Summary

Final fix in the iOS StoreKit 2 in-app-purchase series (the first two — frontend App Store receipt + backend `APPLE_SHARED_SECRET` fallback — merged in #301).

**`fix(iap)`: idempotent subscription upsert**

StoreKit (and Google Play) re-deliver the same `purchase-updated` event multiple times. Subscription creation used a plain `INSERT`, so the second delivery collided on the unique `provider_subscription_id` and surfaced a spurious "Invalid purchase receipt / something went wrong" to the user — even though the first delivery had already activated the subscription.

Changed the insert to an **upsert on `provider_subscription_id`**, making re-delivered purchase callbacks idempotent (the repeat call returns the existing active subscription instead of erroring).

## Verified
End-to-end on a real iOS 18 device (Sandbox): fresh Premium purchase → receipt extracted (StoreKit 2) → backend `verifyReceipt` (status 0, active) → subscription created → **premium unlocked** (`isPremium: true`). The duplicate-callback error is the only remaining rough edge, which this fixes.

## Deploy note
Requires deploying `create-subscription-v2` (bundles `receipt-validation-service.ts`) to prod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced in-app purchase handling to prevent duplicate subscriptions when purchase notifications are re-delivered by payment providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->