### PR TITLE
feat(flags): add tester email bypass for disabled feature flags

### DIFF
--- a/admin-web/app/(dashboard)/system-config/page.tsx
+++ b/admin-web/app/(dashboard)/system-config/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { StatsCard } from '@/components/ui/stats-card'
@@ -79,6 +79,44 @@ export default function SystemConfigPage() {
     },
     enabled: activeTab === 'feature-flags'
   })
+
+  // Fetch Feature Testers
+  const { data: testersData } = useQuery({
+    queryKey: ['feature-testers'],
+    queryFn: async () => {
+      const res = await fetch('/api/admin/system/testers', { credentials: 'include' })
+      if (!res.ok) throw new Error('Failed to fetch testers')
+      return res.json() as Promise<{ emails: string[] }>
+    },
+    enabled: activeTab === 'system-config'
+  })
+
+  const [testerInput, setTesterInput] = useState('')
+
+  const saveTestersMutation = useMutation({
+    mutationFn: async (emails: string[]) => {
+      const res = await fetch('/api/admin/system/testers', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ emails })
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        throw new Error(err.error || 'Failed to save testers')
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      toast.success('Feature tester list saved')
+      queryClient.invalidateQueries({ queryKey: ['feature-testers'] })
+    },
+    onError: (e: Error) => toast.error(e.message)
+  })
+
+  useEffect(() => {
+    if (testersData?.emails) setTesterInput(testersData.emails.join('\n'))
+  }, [testersData])
 
   // Fetch Memory Verse Config
   const { data: memoryVerseData, isLoading: memoryVerseLoading } = useQuery({
@@ -618,6 +656,35 @@ export default function SystemConfigPage() {
             <li><strong>Memory Verses:</strong> <code className="bg-green-100 dark:bg-green-800 px-1 rounded">system_config</code> table (practice unlock limits, verse quotas, gamification)</li>
           </ul>
         </div>
+
+        {/* Feature Testers */}
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-6">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            🧪 Feature Testers
+          </h3>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            These emails can use feature flags marked &quot;Allow tester bypass&quot; even while the flag is disabled.
+            One email per line. Emails never leave the server.
+          </p>
+          <textarea
+            value={testerInput}
+            onChange={(e) => setTesterInput(e.target.value)}
+            rows={5}
+            placeholder={"tester1@example.com\ntester2@example.com"}
+            className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-mono text-sm"
+          />
+          <div className="flex justify-end mt-3">
+            <button
+              onClick={() => saveTestersMutation.mutate(
+                testerInput.split(/[\n,]/).map(e => e.trim()).filter(Boolean)
+              )}
+              disabled={saveTestersMutation.isPending}
+              className="px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 disabled:opacity-50"
+            >
+              {saveTestersMutation.isPending ? 'Saving…' : 'Save Testers'}
+            </button>
+          </div>
+        </div>
       </div>
     )
   }
@@ -774,6 +841,11 @@ export default function SystemConfigPage() {
                         }`}>
                           {flag.enabled ? 'Enabled' : 'Disabled'}
                         </span>
+                        {flag.allow_tester_bypass && (
+                          <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                            🧪 Tester bypass
+                          </span>
+                        )}
                       </div>
                       <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
                         {flag.description}

--- a/admin-web/app/(dashboard)/system-config/page.tsx
+++ b/admin-web/app/(dashboard)/system-config/page.tsx
@@ -92,6 +92,9 @@ export default function SystemConfigPage() {
   })
 
   const [testerInput, setTesterInput] = useState('')
+  // Track unsaved edits so a background refetch of the tester list doesn't
+  // clobber what the admin is currently typing.
+  const [testerInputDirty, setTesterInputDirty] = useState(false)
 
   const saveTestersMutation = useMutation({
     mutationFn: async (emails: string[]) => {
@@ -109,14 +112,20 @@ export default function SystemConfigPage() {
     },
     onSuccess: () => {
       toast.success('Feature tester list saved')
+      // Saved value is now authoritative — allow the refetch to re-seed the box.
+      setTesterInputDirty(false)
       queryClient.invalidateQueries({ queryKey: ['feature-testers'] })
     },
     onError: (e: Error) => toast.error(e.message)
   })
 
   useEffect(() => {
-    if (testersData?.emails) setTesterInput(testersData.emails.join('\n'))
-  }, [testersData])
+    // Only seed from server data when the admin has no unsaved edits, so a
+    // background refetch can't overwrite in-progress typing.
+    if (testersData?.emails && !testerInputDirty) {
+      setTesterInput(testersData.emails.join('\n'))
+    }
+  }, [testersData, testerInputDirty])
 
   // Fetch Memory Verse Config
   const { data: memoryVerseData, isLoading: memoryVerseLoading } = useQuery({
@@ -668,7 +677,7 @@ export default function SystemConfigPage() {
           </p>
           <textarea
             value={testerInput}
-            onChange={(e) => setTesterInput(e.target.value)}
+            onChange={(e) => { setTesterInput(e.target.value); setTesterInputDirty(true) }}
             rows={5}
             placeholder={"tester1@example.com\ntester2@example.com"}
             className="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 font-mono text-sm"

--- a/admin-web/app/api/admin/system/feature-flags/route.ts
+++ b/admin-web/app/api/admin/system/feature-flags/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: NextRequest) {
       enabled_for_plans: flag.enabled_for_plans || [],
       display_mode: flag.display_mode || 'hide',
       rollout_percentage: flag.rollout_percentage,
+      allow_tester_bypass: flag.allow_tester_bypass === true,
       metadata: flag.metadata
     }))
 
@@ -188,7 +189,8 @@ export async function PATCH(request: NextRequest) {
       is_enabled,
       enabled_for_plans,
       display_mode,
-      rollout_percentage
+      rollout_percentage,
+      allow_tester_bypass
     } = body
 
     if (!flag_id) {
@@ -247,6 +249,7 @@ export async function PATCH(request: NextRequest) {
     if (enabled_for_plans !== undefined) updateData.enabled_for_plans = enabled_for_plans
     if (display_mode !== undefined) updateData.display_mode = display_mode
     if (rollout_percentage !== undefined) updateData.rollout_percentage = rollout_percentage
+    if (allow_tester_bypass !== undefined) updateData.allow_tester_bypass = allow_tester_bypass === true
 
     // Update feature flag in database
     const { error: updateError } = await supabaseAdmin

--- a/admin-web/app/api/admin/system/testers/route.ts
+++ b/admin-web/app/api/admin/system/testers/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/lib/supabase/server'
+import { createClient as createAdminClient } from '@supabase/supabase-js'
+
+const CONFIG_KEY = 'feature_tester_emails'
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+async function requireAdmin() {
+  const supabaseUser = await createClient()
+  const { data: { user }, error: userError } = await supabaseUser.auth.getUser()
+  if (userError || !user) {
+    return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) }
+  }
+
+  const supabaseAdmin = createAdminClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
+  const { data: profile } = await supabaseAdmin
+    .from('user_profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single()
+
+  if (!profile?.is_admin) {
+    return { error: NextResponse.json({ error: 'Unauthorized - Admin access required' }, { status: 403 }) }
+  }
+
+  return { user, supabaseAdmin }
+}
+
+/**
+ * GET - Fetch the feature tester email list
+ */
+export async function GET(_request: NextRequest) {
+  try {
+    const auth = await requireAdmin()
+    if ('error' in auth) return auth.error
+
+    const { data, error } = await auth.supabaseAdmin
+      .from('system_config')
+      .select('value')
+      .eq('key', CONFIG_KEY)
+      .maybeSingle()
+
+    if (error) throw error
+
+    const emails = ((data?.value as string) || '')
+      .split(',')
+      .map(e => e.trim().toLowerCase())
+      .filter(Boolean)
+
+    return NextResponse.json({ emails })
+  } catch (error) {
+    console.error('[Testers API] GET error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * POST - Replace the feature tester email list
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const auth = await requireAdmin()
+    if ('error' in auth) return auth.error
+
+    const body = await request.json()
+    if (!Array.isArray(body.emails)) {
+      return NextResponse.json({ error: 'emails must be an array' }, { status: 400 })
+    }
+
+    const normalized = Array.from(new Set(
+      (body.emails as string[]).map(e => String(e).trim().toLowerCase()).filter(Boolean)
+    ))
+
+    const invalid = normalized.filter(e => !EMAIL_RE.test(e))
+    if (invalid.length > 0) {
+      return NextResponse.json(
+        { error: `Invalid email(s): ${invalid.join(', ')}` },
+        { status: 400 }
+      )
+    }
+
+    const { error } = await auth.supabaseAdmin
+      .from('system_config')
+      .upsert({
+        key: CONFIG_KEY,
+        value: normalized.join(','),
+        description: 'Comma-separated emails allowed to bypass feature flags that have allow_tester_bypass=true. Server-side only — never expose to clients.',
+        is_active: false,
+        updated_at: new Date().toISOString()
+      }, { onConflict: 'key' })
+
+    if (error) throw error
+
+    return NextResponse.json({ message: 'Feature tester list updated', emails: normalized })
+  } catch (error) {
+    console.error('[Testers API] POST error:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/admin-web/components/dialogs/edit-feature-flag-dialog.tsx
+++ b/admin-web/components/dialogs/edit-feature-flag-dialog.tsx
@@ -23,7 +23,8 @@ export default function EditFeatureFlagDialog({
     is_enabled: true,
     enabled_for_plans: [] as string[],
     display_mode: 'hide' as 'hide' | 'lock',
-    rollout_percentage: 100
+    rollout_percentage: 100,
+    allow_tester_bypass: false
   })
 
   useEffect(() => {
@@ -34,7 +35,8 @@ export default function EditFeatureFlagDialog({
         is_enabled: flag.enabled ?? true,
         enabled_for_plans: flag.enabled_for_plans || [],
         display_mode: (flag.display_mode || 'hide') as 'hide' | 'lock',
-        rollout_percentage: flag.rollout_percentage ?? 100
+        rollout_percentage: flag.rollout_percentage ?? 100,
+        allow_tester_bypass: flag.allow_tester_bypass ?? false
       })
     }
   }, [flag])
@@ -116,6 +118,26 @@ export default function EditFeatureFlagDialog({
                 </span>
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                   When disabled, feature is hidden from all users regardless of plan
+                </p>
+              </div>
+            </label>
+          </div>
+
+          {/* Tester Bypass */}
+          <div>
+            <label className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                checked={formData.allow_tester_bypass}
+                onChange={(e) => setFormData({ ...formData, allow_tester_bypass: e.target.checked })}
+                className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary"
+              />
+              <div>
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Allow tester bypass
+                </span>
+                <p className="text-xs text-gray-500 dark:text-gray-400">
+                  Emails in the Feature Testers list (System Config tab) see this feature as enabled even when it is disabled. Plan restrictions still apply.
                 </p>
               </div>
             </label>

--- a/backend/supabase/functions/_shared/core/function-factory.ts
+++ b/backend/supabase/functions/_shared/core/function-factory.ts
@@ -550,7 +550,8 @@ async function parseUserContext(
   return {
     type: user.is_anonymous ? 'anonymous' : 'authenticated',
     userId: user.is_anonymous ? undefined : user.id,
-    sessionId: user.is_anonymous ? user.id : undefined
+    sessionId: user.is_anonymous ? user.id : undefined,
+    email: user.is_anonymous ? undefined : (user.email ?? undefined)
   }
 }
 

--- a/backend/supabase/functions/_shared/middleware/feature-access-middleware.ts
+++ b/backend/supabase/functions/_shared/middleware/feature-access-middleware.ts
@@ -3,10 +3,25 @@
  *
  * Validates that users have access to restricted features before executing operations.
  * Prevents bypass attacks by enforcing server-side feature flag checks.
+ *
+ * Tester bypass: users whose email is in system_config.feature_tester_emails may
+ * use flags that have allow_tester_bypass=true even while globally disabled.
+ * Plan gating still applies to testers.
  */
 
 import { AppError } from '../utils/error-handler.ts'
-import { getFeatureFlags } from '../services/feature-flag-service.ts'
+import { getFeatureFlags, isTesterEmail } from '../services/feature-flag-service.ts'
+import type { FeatureFlag } from '../services/feature-flag-service.ts'
+
+/**
+ * A flag counts as enabled for this user if globally enabled, or if the flag
+ * opts into tester bypass and the user is a tester.
+ */
+async function isEnabledForUser(feature: FeatureFlag, userEmail?: string): Promise<boolean> {
+  if (feature.isEnabled) return true
+  if (!feature.allowTesterBypass || !userEmail) return false
+  return await isTesterEmail(userEmail)
+}
 
 /**
  * Check if user has access to a feature
@@ -14,24 +29,26 @@ import { getFeatureFlags } from '../services/feature-flag-service.ts'
  * @param userId - User ID
  * @param userPlan - User's subscription plan
  * @param featureKey - Feature key to check
+ * @param userEmail - Authenticated user's email (enables tester bypass)
  * @throws AppError if user lacks access
  *
  * @example
  * ```typescript
- * await checkFeatureAccess(userId, userPlan, 'ai_discipler')
+ * await checkFeatureAccess(userId, userPlan, 'ai_discipler', userContext.email)
  * ```
  */
 export async function checkFeatureAccess(
   userId: string,
   userPlan: string,
-  featureKey: string
+  featureKey: string,
+  userEmail?: string
 ): Promise<void> {
   // Fetch feature flags
   const featureFlags = await getFeatureFlags()
   const feature = featureFlags.find(f => f.featureKey === featureKey)
 
-  // Feature not found or disabled globally
-  if (!feature || !feature.isEnabled) {
+  // Feature not found or disabled globally (unless tester bypass applies)
+  if (!feature || !(await isEnabledForUser(feature, userEmail))) {
     console.log(`[FeatureAccess] Feature '${featureKey}' is disabled globally`)
     throw new AppError(
       'FEATURE_DISABLED',
@@ -81,6 +98,7 @@ export async function checkFeatureAccess(
  * @param userId - User ID
  * @param userPlan - User's subscription plan
  * @param featureKeys - Array of feature keys to check
+ * @param userEmail - Authenticated user's email (enables tester bypass)
  * @throws AppError if user lacks access to all features
  *
  * @example
@@ -90,13 +108,14 @@ export async function checkFeatureAccess(
  *   'standard_study_mode',
  *   'deep_dive_mode',
  *   'lectio_divina_mode'
- * ])
+ * ], userContext.email)
  * ```
  */
 export async function checkAnyFeatureAccess(
   userId: string,
   userPlan: string,
-  featureKeys: string[]
+  featureKeys: string[],
+  userEmail?: string
 ): Promise<void> {
   const featureFlags = await getFeatureFlags()
 
@@ -106,7 +125,11 @@ export async function checkAnyFeatureAccess(
   for (const featureKey of featureKeys) {
     const feature = featureFlags.find(f => f.featureKey === featureKey)
 
-    if (feature && feature.isEnabled && feature.enabledForPlans.includes(userPlan)) {
+    if (
+      feature &&
+      (await isEnabledForUser(feature, userEmail)) &&
+      feature.enabledForPlans.includes(userPlan)
+    ) {
       hasAccessToAny = true
       break
     }

--- a/backend/supabase/functions/_shared/services/__tests__/feature-flag-tester.test.ts
+++ b/backend/supabase/functions/_shared/services/__tests__/feature-flag-tester.test.ts
@@ -1,0 +1,77 @@
+import { assertEquals } from 'https://deno.land/std@0.208.0/assert/mod.ts'
+import {
+  normalizeEmail,
+  parseTesterEmails,
+  applyTesterBypass,
+  FeatureFlag,
+} from '../feature-flag-service.ts'
+
+function makeFlag(overrides: Partial<FeatureFlag> = {}): FeatureFlag {
+  return {
+    featureKey: 'enable_new_subscriptions',
+    featureName: 'New Subscriptions',
+    isEnabled: false,
+    enabledForPlans: ['free', 'standard', 'plus', 'premium'],
+    rolloutPercentage: 100,
+    displayMode: 'hide',
+    metadata: {},
+    allowTesterBypass: false,
+    ...overrides,
+  }
+}
+
+Deno.test('normalizeEmail lowercases and trims', () => {
+  assertEquals(normalizeEmail('  Fenn.Saji@GMAIL.com '), 'fenn.saji@gmail.com')
+})
+
+Deno.test('parseTesterEmails splits, normalizes, drops empties', () => {
+  assertEquals(
+    parseTesterEmails(' A@b.com, ,C@D.com ,'),
+    ['a@b.com', 'c@d.com']
+  )
+  assertEquals(parseTesterEmails(''), [])
+  assertEquals(parseTesterEmails(null), [])
+  assertEquals(parseTesterEmails(undefined), [])
+})
+
+Deno.test('applyTesterBypass: tester + toggle on -> enabled', () => {
+  const flags = [makeFlag({ isEnabled: false, allowTesterBypass: true })]
+  const result = applyTesterBypass(flags, true)
+  assertEquals(result[0].isEnabled, true)
+})
+
+Deno.test('applyTesterBypass: tester + toggle off -> unchanged', () => {
+  const flags = [makeFlag({ isEnabled: false, allowTesterBypass: false })]
+  const result = applyTesterBypass(flags, true)
+  assertEquals(result[0].isEnabled, false)
+})
+
+Deno.test('applyTesterBypass: non-tester -> unchanged', () => {
+  const flags = [makeFlag({ isEnabled: false, allowTesterBypass: true })]
+  const result = applyTesterBypass(flags, false)
+  assertEquals(result[0].isEnabled, false)
+})
+
+Deno.test('applyTesterBypass: does not disable already-enabled flags', () => {
+  const flags = [makeFlag({ isEnabled: true, allowTesterBypass: true })]
+  const result = applyTesterBypass(flags, true)
+  assertEquals(result[0].isEnabled, true)
+})
+
+Deno.test('applyTesterBypass: does not mutate input array', () => {
+  const flag = makeFlag({ isEnabled: false, allowTesterBypass: true })
+  applyTesterBypass([flag], true)
+  assertEquals(flag.isEnabled, false)
+})
+
+Deno.test('applyTesterBypass: plans and displayMode untouched', () => {
+  const flags = [makeFlag({
+    isEnabled: false,
+    allowTesterBypass: true,
+    enabledForPlans: ['premium'],
+    displayMode: 'lock',
+  })]
+  const result = applyTesterBypass(flags, true)
+  assertEquals(result[0].enabledForPlans, ['premium'])
+  assertEquals(result[0].displayMode, 'lock')
+})

--- a/backend/supabase/functions/_shared/services/auth-service.ts
+++ b/backend/supabase/functions/_shared/services/auth-service.ts
@@ -130,7 +130,8 @@ export class AuthService {
         type: user.is_anonymous ? 'anonymous' : 'authenticated',
         userId: user.is_anonymous ? undefined : user.id,
         sessionId: user.is_anonymous ? user.id : undefined,
-        userType
+        userType,
+        email: user.is_anonymous ? undefined : (user.email ?? undefined)
       }
       
       return userContext

--- a/backend/supabase/functions/_shared/services/feature-flag-service.ts
+++ b/backend/supabase/functions/_shared/services/feature-flag-service.ts
@@ -32,6 +32,7 @@ export interface FeatureFlag {
   rolloutPercentage: number // 0-100 (for future A/B testing)
   displayMode: 'hide' | 'lock' // How feature appears when user lacks access
   metadata: Record<string, any>
+  allowTesterBypass: boolean // Tester-email bypass opt-in (see feature_tester_emails)
 }
 
 interface CacheEntry {
@@ -110,6 +111,7 @@ async function fetchFeatureFlagsFromDB(): Promise<FeatureFlag[]> {
     rolloutPercentage: row.rollout_percentage || 100,
     displayMode: (row.display_mode || 'hide') as 'hide' | 'lock', // Default to 'hide' for backward compatibility
     metadata: row.metadata || {},
+    allowTesterBypass: row.allow_tester_bypass === true,
   }))
 
   return flags
@@ -255,4 +257,86 @@ export function getCacheStats(): { age: number; valid: boolean; count: number } 
     valid: isCacheValid(flagsCache),
     count: flagsCache?.data.length || 0,
   }
+}
+
+// ============================================================================
+// Tester Bypass (feature_tester_emails)
+// ============================================================================
+//
+// A global list of tester emails stored in system_config under key
+// 'feature_tester_emails' (comma-separated). Users on this list treat any
+// flag with allowTesterBypass=true as enabled, even when is_enabled=false.
+// Plan gating (enabledForPlans) and displayMode behavior are unchanged.
+// The list is server-side only — never include it in any response.
+
+interface TesterEmailsCacheEntry {
+  emails: string[]
+  timestamp: number
+}
+
+let testerEmailsCache: TesterEmailsCacheEntry | null = null
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function parseTesterEmails(raw: string | null | undefined): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map(normalizeEmail)
+    .filter(e => e.length > 0)
+}
+
+async function fetchTesterEmails(): Promise<string[]> {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from('system_config')
+    .select('value')
+    .eq('key', 'feature_tester_emails')
+    .maybeSingle()
+
+  if (error) {
+    console.error('[FeatureFlags] Error fetching tester emails:', error)
+    return [] // fail-safe: no bypass
+  }
+
+  return parseTesterEmails(data?.value as string | null)
+}
+
+/**
+ * Check whether an email is in the tester allowlist.
+ * Uses the same 5-minute TTL caching pattern as feature flags.
+ * Fail-safe: returns false on any error or for missing/anonymous emails.
+ */
+export async function isTesterEmail(email: string | null | undefined): Promise<boolean> {
+  if (!email) return false
+
+  const now = Date.now()
+  if (!testerEmailsCache || now - testerEmailsCache.timestamp >= CACHE_TTL_MS) {
+    testerEmailsCache = {
+      emails: await fetchTesterEmails(),
+      timestamp: now,
+    }
+  }
+
+  return testerEmailsCache.emails.includes(normalizeEmail(email))
+}
+
+/**
+ * Return a copy of the flags with tester bypass applied.
+ * When isTester is true, flags with allowTesterBypass=true are reported enabled.
+ * Pure transform — never mutates the (cached) input array.
+ */
+export function applyTesterBypass(flags: FeatureFlag[], isTester: boolean): FeatureFlag[] {
+  if (!isTester) return flags
+  return flags.map(flag =>
+    flag.allowTesterBypass && !flag.isEnabled
+      ? { ...flag, isEnabled: true }
+      : flag
+  )
+}
+
+export function clearTesterEmailsCache(): void {
+  testerEmailsCache = null
 }

--- a/backend/supabase/functions/_shared/types/index.ts
+++ b/backend/supabase/functions/_shared/types/index.ts
@@ -19,6 +19,7 @@ export interface UserContext {
   readonly userId?: string
   readonly sessionId?: string
   readonly userType?: 'admin' | 'user' // Admin users get premium access temporarily
+  readonly email?: string // Authenticated user's email (used for feature tester bypass)
 }
 
 /**

--- a/backend/supabase/functions/add-memory-verse-from-daily/index.ts
+++ b/backend/supabase/functions/add-memory-verse-from-daily/index.ts
@@ -90,7 +90,7 @@ async function handleAddMemoryVerseFromDaily(
 
   // Validate feature access for memory verses
   const userPlan = await services.authService.getUserPlan(req)
-  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses')
+  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses', userContext.email)
   console.log(`✅ [AddMemoryVerseFromDaily] Feature access validated for user ${userContext.userId}`)
 
   // Parse and validate request body

--- a/backend/supabase/functions/add-memory-verse-manual/index.ts
+++ b/backend/supabase/functions/add-memory-verse-manual/index.ts
@@ -141,7 +141,7 @@ async function handleAddMemoryVerseManual(
 
   // Validate feature access using middleware
   const userId = userContext.userId!
-  await checkFeatureAccess(userId, userPlan, 'memory_verses')
+  await checkFeatureAccess(userId, userPlan, 'memory_verses', userContext.email)
   console.log(`✅ [AddMemoryVerse] Feature access granted: memory_verses available for plan ${userPlan}`)
 
   // Parse request body

--- a/backend/supabase/functions/delete-memory-verse/index.ts
+++ b/backend/supabase/functions/delete-memory-verse/index.ts
@@ -46,7 +46,7 @@ async function handleDeleteMemoryVerse(
 
   // Validate feature access for memory verses
   const userPlan = await services.authService.getUserPlan(req)
-  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses')
+  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses', userContext.email)
 
   // Get memory_verse_id from query parameter
   const url = new URL(req.url)

--- a/backend/supabase/functions/learning-paths/index.ts
+++ b/backend/supabase/functions/learning-paths/index.ts
@@ -738,7 +738,7 @@ async function handleEnroll(
 
   // Check feature access for WRITE operations (enrollment)
   const userPlan = await services.authService.getUserPlan(req);
-  await checkFeatureAccess(userContext.userId, userPlan, 'learning_paths');
+  await checkFeatureAccess(userContext.userId, userPlan, 'learning_paths', userContext.email);
   console.log(`✅ [LearningPaths] Feature access granted for enrollment: learning_paths available for plan ${userPlan}`);
 
   const { supabaseServiceClient } = services;

--- a/backend/supabase/functions/study-generate/index.ts
+++ b/backend/supabase/functions/study-generate/index.ts
@@ -271,7 +271,7 @@ async function handleStudyGenerate(req: Request, services: ServiceContainer): Pr
   // Check if advanced mode requires feature access
   if (requestedMode in studyModeFeatures) {
     const featureKey = studyModeFeatures[requestedMode]
-    await checkFeatureAccess(userId, userPlan, featureKey)
+    await checkFeatureAccess(userId, userPlan, featureKey, userContext.email)
     console.log(`✅ [StudyGenerate] Advanced mode '${requestedMode}' validated for user ${userId}`)
   }
 

--- a/backend/supabase/functions/study-reflections/index.ts
+++ b/backend/supabase/functions/study-reflections/index.ts
@@ -87,7 +87,7 @@ async function handleReflections(
 
   // Feature flag validation - Check if reflections is enabled for user's plan
   const userId = userContext.userId!
-  await checkFeatureAccess(userId, userPlan, 'reflections')
+  await checkFeatureAccess(userId, userPlan, 'reflections', userContext.email)
   console.log(`✅ [Reflections] Feature access granted: reflections available for plan ${userPlan}`)
 
   // Route to appropriate handler based on HTTP method

--- a/backend/supabase/functions/submit-memory-practice/index.ts
+++ b/backend/supabase/functions/submit-memory-practice/index.ts
@@ -573,7 +573,7 @@ async function handleSubmitMemoryPractice(
 
   // Validate feature access for memory verses
   const userPlan = await services.authService.getUserPlan(req)
-  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses')
+  await checkFeatureAccess(userContext.userId, userPlan, 'memory_verses', userContext.email)
 
   // Parse request body
   let body: SubmitPracticeRequest

--- a/backend/supabase/functions/system-config/index.ts
+++ b/backend/supabase/functions/system-config/index.ts
@@ -49,9 +49,13 @@ Deno.serve(async (req) => {
     // feature_tester_emails allowlist, report allow_tester_bypass flags as enabled.
     // Endpoint stays public — no JWT means no bypass, same response as before.
     // Tester emails themselves are NEVER included in the response.
+    // Only resolve the caller when at least one flag actually opts into bypass —
+    // otherwise the getUser() round-trip can never change the response, and this
+    // is a public endpoint every client hits on startup.
     let testerBypassActive = false
     const authHeader = req.headers.get('Authorization')
-    if (authHeader?.startsWith('Bearer ')) {
+    const anyFlagAllowsBypass = featureFlags.some(f => f.allowTesterBypass)
+    if (anyFlagAllowsBypass && authHeader?.startsWith('Bearer ')) {
       try {
         const anonClient = createClient(
           Deno.env.get('SUPABASE_URL')!,

--- a/backend/supabase/functions/system-config/index.ts
+++ b/backend/supabase/functions/system-config/index.ts
@@ -10,7 +10,7 @@
  */
 
 import { getSystemConfig } from '../_shared/services/system-config-service.ts'
-import { getFeatureFlags } from '../_shared/services/feature-flag-service.ts'
+import { getFeatureFlags, isTesterEmail, applyTesterBypass } from '../_shared/services/feature-flag-service.ts'
 import { MemoryVerseConfigService } from '../_shared/services/memory-verse-config-service.ts'
 import { createClient } from 'jsr:@supabase/supabase-js@2'
 
@@ -45,6 +45,31 @@ Deno.serve(async (req) => {
     // Fetch feature flags (uses 5-min cache)
     const featureFlags = await getFeatureFlags()
 
+    // Tester bypass: if the caller sent a valid JWT and their email is in the
+    // feature_tester_emails allowlist, report allow_tester_bypass flags as enabled.
+    // Endpoint stays public — no JWT means no bypass, same response as before.
+    // Tester emails themselves are NEVER included in the response.
+    let testerBypassActive = false
+    const authHeader = req.headers.get('Authorization')
+    if (authHeader?.startsWith('Bearer ')) {
+      try {
+        const anonClient = createClient(
+          Deno.env.get('SUPABASE_URL')!,
+          Deno.env.get('SUPABASE_ANON_KEY')!,
+          { global: { headers: { Authorization: authHeader } }, auth: { autoRefreshToken: false, persistSession: false } }
+        )
+        const { data: { user } } = await anonClient.auth.getUser()
+        if (user && !user.is_anonymous && user.email) {
+          testerBypassActive = await isTesterEmail(user.email)
+        }
+      } catch (authError) {
+        // Invalid/expired token → treat as anonymous, no bypass. Never fail the endpoint.
+        console.warn('[SystemConfig] JWT resolution failed, continuing without bypass:', authError)
+      }
+    }
+
+    const resolvedFlags = applyTesterBypass(featureFlags, testerBypassActive)
+
     // Fetch memory verse config (uses 5-min cache)
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
@@ -54,7 +79,7 @@ Deno.serve(async (req) => {
 
     // Transform feature flags into simple object
     const flagsObject: Record<string, any> = {}
-    featureFlags.forEach(flag => {
+    resolvedFlags.forEach(flag => {
       flagsObject[flag.featureKey] = {
         enabled: flag.isEnabled,
         displayMode: flag.displayMode, // 'hide' | 'lock'
@@ -65,6 +90,7 @@ Deno.serve(async (req) => {
     console.log('[SystemConfig] Returning config:', {
       maintenanceModeEnabled: systemConfig.maintenanceModeEnabled,
       flagCount: featureFlags.length,
+      testerBypassActive,
       memoryVerseConfigLoaded: !!memoryVerseConfig,
     })
 
@@ -82,6 +108,7 @@ Deno.serve(async (req) => {
             forceUpdate: systemConfig.forceUpdateEnabled,
           },
           featureFlags: flagsObject,
+          testerBypassActive,
           memoryVerseConfig: {
             unlockLimits: memoryVerseConfig.unlockLimits,
             verseLimits: memoryVerseConfig.verseLimits,

--- a/backend/supabase/migrations/20260704000001_feature_tester_bypass.sql
+++ b/backend/supabase/migrations/20260704000001_feature_tester_bypass.sql
@@ -1,0 +1,32 @@
+-- Feature flag tester bypass (spec: docs/superpowers/specs/2026-07-04-feature-flag-tester-bypass-design.md)
+--
+-- 1) Per-flag opt-in: allow_tester_bypass — when true, users whose email is in
+--    the feature_tester_emails list see this flag as enabled even if is_enabled=false.
+-- 2) Global tester list: system_config key 'feature_tester_emails'
+--    (comma-separated, same server-side-only handling as 'admin_emails').
+--    Resolution happens ONLY server-side; this value is never returned by
+--    public endpoints (system-config Edge Function builds its own response
+--    and the get_system_configs() consumers never expose raw config rows to clients).
+
+ALTER TABLE feature_flags
+  ADD COLUMN IF NOT EXISTS allow_tester_bypass BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN feature_flags.allow_tester_bypass IS
+  'When true, emails in system_config.feature_tester_emails treat this flag as enabled even when is_enabled=false. Plan gating still applies.';
+
+-- is_active MUST be false here. system_config's public RLS policy
+-- (USING (is_active = true)) and the get_system_configs() RPC (granted to
+-- anon + authenticated) both expose every is_active=true row directly to
+-- the anon key via REST or rpc('get_system_configs'). Setting is_active =
+-- false keeps this row invisible to those generic public paths; it is only
+-- ever read by trusted service-role code (feature-flag-service.ts and the
+-- admin-web API route), which uses a service-role client that bypasses RLS
+-- entirely and does not filter on is_active.
+INSERT INTO system_config (key, value, description, is_active)
+VALUES (
+  'feature_tester_emails',
+  '',
+  'Comma-separated emails allowed to bypass feature flags that have allow_tester_bypass=true. Server-side only — never expose to clients.',
+  false
+)
+ON CONFLICT (key) DO NOTHING;

--- a/backend/supabase/migrations/20260704000001_feature_tester_bypass.sql
+++ b/backend/supabase/migrations/20260704000001_feature_tester_bypass.sql
@@ -3,10 +3,12 @@
 -- 1) Per-flag opt-in: allow_tester_bypass — when true, users whose email is in
 --    the feature_tester_emails list see this flag as enabled even if is_enabled=false.
 -- 2) Global tester list: system_config key 'feature_tester_emails'
---    (comma-separated, same server-side-only handling as 'admin_emails').
---    Resolution happens ONLY server-side; this value is never returned by
---    public endpoints (system-config Edge Function builds its own response
---    and the get_system_configs() consumers never expose raw config rows to clients).
+--    (comma-separated). Stored with is_active = false so it is NOT reachable
+--    via the public paths (see the is_active comment on the INSERT below).
+--    NOTE: unlike 'admin_emails' (which is stored is_active = true and IS
+--    therefore anon-readable via get_system_configs()/REST — a separate
+--    pre-existing exposure), this row is deliberately kept off those paths.
+--    Resolution happens ONLY server-side via trusted service-role reads.
 
 ALTER TABLE feature_flags
   ADD COLUMN IF NOT EXISTS allow_tester_bypass BOOLEAN NOT NULL DEFAULT false;

--- a/backend/supabase/migrations/20260704000002_hide_admin_emails_from_public.sql
+++ b/backend/supabase/migrations/20260704000002_hide_admin_emails_from_public.sql
@@ -1,0 +1,19 @@
+-- Close a pre-existing anon-key exposure of the admin email allowlist.
+--
+-- system_config has a public RLS SELECT policy (USING (is_active = true)) plus
+-- GRANT SELECT ... TO anon, and the get_system_configs() RPC (granted to anon +
+-- authenticated) returns every is_active = true row. The 'admin_emails' row was
+-- seeded with is_active = true, so any client holding only the public anon key
+-- could read the admin email list via:
+--   GET /rest/v1/system_config?key=eq.admin_emails
+--   POST /rest/v1/rpc/get_system_configs
+--
+-- admin_emails is only ever consumed server-side by autoGrantAdminIfEligible
+-- (user-profile Edge Function), which reads it with the service-role client
+-- (bypasses RLS, no is_active filter), so hiding it from the public paths does
+-- not affect the admin auto-grant. Mirror the feature_tester_emails handling.
+
+UPDATE system_config
+SET is_active = false,
+    updated_at = NOW()
+WHERE key = 'admin_emails';

--- a/frontend/lib/core/services/system_config_service.dart
+++ b/frontend/lib/core/services/system_config_service.dart
@@ -28,6 +28,7 @@ class SystemConfigService extends ChangeNotifier {
   SystemConfig? _config;
   DateTime? _lastFetch;
   String? _error;
+  StreamSubscription<AuthState>? _authSubscription;
 
   // Getters
   bool get isLoading => _isLoading;
@@ -37,6 +38,10 @@ class SystemConfigService extends ChangeNotifier {
 
   /// Check if app is in maintenance mode
   bool get isMaintenanceModeActive => _config?.maintenanceMode.enabled ?? false;
+
+  /// Whether the current signed-in user has feature tester bypass active
+  /// (resolved server-side; true only when their email is in the tester list).
+  bool get isTesterBypassActive => _config?.testerBypassActive ?? false;
 
   /// Get maintenance mode message
   String get maintenanceModeMessage =>
@@ -70,6 +75,26 @@ class SystemConfigService extends ChangeNotifier {
       }
 
       _isInitialized = true;
+
+      // Refetch config when the signed-in user changes: tester bypass is
+      // resolved server-side per user, so cached flags are per-identity.
+      _authSubscription ??= _supabase.auth.onAuthStateChange.listen((state) {
+        final event = state.event;
+        if (event == AuthChangeEvent.signedOut) {
+          Logger.debug(
+              '🔄 [SystemConfigService] Auth change ($event) — clearing cache and refreshing config');
+          // Clear persisted + in-memory cache first so a failed refetch after
+          // logout can't leave the previous user's tester-resolved flags visible.
+          clearCache().then((_) => fetchSystemConfig(forceRefresh: true));
+        } else if (event == AuthChangeEvent.signedIn ||
+            event == AuthChangeEvent.userUpdated) {
+          Logger.debug(
+              '🔄 [SystemConfigService] Auth change ($event) — refreshing config');
+          _lastFetch = null; // Invalidate memory cache
+          fetchSystemConfig(forceRefresh: true);
+        }
+      });
+
       Logger.debug('✅ [SystemConfigService] Initialization complete');
     } catch (e) {
       _error = 'Failed to initialize system config: $e';
@@ -272,6 +297,12 @@ class SystemConfigService extends ChangeNotifier {
     return feature?.enabled ?? true;
   }
 
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    super.dispose();
+  }
+
   // Private helper methods
 
   bool _shouldRefresh() {
@@ -363,12 +394,14 @@ class SystemConfig {
   final VersionControl versionControl;
   final Map<String, FeatureFlag> featureFlags;
   final MemoryVerseConfig memoryVerseConfig;
+  final bool testerBypassActive;
 
   SystemConfig({
     required this.maintenanceMode,
     required this.versionControl,
     required this.featureFlags,
     required this.memoryVerseConfig,
+    this.testerBypassActive = false,
   });
 
   factory SystemConfig.fromJson(Map<String, dynamic> json) {
@@ -380,6 +413,7 @@ class SystemConfig {
       memoryVerseConfig: json['memoryVerseConfig'] != null
           ? MemoryVerseConfig.fromJson(json['memoryVerseConfig'])
           : MemoryVerseConfig.defaultConfig(),
+      testerBypassActive: json['testerBypassActive'] ?? false,
     );
   }
 
@@ -390,6 +424,7 @@ class SystemConfig {
       'featureFlags':
           featureFlags.map((key, value) => MapEntry(key, value.toJson())),
       'memoryVerseConfig': memoryVerseConfig.toJson(),
+      'testerBypassActive': testerBypassActive,
     };
   }
 }

--- a/frontend/lib/core/services/system_config_service.dart
+++ b/frontend/lib/core/services/system_config_service.dart
@@ -19,6 +19,11 @@ import '../utils/logger.dart';
 class SystemConfigService extends ChangeNotifier {
   static const String _cacheKey = 'system_config_cache';
   static const String _cacheTimestampKey = 'system_config_cache_timestamp';
+  // The cached config is identity-specific (testerBypassActive + bypass-resolved
+  // flags are per-user), so the cache is tagged with the user id that produced
+  // it. A cold start under a different account (initialSession, which the auth
+  // listener does not fire on) must not serve the previous user's resolved flags.
+  static const String _cacheUserKey = 'system_config_cache_user';
   static const Duration _cacheDuration = Duration(minutes: 5);
 
   final SupabaseClient _supabase = Supabase.instance.client;
@@ -316,6 +321,17 @@ class SystemConfigService extends ChangeNotifier {
       final cachedJson = prefs.getString(_cacheKey);
       final cachedTimestamp = prefs.getInt(_cacheTimestampKey);
 
+      // Discard a cache produced by a different identity — serving another
+      // user's tester-resolved flags (even briefly) is wrong. Leaving _config
+      // null makes _shouldRefresh() true so initialize() refetches immediately.
+      final cachedUserId = prefs.getString(_cacheUserKey);
+      final currentUserId = _supabase.auth.currentUser?.id;
+      if (cachedJson != null && cachedUserId != currentUserId) {
+        Logger.debug(
+            'ℹ️ [SystemConfigService] Cached config belongs to a different user — discarding, will refetch');
+        return;
+      }
+
       if (cachedJson != null && cachedTimestamp != null) {
         final cacheAge =
             DateTime.now().millisecondsSinceEpoch - cachedTimestamp;
@@ -347,6 +363,13 @@ class SystemConfigService extends ChangeNotifier {
       await prefs.setString(_cacheKey, jsonEncode(_config!.toJson()));
       await prefs.setInt(
           _cacheTimestampKey, DateTime.now().millisecondsSinceEpoch);
+      // Tag the cache with the identity that produced it (null for anon).
+      final currentUserId = _supabase.auth.currentUser?.id;
+      if (currentUserId != null) {
+        await prefs.setString(_cacheUserKey, currentUserId);
+      } else {
+        await prefs.remove(_cacheUserKey);
+      }
 
       Logger.debug('✅ [SystemConfigService] Saved to cache');
     } catch (e) {
@@ -376,6 +399,7 @@ class SystemConfigService extends ChangeNotifier {
       final prefs = await SharedPreferences.getInstance();
       await prefs.remove(_cacheKey);
       await prefs.remove(_cacheTimestampKey);
+      await prefs.remove(_cacheUserKey);
 
       _config = null;
       _lastFetch = null;


### PR DESCRIPTION
## Summary

Adds a global tester-email allowlist plus a per-flag opt-in, letting a small set of trusted testers use flags that are globally disabled in production — without affecting any other user.

- `system_config.feature_tester_emails` — comma-separated tester allowlist (server-side only, kept off the public RLS/RPC path via `is_active=false`)
- `feature_flags.allow_tester_bypass` — per-flag opt-in toggle
- Backend: `feature-flag-service.ts` resolves bypass (fail-safe, 5-min cache); `system-config` Edge Function returns `testerBypassActive` server-side via JWT; `checkFeatureAccess`/`checkAnyFeatureAccess` middleware enforce it, with plan gating (`FEATURE_LOCKED`) still applying normally
- Frontend: `SystemConfigService` parses `testerBypassActive`, refetches config on auth state change
- Admin web: "Allow tester bypass" toggle on each flag + a "Feature Testers" card to manage the email list

## Security notes

Two independent instances of the same bug were caught during review and fixed before merge: an admin-editable `system_config` row for the tester list was set `is_active=true`, which would have made the tester email list publicly readable via the `get_system_configs()` RPC (gated only on `is_active=true`). Fixed in both the initial migration and the admin API route; the latter now explicitly sets `is_active: false` on every write as defense in depth.

Verified end-to-end against a local Supabase instance with real minted JWTs: anonymous → disabled, tester → enabled+bypass, non-tester → disabled with no leakage.

## Test plan

- [ ] Add your email to Feature Testers in the admin panel
- [ ] Toggle "Allow tester bypass" on a disabled flag (e.g. `enable_new_subscriptions`)
- [ ] Confirm your account sees it enabled while a non-tester account does not
- [ ] Confirm anonymous/unauthenticated requests never see bypass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Feature Testers** admin setting to manage an email allowlist for feature access.
  * Feature flags can now be configured with **Tester Bypass** and display an indicator when active for a tester.
  * Public system configuration responses now include **tester bypass status** for signed-in users.
* **Bug Fixes**
  * Feature access checks now honor tester allowlisting for eligible emails across app flows.
  * Tester bypass status stays correctly in sync on sign-in, sign-out, and session updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->