### PR TITLE
docs(marketing): Season 1 growth additions, PreWeek1 bridge, Prompts library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -493,3 +493,5 @@ target/
 .guides/
 
 secrets/*
+
+docs/marketing/Content_Playbook_Season1/PDF/

--- a/docs/marketing/Content_Playbook_Season1/Content_Playbook_PreWeek1_Bridge.md
+++ b/docs/marketing/Content_Playbook_Season1/Content_Playbook_PreWeek1_Bridge.md
@@ -1,0 +1,105 @@
+# Disciplefy Content Playbook — Season 1: Foundations of Faith
+## Pre-Week 1 — Weekend Bridge
+Version: 2.0 *(updated — see Changelog)*
+
+## Mission
+The Launch carousel already posted Friday, and Week 1's 4 how-to Reels don't start until Monday — that left Saturday and Sunday as dead air right after the launch, when interest is highest. This bridges the gap by reusing 2 of the already-built How-To Carousels (from `Instagram_Launch_and_HowTo_Carousels.md` / `Instagram_Carousel_Image_Prompts.md`) that Week 1 no longer needs in carousel form, since it covers those same features as Reels instead.
+
+## Why Carousel + Reel for the same feature is fine
+Different jobs: Reel = reach/discovery (new people), Carousel = depth/reference (saves, step-by-step detail). Posting the Carousel version Sat/Sun and the Reel version Mon/Tue isn't repetition — it's covering two audience behaviors, 2+ days apart (no same-day feed competition). This also restores the swipeable step-by-step detail that got traded away when Week 1 switched its How-Tos to Reel format.
+
+## Content Funnel
+Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install → Bible Study → Spiritual Growth
+
+---
+
+## 🎨 Carousel Image Generation — STYLE BLOCK (prepend to every slide prompt below)
+> Premium, warm, bright slide designed as one frame in a multi-slide, swipeable Instagram carousel for a Christian discipleship app called Disciplefy. Portrait 4:5 (1080×1350). Soft cream/off-white background (`#FAF8F5`) bathed in bright natural window light — airy, cozy, inviting. Warm wooden desk with tasteful props (open Bible, ceramic coffee mug, small potted plant, leather journal with pen), softly sunlit. Bold near-black charcoal (`#1E1E1E`) headline in Poppins, left-aligned; short subline in warm gray. Gold accents (`#B8860B` / `#C79A3B`) for logo, icons, dividers, and key words. Brand frame: gold Disciplefy logo + thin gold divider top-left; gold globe icon + "disciplefy.in" bottom-left. No dark/moody look, clutter, cheesy stock, distorted text, or clip-art crosses. Only the cover slide (Slide 1) gets the gold "Swipe →" cue.
+
+**Step slides:** attach the actual Disciplefy app screenshot as a reference image for each Step slide and instruct the model to use it exactly, not redesign or regenerate the UI — same approach as the Outro logo prompts in `Week1_Reel_Intro_Outro_Google_Flow_Prompts.md`. Don't leave the screen blank for later compositing; let the generation place the real screenshot into the mockup directly.
+
+## 📖 Daily Verse — Morning Story Image Generation
+Same 7 rotating layout variants as `Content_Playbook_Season1_Week1.md` — Saturday uses **Variant F (Side-by-Side)**, Sunday uses **Variant G (Vertical Bookmark)**. Full variant specs and shared brand rules live there, not repeated here.
+
+---
+
+## Saturday — 💡 How To: Generate a Study Guide (Carousel)
+**Format:** Carousel, 6 slides (reused from `Instagram_Carousel_Image_Prompts.md` POST 2 — not regenerated, already built)
+**Bible Verse:** Psalm 119:105 — "Your word is a lamp to my feet and a light to my path."
+
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Open Bible, ceramic coffee mug, small plant, leather journal with pen near a window with warm natural light. Headline: "Don't know where to start your Bible study?" Small gold book icon + subline "A simple way to understand God's Word." Gold "Swipe →" cue bottom-right. | So many of us open the Bible and freeze — too many books, too many places to start. Here's a simple tool built to help you actually understand what you're reading, not just read it. Swipe to see how it works → |
+| 2 — Step 1 | Smartphone mockup on warm wooden desk, small plant nearby. Screen shows the attached Generate-screen screenshot (real bottom-nav label is "Generate," not "Study" — reference image provided, use exactly). Gold "Step 1" badge. Headline: "Open the Generate Tab." | Everything starts in the Generate tab — one tap and you're ready to dig into any part of Scripture. |
+| 3 — Step 2 | Smartphone mockup, ceramic mug nearby. Screen shows the attached screenshot of typing a verse/topic, e.g. "Romans 8:28" (reference image provided). Gold "Step 2" badge. Headline: "Type Any Verse or Topic." | Type literally anything — a reference like Romans 8:28, or just what's on your heart: "anxiety," "forgiveness," whatever you're wrestling with. |
+| 4 — Step 3 | Smartphone mockup, open Bible nearby. Screen shows the attached screenshot of the study-mode picker (real: 5 named modes — Quick Read, Standard Study, Deep Dive, Lectio Divina, Sermon Outline — not a 2-way toggle; this is chosen before generating, reference image provided). Gold "Step 3" badge. Headline: "Pick Your Mode." | Only have 5 minutes? Pick Quick Read. Want to go deeper? Choose Deep Dive — or Lectio Divina, or a full Sermon Outline. Same passage, your pace. |
+| 5 — Step 4 | Smartphone mockup gently floating, small plant nearby. Screen shows the attached screenshot of the generated Study Guide — topic title, Summary section, with "Listen" and "Ask Discipler" buttons at the bottom (reference image provided). Gold "Step 4" badge. Headline: "Your Study, Ready." | One tap on Generate and you get a full breakdown — summary, context, and a way to keep exploring with Discipler. |
+| 6 — CTA | Warm morning sunlight over a wooden desk, open Bible + mug. Headline: "Any verse. Any topic. A full study." Subline: "Try it free → link in bio." | That's it — no guesswork, no blank page. Try it free today, link in bio. |
+
+**Caption:** Open the Bible and freeze on where to start? Type any verse or topic — get a full study guide (context, key verses, reflection, application) in seconds. Free on Web & Android — link in bio.
+**Hashtags:** #Disciplefy #BibleStudy #StudyGuide #BibleApp
+
+**Stories (2x/day):**
+- Morning: 📖 Verse — Psalm 119:105 + 💡 Tip — "Not sure where to start? Type whatever's on your heart, not just a reference."
+  - **Daily Verse Image Prompt fill (Variant F — Side-by-Side):** VERSE: "Your word is a lamp to my feet and a light to my path." · REFERENCE: "Psalm 119:105" · BACKGROUND: "Morning desk with Bible, soft lamp glow."
+- Evening: Share the Carousel + 📖 Reflection — Try generating a study guide for one verse today.
+
+**CTA:** Try it free → link in bio.
+**KPI:** Saves · Shares
+
+---
+
+## Sunday — 🚶 How To: Learning Paths (Carousel)
+**Format:** Carousel, 5 slides *(trimmed from 6 — the old Step 2 + Step 3 described the same single screenshot, just "scrolled"; collapsed into one real step)*
+**Bible Verse:** Hebrews 12:1 — "let us run with endurance the race that is set before us."
+
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Open Bible + a journal with a small hand-drawn list/steps, mug and plant nearby, sunlit. Headline: "Studying random verses and not really growing?" Small gold path/steps icon + subline "Follow a path instead." Gold "Swipe →" cue bottom-right. | Ever feel like you study a verse here, a verse there, but never actually grow? Random reading doesn't build on itself — a guided path does. Swipe to see how → |
+| 2 — Step 1 | Smartphone mockup on warm wooden desk, small plant nearby. Screen shows the attached screenshot of the Topics tab — the browse list of available Learning Paths (real tab, confirmed; reference image provided, use exactly). Gold "Step 1" badge. Headline: "Open the Topics Tab." | Find them all in the Topics tab, organized and ready whenever you are. |
+| 3 — Step 2 | Smartphone mockup, ceramic mug nearby. Screen shows the attached screenshot of a Learning Path's detail screen — one single screenshot: title, level badge (e.g. "Seeker"), stats row (Topics · XP · days), "Start Path" button, and the numbered topics list below it, each tagged with a category and XP, some marked "Milestone" (real: topic count is dynamic per path, e.g. 16 — not a fixed "1→8"; reference image provided, use exactly). Gold "Step 2" badge. Headline: "See the Whole Path." | Every path lays out its topics with XP and milestones up front — no guessing what's next. |
+| 4 — Step 3 | Smartphone mockup, open journal nearby. Screen shows the attached screenshot of an individual topic's Study Guide screen — topic title, Summary section, "Listen" and "Ask Discipler" buttons at the bottom (reference image provided). Gold "Step 3" badge. Headline: "Open a Topic." | Tap into any topic and you're studying — same Study Guide experience, no separate app or setup. |
+| 5 — CTA | Warm morning sunlight over a wooden desk, open Bible + mug. Headline: "Stop wandering. Start a path." Subline: "Free → link in bio." | Growth isn't random — it's a path. Start yours free, link in bio. |
+
+**Caption:** Growth isn't random verses — it's a path. Learning Paths walk you through Scripture step by step so you always know what's next. Free — link in bio. Follow for more of these walkthroughs. 🌱
+**Hashtags:** #Disciplefy #Discipleship #SpiritualGrowth #BibleStudy
+
+**Stories (2x/day):**
+- Morning: 📖 Verse — Hebrews 12:1 + 🙏 Prayer — "Lord, keep me from wandering — walk me step by step in Your Word."
+  - **Daily Verse Image Prompt fill (Variant G — Vertical Bookmark):** VERSE: "Let us run with endurance the race that is set before us." · REFERENCE: "Hebrews 12:1" · BACKGROUND: "Mountain sunrise, a path winding through."
+- Evening: Share the Carousel + 📖 Reflection — Which topic would you want a guided path for?
+
+**CTA:** Free → link in bio.
+**KPI:** Saves · Shares
+
+---
+
+## Note on Week 1 overlap
+Monday and Tuesday of `Content_Playbook_Season1_Week1.md` cover these same two features again — as Reels, not Carousels. That's intentional (see "Why Carousel + Reel" above), not a duplicate mistake. Memory Verses and Discipler carousels (POST 4 and POST 5) are used the same way in `Content_Playbook_Season1_Week3.md` (Tuesday) and `Content_Playbook_Season1_Week4.md` (Tuesday) — swapped in for that week's Bible Tips slot, 2 days ahead of that week's matching Saturday reel.
+
+## Growth Additions (2026)
+Full detail in `Content_Playbook_Season1_Week1.md` → "Growth Additions" — this bridge's Follow-CTA slot is Sunday's carousel caption (done above). Trending-audio note doesn't apply (no Daniel Reels this bridge). Stories sticker guidance still applies — add one to either day's Evening slot, not both.
+
+## Production Rhythm
+Both carousels are already fully built (`Instagram_Carousel_Image_Prompts.md`) — no new generation needed beyond compositing real screenshots into the Step slides, same as they were always going to need.
+
+## Success Metrics
+Track: Saves · Shares · Profile Visits · Website Clicks · App Installs.
+
+---
+
+## Changelog
+- **v1.1:** Removed all on-slide text/badge-rendering from the image prompts (headline/subline/step-number now explicitly added in Canva, not generated) — matches house convention that AI-rendered text is unreliable. Step slides changed from "blank screen, composite screenshot later" to "attach the real screenshot as a reference image and generate it in directly."
+- **v1.2:** Reverted v1.1's text split — the generation tool in use here renders text reliably, so headline/subline/step-badge text goes back directly in the prompt, no separate Canva column. Screenshot-reference-image instruction for Step slides stays (that's a different concern — the model still can't invent the real app UI).
+- **v1.3:** Added a per-slide Caption to both carousels — Instagram now supports a distinct caption per carousel image (rolled out June 2026), shown as viewers swipe. Captions add commentary/context beyond the on-image headline text, not a repeat of it.
+- **v1.4:** Step slides (2-5 in both carousels) previously had only a "Step N" badge, no headline — added a short on-image headline to each so every slide carries real text, not just Cover/CTA.
+- **v1.5:** Corrected screenshot-content assumptions against the real app UI (verified via screenshots + code): "Study tab" → real label is "Generate"; "Quick/Deep mode toggle" → real UI is a 5-mode picker (Quick Read, Standard Study, Deep Dive, Lectio Divina, Sermon Outline); Learning Paths "lessons 1→8 + progress bar" → real screen shows a dynamic-count numbered topic list with XP and milestone badges (e.g. 16 topics), not a fixed count.
+- **v1.6:** Sunday's 4 step slides had Step 1 ("learning path overview") and Step 3 ("pick a path, see what's next") both vaguely describing the same real screen (the Learning Path Detail page: title, level badge, stats, Start Path button, topics list). Re-mapped to the 2 actual confirmed screens: Step 1 = Topics tab (browse list), Step 2 = Path Detail header/stats/Start Path, Step 3 = that same screen's topics list scrolled down, Step 4 = an individual topic's Study Guide (Summary + Listen/Ask Discipler buttons).
+- **v1.7:** Caught that v1.6's Step 2 and Step 3 were still the same single screenshot (stats/Start Path + topics list appear together, not two scroll states) — merged into one slide. Sunday's carousel is now 5 slides, not 6: Cover → Topics tab → Path Detail (one screenshot) → Study Guide → CTA.
+- **v1.8:** Saturday's carousel had the mode picker (Step 4) placed *after* the generated result (Step 3) — backwards, and Step 3's headline ("Tap Generate") didn't match its own screen (the result, not the tap). Reordered: type verse → pick mode → view generated result (with real Listen/Ask Discipler buttons).
+- **v1.9:** Memory Verses and Discipler carousels (POST 4/5) are no longer just "reserved for later" — they're now live in `Content_Playbook_Season1_Week3.md` and `Week4.md`, swapped into that week's Tuesday slot 2 days ahead of the matching Saturday reel. Updated the cross-reference note accordingly.
+- **v2.0:** Added a Follow-CTA to Sunday's Learning Paths caption and a "Growth Additions (2026)" pointer section (full detail lives in Week 1).

--- a/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week1.md
+++ b/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week1.md
@@ -1,6 +1,6 @@
 # Disciplefy Content Playbook — Season 1: Foundations of Faith
 ## Week 1 — Launch Week
-Version: 3.0 *(rewritten — see Changelog)*
+Version: 3.9 *(rewritten — see Changelog)*
 
 ## Mission of the Week
 Get the app in front of people and prove it works — before teaching the deeper "reading vs. studying" theme that Weeks 2-4 build on. Week 1 is 4 screen-recording How-To Reels (the Launch post itself already went out Friday before this formal week), not the regular Bible Explained/Bible Tips rhythm — that rhythm starts fresh in Week 2 (see `Content_Playbook_Season1_Week2.md`).
@@ -15,22 +15,71 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
+## 🎬 Video Generation Prompts — Intro / Outro (Google Flow / Veo)
+Reusable across all 4 Monday-Thursday Reels — the same two generated clips bookend every video; only the real Disciplefy screen-recording in the middle changes per day. Full detail also kept standalone at `Week1_Reel_Intro_Outro_Google_Flow_Prompts.md` — this section embeds the same prompts directly so this file is self-contained.
+
+**STYLE BLOCK (prepend to both prompts below):**
+> Premium, warm, cinematic short video clip for a Christian discipleship app called **Disciplefy**, used as an Instagram Reel intro/outro segment. Portrait **9:16**. Warm, golden-hour or soft window lighting — reverent, peaceful, hopeful, premium. **Slow, intentional pacing**: fade, slow zoom, soft dissolve, gentle light bloom. **No** fast cuts, whip pans, spinning, or aggressive animation. Setting: a quiet home or coffee-shop workspace, warm wood tones, soft natural light, subtle film grain, organic feel — never overly sharp or artificial. **No other apps, phone UI, or on-screen branding besides Disciplefy's own logo where explicitly noted.** Avoid: cheesy stock-photo feel, clip-art crosses, corporate look, garbled text.
+
+**Intro prompt (reusable, ~3-5s):**
+> No people in frame — a still-life scene on a warm wooden desk in soft morning window light: an open physical Bible, a ceramic coffee mug with gentle steam, a small potted plant, a leather journal with a pen resting on it. Slow, gentle camera push-in or soft pan across the desk. Warm, cinematic, reverent, quiet mood. No text rendered in-clip — each day's specific hook line (see that day's Script/Timeline) is added as a text overlay in edit.
+
+**Outro prompt (reusable, ~3-4s):**
+> Warm, premium closing card for Disciplefy. Soft cream/warm-gold gradient background with gentle light bloom. **Use the attached logo image** (gold open-book-with-cross icon + "Disciplefy" wordmark) — it gently fades and rises into the center of frame with a soft glow, no harsh motion, keeping the logo's real shape and type intact (don't regenerate or redraw it). Logo only — no additional text; the caption already carries "link in bio."
+
+*Attach the actual logo file as a reference image in Google Flow when generating the Outro — don't let the model invent its own logo, AI-drawn logos/text are unreliable. If it distorts when animated, generate the empty gradient card instead and composite the real static logo on top in edit.*
+
+## 🖼️ Thumbnail Image Generation — STYLE BLOCK (prepend to each day's thumbnail prompt below)
+> Premium, warm thumbnail frame for a Disciplefy Instagram Reel. Portrait **9:16 (1080×1920)**, safe-zone aware — keep the headline and focal object clear of the top ~250px and bottom ~250px (reserved for Instagram's own UI overlays). Soft cream background (`#FAF8F5`) bathed in natural window light. Bold near-black charcoal (`#1E1E1E`) headline, Poppins 700, **maximum five words**. One clear focal object only — no busy collage, no clutter. One small gold (`#B8860B`) accent only (icon, divider, or bookmark ribbon) — gold should never dominate. Brand frame: small gold Disciplefy logo top-left with a thin gold divider beneath; small gold globe icon + "disciplefy.in" bottom-left. **Never:** red arrows, shock faces, clickbait expressions, clip-art crosses, busy collages.
+
+## 📖 Daily Verse — Morning Story Image Generation
+Adapted from `Prompts/Daily Bible Verse v2.md` (issues resolved: no Material 3/indigo, AI-imagery contradiction reworded, typography in the documented 600-700 range, IG safe-zone added) — but **not one fixed layout every day**. Instead, 7 distinct layout variants, one locked to each weekday, so the series stays visually fresh day-to-day while each weekday builds its own recognizable sub-identity (canonical set — reused across all 4 weeks, only Verse/Reference/Background change).
+
+**Shared across every variant (brand consistency, never varies):**
+> Christian discipleship app Disciplefy, Instagram Story, 1080×1920 (9:16). Warm, peaceful, premium, minimal, cinematic, Scripture-first. Photorealistic — must not look AI-generated, illustrated, or fantasy-styled. Color palette: cream `#FAF8F5` · gold accent `#B8860B`/`#C79A3B` · heading charcoal `#1E1E1E` · body `#4B5563`. Poppins Bold (heading/reference, 600-700 weight) · Inter Medium (verse text) — never shrink text for a long verse, grow the card/space instead. Disciplefy logo used exactly as uploaded, never regenerated. Keep logo, heading, and footer clear of the top ~250px / bottom ~250px IG Story safe zones. No people, no hands, no distracting objects — Scripture stays the visual hero. *(English-only for now — Hindi/Malayalam need a separate font pairing, not yet defined.)*
+
+**Monday — Variant A: Classic Card**
+> Realistic background scene per `{{BACKGROUND}}`, softly lit. Centered scripture card (~55% of frame), rounded 12px, warm gold background, soft shadow, large quotation-mark icon, reference at top, verse centered, generous padding. Top: logo + gold divider + "Today's Verse" heading. Bottom: "disciplefy.in" + small gold divider.
+
+**Tuesday — Variant B: Full-Bleed Photo Overlay**
+> Full-bleed photorealistic scene per `{{BACKGROUND}}` filling the entire frame — no separate card. Verse and reference overlaid directly on the photo in the bottom third, sitting on a soft gold-tinted gradient scrim (dark-to-transparent) for readability. Small logo top-left, no heading text needed. More editorial/cinematic than Monday's card style.
+
+**Wednesday — Variant C: Split Layout**
+> Frame split horizontally: top 60% is the photorealistic scene per `{{BACKGROUND}}`; bottom 40% is a solid warm-cream panel holding the verse + reference in charcoal text, with a thin gold divider marking the split. Logo small, top-left, sitting over the photo section.
+
+**Thursday — Variant D: Minimalist Typography**
+> No photo — solid warm cream background or a very soft cream-to-gold gradient. Large gold quotation mark, verse in big centered Inter Medium type, reference in gold Poppins Bold beneath, generous whitespace all around. Logo small, top-center. Words are the hero this day, a deliberate change of pace from the photo-driven variants.
+
+**Friday — Variant E: Framed Photo**
+> A single photorealistic scene per `{{BACKGROUND}}`, styled as a framed photograph or polaroid-style card, very slightly tilted, soft drop shadow, resting on a warm cream background. Verse + reference sit beneath the framed photo like a caption. Small gold pin or clip accent at the photo's top edge. Logo small, top-left of the whole frame.
+
+**Saturday — Variant F: Side-by-Side**
+> Frame split vertically down the middle: left half is a soft off-white verse card (reference top, verse centered, quotation icon) on cream; right half is the photorealistic scene per `{{BACKGROUND}}`. Thin vertical gold divider between the two halves. Logo small, top-left over the card half.
+
+**Sunday — Variant G: Vertical Bookmark**
+> A tall, narrow "bookmark"-shaped card (rounded top, tapered bottom point) centered on a softly blurred, warm photorealistic background per `{{BACKGROUND}}`. Verse + reference run down the bookmark in elegant vertical-feeling spacing. Small gold tassel or ribbon detail at the bookmark's top. Logo small, top-left of the whole frame. Reflective, quieter mood fitting Sunday.
+
+---
+
 ## Monday — 💡 How To: Generate a Study Guide
 **Format:** Reel — real screen recording + Founder voice-over
 **Bible Verse:** Psalm 119:105 — "Your word is a lamp to my feet and a light to my path."
 
-**Thumbnail:** "A FULL BIBLE STUDY IN SECONDS"
+**Thumbnail:** "A Full Study In Seconds" *(trimmed to 5 words from the original 6-word draft to meet the thumbnail rule)*
+**Thumbnail Image Prompt** *(prepend the Thumbnail STYLE BLOCK above)*:
+> Headline: "A Full Study In Seconds." Scene: a single open Bible resting on a warm wooden desk in soft morning light, a smartphone lying face-up beside it with only a soft warm glow on its blank screen (no rendered app UI), a gold ribbon bookmark draped across the Bible's open page, a ceramic coffee mug and small potted plant nearby.
 
 **Script / Timeline (~40s) — intro, then straight into Disciplefy only (no other app shown), outro at the end:**
+
 | Time | Section | Screen | Voice-over |
 |---|---|---|---|
 | 0:00-0:03 | INTRO | On-screen text over simple b-roll (open physical Bible, no app): "Don't know where to start your Bible study?" | "Ever open your Bible and just... freeze?" |
 | 0:03-0:08 | INTRO | B-roll: flipping through a physical Bible, unsure | "Reading is easy. Knowing what it means? Not so much." |
-| 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap the Study tab | "That's where Disciplefy's Study Guide comes in." |
+| 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap the Generate tab (real bottom-nav label is "Generate," screen titled "Generate Study Guide") | "That's where Disciplefy's Study Guide comes in." |
 | 0:12-0:20 | DISCIPLEFY | Type "Romans 8:28" (or "anxiety") into the search field | "Type any verse — or even just what's on your heart, like 'anxiety.'" |
-| 0:20-0:24 | DISCIPLEFY | Tap Generate, loading animation | "Tap Generate—" |
-| 0:24-0:32 | DISCIPLEFY | Scroll through summary, context, key verses, reflection questions, application | "—and get a full study: context, key verses, questions to reflect on, and how to apply it." |
-| 0:32-0:36 | DISCIPLEFY | Toggle Quick / Deep mode | "Five minutes, or go deep — your choice." |
+| 0:20-0:24 | DISCIPLEFY | Open the study-mode picker (real modes: Quick Read, Standard Study, Deep Dive, Lectio Divina, Sermon Outline — not a 2-way toggle; chosen before generating) | "Five minutes, or go deep — your choice." |
+| 0:24-0:28 | DISCIPLEFY | Tap Generate, loading animation | "Tap Generate—" |
+| 0:28-0:36 | DISCIPLEFY | Scroll through the generated Study Guide — summary, key verses, reflection questions | "—and get a full study: context, key verses, questions to reflect on, and how to apply it." |
 | 0:36-0:40 | OUTRO | Gold CTA card, on-screen text: "Try it free — link in bio." | "Any verse. Any topic. A full study, in seconds. Free — link in bio." |
 
 **Caption:** Open the Bible and freeze on where to start? Type any verse or topic — get a full study guide (context, key verses, reflection, application) in seconds. Free on Web & Android — link in bio.
@@ -38,6 +87,7 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Psalm 119:105 + 💡 Tip — "Not sure where to start? Type whatever's on your heart, not just a reference."
+  - **Daily Verse Image Prompt fill (Variant A — Classic Card):** VERSE: "Your word is a lamp to my feet and a light to my path." · REFERENCE: "Psalm 119:105" · BACKGROUND: "Morning desk with Bible, soft lamp glow."
 - Evening: Share the Reel + 📖 Reflection — Try generating a study guide for one verse today.
 
 **CTA:** Try it free → link in bio.
@@ -49,17 +99,20 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 **Format:** Reel — real screen recording + Founder voice-over
 **Bible Verse:** Hebrews 12:1 — "let us run with endurance the race that is set before us."
 
-**Thumbnail:** "STOP WANDERING. START A PATH."
+**Thumbnail:** "Stop Wandering. Start A Path."
+**Thumbnail Image Prompt** *(prepend the Thumbnail STYLE BLOCK above)*:
+> Headline: "Stop Wandering. Start A Path." Scene: an open Bible on a warm wooden desk, soft morning light. A thin gold dotted line traces a gentle winding path across the visible page like a subtle highlighted trail (elegant and abstract, not a literal map or illustration), leading toward a small potted plant at the edge of frame.
 
 **Script / Timeline (~40s) — intro, then straight into Disciplefy only (no other app shown), outro at the end:**
+
 | Time | Section | Screen | Voice-over |
 |---|---|---|---|
 | 0:00-0:03 | INTRO | On-screen text over simple b-roll (open physical Bible, no app): "Studying random verses and not really growing?" | "Ever feel like you're studying... but going nowhere?" |
 | 0:03-0:08 | INTRO | B-roll: flipping between unrelated chapters in a physical Bible | "Random verses don't build on each other." |
 | 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap the Topics tab | "Learning Paths fix that." |
 | 0:12-0:20 | DISCIPLEFY | Scroll through path options (Foundations, Prayer, Grace...) | "Pick a guided journey — Foundations, Prayer, Grace, and more." |
-| 0:20-0:28 | DISCIPLEFY | Tap into a path, show lessons 1→8 with progress bar | "Each one has 8 lessons, so you always know exactly where you are." |
-| 0:28-0:35 | DISCIPLEFY | Open lesson 1, scroll content, tap Complete | "Every lesson builds on the last — real growth, not just random reading." |
+| 0:20-0:28 | DISCIPLEFY | Tap into a path, show its numbered topic list with XP per topic and a milestone badge (real: topic count is dynamic per path, e.g. 16 — not a fixed number, no literal "progress bar" on this screen) | "Each path lays out exactly what's next, so you always know where you are." |
+| 0:28-0:35 | DISCIPLEFY | Open topic 1, scroll content, tap Complete | "Every topic builds on the last — real growth, not just random reading." |
 | 0:35-0:40 | OUTRO | On-screen text: "Free — link in bio." | "Stop wandering. Start a path — free, link in bio." |
 
 **Caption:** Growth isn't random verses — it's a path. Learning Paths walk you through Scripture step by step so you always know what's next. Free — link in bio. 🌱
@@ -67,6 +120,7 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Hebrews 12:1 + 🙏 Prayer — "Lord, keep me from wandering — walk me step by step in Your Word."
+  - **Daily Verse Image Prompt fill (Variant B — Full-Bleed Photo Overlay):** VERSE: "Let us run with endurance the race that is set before us." · REFERENCE: "Hebrews 12:1" · BACKGROUND: "Mountain sunrise, a path winding through."
 - Evening: Share the Reel + 📖 Reflection — Which topic would you want a guided path for?
 
 **CTA:** Free → link in bio.
@@ -78,16 +132,19 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 **Format:** Reel — real screen recording + Founder voice-over
 **Bible Verse:** Psalm 119:11 — "I have stored up your word in my heart, that I might not sin against you."
 
-**Thumbnail:** "MAKE IT STICK"
+**Thumbnail:** "Make It Stick"
+**Thumbnail Image Prompt** *(prepend the Thumbnail STYLE BLOCK above)*:
+> Headline: "Make It Stick." Scene: a small handwritten verse card tucked between the pages of an open Bible on a warm wooden desk, a single gold paperclip holding it in place, soft morning light. A few more identical small verse cards fanned slightly beside it, implying repetition and practice.
 
 **Script / Timeline (~42s) — intro, then straight into Disciplefy only (no other app shown), outro at the end:**
+
 | Time | Section | Screen | Voice-over |
 |---|---|---|---|
 | 0:00-0:03 | INTRO | On-screen text over simple b-roll (no app): "Memorize a verse… forget it in a week?" | "Ever memorize a verse... and lose it a week later?" |
 | 0:03-0:08 | INTRO | B-roll: person trying to recall a verse, blank look | "Most of us do — memorizing without a system doesn't stick." |
-| 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap Memory Verse, tap Add Verse | "Disciplefy's Memory Verse feature is built to make it stick." |
+| 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap the Memory Verses icon on the Home screen (real: reached from a Home-screen icon, not a bottom-nav tab), tap Add Verse | "Disciplefy's Memory Verse feature is built to make it stick." |
 | 0:12-0:20 | DISCIPLEFY | Search and add a verse | "Add any verse you want to learn." |
-| 0:20-0:28 | DISCIPLEFY | Cycle through flip cards, word bank, fill-in-the-blank | "Practice it with flip cards, a word bank, or fill-in-the-blank." |
+| 0:20-0:28 | DISCIPLEFY | Cycle through a few practice modes — flip cards, word bank, fill-in-the-blank (real: 3 of 8 actual modes, a representative sample, not exhaustive) | "Practice it with flip cards, a word bank, or fill-in-the-blank." |
 | 0:28-0:33 | DISCIPLEFY | Notification popup: review reminder | "It reminds you right before you'd forget — not just once." |
 | 0:33-0:38 | DISCIPLEFY | Show the green streak heat map | "And this streak keeps you consistent." |
 | 0:38-0:42 | OUTRO | On-screen text: "Free — link in bio." | "Hide His Word in your heart. Free — link in bio." |
@@ -97,6 +154,7 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Psalm 119:11 + 💡 Tip — "Pick one short verse this week and practice it daily — consistency beats cramming."
+  - **Daily Verse Image Prompt fill (Variant C — Split Layout):** VERSE: "I have stored up your word in my heart, that I might not sin against you." · REFERENCE: "Psalm 119:11" · BACKGROUND: "Coffee and Bible, warm morning light."
 - Evening: Share the Reel + 📖 Reflection — Which verse are you memorizing first?
 
 **CTA:** Free → link in bio.
@@ -108,26 +166,32 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 **Format:** Reel — real screen recording + Founder voice-over
 **Bible Verse:** 1 Peter 3:15 — "always being prepared to make a defense to anyone who asks you for a reason for the hope that is in you."
 
-**Thumbnail:** "JUST ASK OUT LOUD"
+**Thumbnail:** "Just Ask Out Loud"
+**Thumbnail Image Prompt** *(prepend the Thumbnail STYLE BLOCK above)*:
+> Headline: "Just Ask Out Loud." Scene: a smartphone resting upright on a warm wooden desk with a soft gold soundwave glow emanating gently from its screen (implying a voice moment, no rendered UI), an open Bible beside it, warm bright lamp-glow lighting — warm and inviting, not dark or moody.
 
 **Script / Timeline (~40s) — intro, then straight into Disciplefy only (no other app shown), outro at the end:**
+
 | Time | Section | Screen | Voice-over |
 |---|---|---|---|
 | 0:00-0:03 | INTRO | On-screen text over simple b-roll (no app): "A faith question at midnight — and no one to ask?" | "Ever have a faith question... and no one to ask?" |
 | 0:03-0:08 | INTRO | B-roll: person alone at night, holding phone | "Some questions can't wait for Sunday." |
-| 0:08-0:12 | DISCIPLEFY | Open Disciplefy, tap into the Discipler | "Meet your Voice Discipler." |
+| 0:08-0:12 | DISCIPLEFY | Open a generated Study Guide, tap "Ask Discipler" (real button, bottom of the Study Guide screen next to "Listen" — this is the real entry point, confirmed against actual app screenshots) | "Meet your Discipler." |
 | 0:12-0:20 | DISCIPLEFY | Tap the mic, speak: "How do I forgive someone who hurt me?" | "Tap the mic, and just ask — out loud, like you would a friend." |
 | 0:20-0:30 | DISCIPLEFY | Scroll through the Scripture-grounded response | "It answers — grounded in Scripture, every time." |
 | 0:30-0:36 | DISCIPLEFY | On-screen text: "A companion, not a replacement." | "A companion for your walk — not a replacement for your pastor or church." |
-| 0:36-0:40 | OUTRO | On-screen text: "Free — link in bio." | "Real questions. Biblical answers. Anytime. Free — link in bio." |
+| 0:36-0:40 | OUTRO | On-screen text: "Free — link in bio." | "Real questions. Biblical answers. Anytime. Free — link in bio. And follow for a new faith question every week." |
 
-**Caption:** Faith question, no one to ask right now? Tap the mic, ask out loud — get a Scripture-grounded answer. A companion for your walk, not a replacement for your pastor or church. Free — link in bio. 🙏
+*This week's Follow-CTA slot (see Growth Additions below) — the added line is a soft ask, not a hard sell; doesn't replace the app CTA, just tacks on at the very end.*
+
+**Caption:** Faith question, no one to ask right now? Tap the mic, ask out loud — get a Scripture-grounded answer. A companion for your walk, not a replacement for your pastor or church. Free — link in bio. Follow for more real questions, answered. 🙏
 **Hashtags:** #Disciplefy #Discipleship #VoiceDiscipler #FaithQuestions
 
 **Theology-safe note:** Discipler copy must always frame it as a companion that points back to Scripture and community — never a replacement for pastor, church, or the Bible itself.
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — 1 Peter 3:15 + 🙏 Prayer — "Lord, give me courage to ask hard questions and to keep seeking You for the answers."
+  - **Daily Verse Image Prompt fill (Variant D — Minimalist Typography):** VERSE: "Always being prepared to make a defense to anyone who asks you for a reason for the hope that is in you." · REFERENCE: "1 Peter 3:15" · BACKGROUND: "Library, quiet study corner (used for logo/mood only — Variant D has no photo)."
 - Evening: Share the Reel + 📖 Reflection — What's a faith question you've never asked out loud?
 
 **CTA:** Free → link in bio.
@@ -150,11 +214,40 @@ Same as Friday — open this week only. Standing Saturday "Study With Disciplefy
 
 **Slides:** Cover ("Disciplefy launched this week — here's everything it can do") → recap the 4 features (Study Guide, Learning Paths, Memory Verses, Discipler) → one practical takeaway → invite to church/community → Disciplefy CTA
 
+**🎨 STYLE BLOCK (prepend to every slide prompt below)** — same warm Marketing/Social system as `Instagram_Carousel_Image_Prompts.md`:
+> Premium, warm, bright slide designed as one frame in a multi-slide, swipeable Instagram carousel for a Christian discipleship app called Disciplefy. Portrait 4:5 (1080×1350). Soft cream/off-white background (`#FAF8F5`) bathed in bright natural window light — airy, cozy, inviting. Warm wooden desk with tasteful props (open Bible, ceramic coffee mug, small potted plant, leather journal with pen), softly sunlit. Bold near-black charcoal (`#1E1E1E`) headline, Poppins, left-aligned; short subline in warm gray. Gold accents (`#B8860B` / `#C79A3B`) for logo, icons, dividers, and key words. Brand frame: gold Disciplefy logo + thin gold divider top-left; gold globe icon + "disciplefy.in" bottom-left. No dark/moody look, clutter, cheesy stock, distorted text, or clip-art crosses.
+
+**Slide 1 — Cover:**
+> Bright, cozy sunlit desk scene (as per STYLE BLOCK). Bold charcoal headline: "One Week In: Everything Disciplefy Can Do." Warm-gray subline: "A recap, in case you missed a day." Small gold accent icon (open book).
+
+**Caption (on-slide text):** Disciplefy launched this week — here's everything it can do, swipe through in case you missed a day.
+
+**Slide 2 — What's Inside recap:**
+> Bright cream background, airy and clean. A balanced 2×2 grid of four minimalist gold line-icons, each on a soft off-white rounded card with a subtle shadow: (1) open book "Study Guides", (2) winding path "Learning Paths", (3) bookmark with heart "Memory Verses", (4) microphone with soundwave "Voice Discipler" — icons in gold, labels in charcoal. Small charcoal heading at top: "This Week's Features." Elegant, evenly spaced.
+
+**Caption (on-slide text):** Four features, one goal: help you actually study Scripture, not just skim it — Study Guides, Learning Paths, Memory Verses, and Voice Discipler.
+
+**Slide 3 — One practical takeaway:**
+> Bright cream scene, warm window light, a single open Bible with a leather journal and pen beside it. Bold charcoal headline: "Try Just One Feature This Week." Warm-gray subline: "You don't need to use all four today — pick one." Small gold arrow accent.
+
+**Caption (on-slide text):** Don't feel like you need to use all four today. Pick just one and start there this week.
+
+**Slide 4 — Invite to church/community:**
+> Warm, hopeful scene: soft Sunday-morning light through a window, a person's silhouette or just an empty warm room with a coat and Bible by the door (implying heading out), gentle golden glow. Bold charcoal headline: "Carry It Into Worship Today." Small warm-gray subline referencing Hebrews 10:24-25 ("...encouraging one another..."). No literal church building needed — keep it intimate and personal.
+
+**Caption (on-slide text):** Whatever stood out to you this week, bring it into worship today — that's where it's meant to be lived out.
+
+**Slide 5 — CTA:**
+> Bright, hopeful closing scene: warm morning sunlight over a wooden desk with an open Bible and mug, soft golden glow. Bold charcoal headline: "Missed a Post This Week?" with a gold arrow →. Smaller warm-gray line beneath: "Catch up — link in bio."
+
+**Caption (on-slide text):** If you missed a post this week, no worries — catch up any time. Link in bio.
+
 **Caption:** This week Disciplefy went live — a study guide for any verse, a path to follow, verses that stick, and questions you can finally ask out loud. Today, carry it into worship. Send this to a friend heading to church today. 🙏
 **Hashtags:** #Disciplefy #SundayReflection #Worship #BibleStudy #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Hebrews 10:25 + 🙏 Prayer — "Lord, thank You for this week's launch. Help me carry it into worship today."
+  - **Daily Verse Image Prompt fill (Variant G — Vertical Bookmark):** VERSE: "...not neglecting to meet together, as is the habit of some, but encouraging one another..." · REFERENCE: "Hebrews 10:24-25" · BACKGROUND: "Church pew, soft morning light through a window."
 - Evening: Share Carousel + 📖 Reflection — Which of this week's 4 features will you try first?
 
 **CTA:** Missed a post this week? Catch up — link in bio.
@@ -166,6 +259,20 @@ Same as Friday — open this week only. Standing Saturday "Study With Disciplefy
 - Feed cadence this week is 4 Reels (Mon-Thu) + 1 Carousel (Sun), Fri/Sat open — reel-heavy on purpose, since reach + proof-of-feature was this week's actual goal, not the season's normal 4 Reel/3 Carousel balance. That balance resumes Week 2.
 - Watch time (incl. replays) is the #1 ranking signal for all 4 Reels this week — each hook must land in the first ~3s, and a short loop-worthy ending helps more than a longer runtime.
 - Shares (DM sends) are the strongest distribution trigger — every post above already carries a share-worthy CTA or invite line.
+
+## Growth Additions (2026) — canonical, referenced by Weeks 2-4 and PreWeek1
+Three tactics not yet baked into the plan before this update — reach (discovery) and follows (conversion) are different problems, these split across both:
+
+**1. Follow-CTA (conversion) — once per week, not every post.** Asking to follow on every single post reads as needy and gets tuned out. One rotating slot per week, always the week's highest-reach/highest-engagement post:
+- Week 1: Thursday's Discipler Reel outro (done above — soft-tacked-on line, doesn't replace the app CTA)
+- Week 2: Saturday's Episode 2 Reel
+- Week 3: Saturday's Episode 9 ⭐ Hero Reel
+- Week 4: Saturday's Episode 13 ⭐ Hero Reel
+- PreWeek1: Sunday's Learning Paths carousel, CTA slide caption
+
+**2. Trending audio (reach) — Daniel Reels only, when it actually fits.** Check Instagram's trending-audio tab weekly; layer a soft trending instrumental under the narration *only* if the mood matches (warm, reverent, unhurried) — skip the week entirely if nothing fits rather than forcing a mismatched trend for reach. Doesn't apply to Mon-Thu's screen-recording Reels this week (voice-over + real UI audio takes priority there).
+
+**3. Stories interactive stickers (reach + engagement) — 2-3x/week, not daily.** Add a poll or question sticker to the Evening Story slot on the days it fits naturally (e.g. "Did you try this today? Yes/No," "What stood out to you?"). Stories has its own discovery mechanic separate from the main feed — currently every Evening slot is pure broadcast (share + reflection prompt), no interactivity. Don't do it daily — it dilutes and starts feeling like a survey, not a devotional.
 - Real screen-recordings count as original content, same as AI-generated Reels — full distribution credit.
 
 ## Production Rhythm
@@ -184,3 +291,10 @@ Ignore vanity metrics. Focus on helping more believers take one step closer to b
 - **v3.0:** Switched the 4 How-To posts (Mon-Thu) from Carousel to real screen-recording Reel — better reach and install-driving trust than static screenshots for this specific goal. This made Friday's Episode 1 reel redundant with Monday's new Study Guide Reel, so it was dropped (the story arc still starts at Episode 2 in Week 2, nothing lost). Friday and Saturday are open this week as a result.
 - **v3.1:** Replaced each Reel's one-line "Demo flow" with a full timestamped Script/Timeline (screen action + voice-over per beat) — production-ready instead of a bullet summary. On-screen text kept minimal (hook line + CTA card only, per Visual Bible's "large captions, minimal overlays") — the steps themselves are carried by voice-over + real screen action, not per-step text overlays.
 - **v3.2:** Intro/problem beats no longer show a generic screen recording (was ambiguous, read like "another app") — now simple non-app b-roll (physical Bible, person) or on-screen text only. Every script is now explicitly Intro (no app) → Disciplefy screen recording only → Outro (CTA card).
+- **v3.3:** Added detailed generation prompts for everything that isn't a real screen recording: a shared Google Flow/Veo Intro + Outro video prompt section (embedded here, not just linked), a Thumbnail STYLE BLOCK + one detailed thumbnail image prompt per Mon-Thu Reel (also trimmed Monday's thumbnail text from 6 to 5 words to meet the Visual Bible's thumbnail rule), and full STYLE BLOCK + 5 slide-by-slide image prompts for Sunday's Reflection Carousel (previously just a topic outline, no actual generation prompts).
+- **v3.4:** Added a Daily Verse Story image-generation template (adapted from `Prompts/Daily Bible Verse v2.md` with its flagged issues resolved) plus a per-day Verse/Reference/Background fill for every Morning Story this week — previously the Morning Stories named a verse reference but had no actual image prompt to generate the card.
+- **v3.5:** Replaced the single fixed Daily Verse layout with 7 distinct variants, one locked to each weekday (Classic Card, Full-Bleed Photo Overlay, Split Layout, Minimalist Typography, Framed Photo, Side-by-Side, Vertical Bookmark) — per direction, the verse card shouldn't look identical every day. Canonical set, reused by Weeks 2-4.
+- **v3.6:** Added a per-slide Caption to Sunday's carousel — Instagram now supports a distinct caption per carousel image (rolled out June 2026), shown as viewers swipe. Captions add commentary/context beyond the on-image headline text, not a repeat of it.
+- **v3.7:** Corrected screen-recording script assumptions against the real app UI/screenshots: "Study tab" → real label is "Generate"; "Quick/Deep mode toggle" → real UI is a 5-mode picker (Quick Read, Standard Study, Deep Dive, Lectio Divina, Sermon Outline), not a 2-way switch; Learning Paths "lessons 1→8 with progress bar" → real screen shows a dynamic-count numbered topic list with XP and milestone badges (e.g. 16 topics), no fixed count or literal progress bar; Discipler entry point corrected to "Ask Discipler" button on a generated Study Guide (confirmed via screenshot), not a generic "tap into the Discipler"; Memory Verse practice-mode line clarified as a 3-of-8 sample, not exhaustive; Memory Verse entry point clarified as a Home-screen icon, not a nav tab.
+- **v3.8:** Monday's Reel had the mode picker placed *after* tapping Generate and viewing results — backwards, since you pick a mode before generating. Reordered: type verse → pick mode → tap Generate → view results.
+- **v3.9:** Added "Growth Additions (2026)" — canonical section covering 3 tactics not previously in the plan: (1) Follow-CTA rotated once/week on the highest-reach post (this week: Thursday's Discipler Reel), (2) trending audio on Daniel Reels where mood fits, (3) Stories interactive stickers 2-3x/week. Weeks 2-4 and PreWeek1 reference this section rather than repeating it.

--- a/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week2.md
+++ b/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week2.md
@@ -1,11 +1,32 @@
 # Disciplefy Content Playbook — Season 1: Foundations of Faith
 ## Week 2
+Version: 1.5 *(updated — see Changelog)*
 
 ## Mission of the Week
 This is the first week of the season's regular named-series rhythm (Week 1 was the Launch + How-To set — see `Content_Playbook_Season1_Week1.md`). Each series' topic bank (`Daily Devotion/`) starts at item #1 this week.
 
 ## Content Funnel
 Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install → Bible Study → Spiritual Growth
+
+---
+
+## 🎬 Video Generation — Daniel Reel STYLE BLOCK (Mon / Wed / Fri)
+Reusable across all 3 AI-generated Reels this week (Bible Explained, Walking with Jesus, Growing in Christ) — these are full Google Flow/Veo generations, not screen recordings. Per `Prompts/Daily Devotions.md`'s meta-prompt: 8 clips × 5 seconds = 40s, one Google Flow/Veo prompt + one voice-over line per clip.
+
+**Visual Style (every clip):** Premium cinematic Christian lifestyle. Apple-commercial quality, photorealistic live action, authentic Indian environment, warm golden-hour grading, soft natural lighting, natural performances, vertical 9:16, 4K, 24fps. No CGI, no fantasy, no AI artifacts, no fast cuts/whip pans/spinning.
+
+**Character — Daniel** *(canonical bio, per `Prompts/Daily Devotions.md` — keep identical every clip)*: Young Indian professional (26-30), neatly styled short black hair, clean shaven, warm medium-brown skin, navy Oxford shirt, dark chinos, brown leather watch, calm/thoughtful/gentle, usually reading Scripture before work. Never looks into camera, never acknowledges camera, never speaks to audience.
+
+**Story Structure (all 8 clips follow this purpose order):** 1 Hook · 2 Introduce biblical truth · 3 Explain truth · 4 Deepen understanding · 5 Real-life application · 6 Encouragement (prayer/Scripture/nature) · 7 Invitation to reflect · 8 Hopeful conclusion (leave negative space top-third for the Disciplefy end-screen logo, added in edit — no text/logo in the generated clip itself).
+
+## 🖼️ Thumbnail Image Generation — STYLE BLOCK (prepend to each day's thumbnail prompt below)
+> Premium, warm thumbnail frame for a Disciplefy Instagram Reel. Portrait 9:16 (1080×1920), safe-zone aware — keep headline and focal object clear of the top ~250px and bottom ~250px (Instagram UI overlay zones). Soft cream background (`#FAF8F5`) bathed in natural window light. Bold near-black charcoal (`#1E1E1E`) headline, Poppins 700, maximum five words. One clear focal object only. One small gold (`#B8860B`) accent only. Brand frame: small gold Disciplefy logo top-left with thin gold divider; small gold globe + "disciplefy.in" bottom-left. Never: red arrows, shock faces, clickbait expressions, clip-art crosses, busy collages.
+
+## 🎨 Carousel Image Generation — STYLE BLOCK (prepend to each slide prompt, Tue / Thu / Sun)
+> Premium, warm, bright slide, one frame in a multi-slide swipeable Instagram carousel for Disciplefy. Portrait 4:5 (1080×1350). Soft cream background (`#FAF8F5`), bright natural window light, warm wooden desk with tasteful props (open Bible, coffee mug, small plant, leather journal). Bold near-black charcoal (`#1E1E1E`) headline, Poppins, left-aligned; warm-gray subline. Gold accents (`#B8860B` / `#C79A3B`) — no indigo. Brand frame: gold logo + divider top-left, gold globe + "disciplefy.in" bottom-left. No dark/moody look, clutter, distorted text, or clip-art crosses.
+
+## 📖 Daily Verse — Morning Story Image Generation
+Same 7 layout variants as `Content_Playbook_Season1_Week1.md` (Variant A Monday through Variant G Sunday, full detail there — not repeated here) — each weekday keeps its own recognizable sub-style rather than one fixed layout every day. Only Verse/Reference/Background change per day; shared brand rules (palette, typography, logo, safe zones) also defined in Week 1.
 
 ---
 
@@ -18,13 +39,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 **Production:** Google Flow / Veo AI, 40s
 **Structure:** Hook → Problem → Biblical Truth → Application → CTA
 **Visual style:** Modern Indian apartment, morning sunlight, open Bible, coffee, notebook, Daniel as recurring character
-**Thumbnail:** "REST FOR YOUR SOUL"
+**Thumbnail:** "Rest For Your Soul"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Rest For Your Soul." Scene: an open Bible on a warm wooden desk turned to Matthew 11, morning light, a folded pair of reading glasses resting on the page, a small gold accent divider beneath the headline.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "Ever feel like faith is just... one more thing you have to do?" | Daniel in his apartment kitchen at dawn, tired expression, reaching for his phone as notifications stack up, warm morning light through the window. |
+| 2 | Introduce truth | "Jesus said something different: 'Come to me, and I will give you rest.'" | Daniel sits at his desk, opens his Bible to Matthew 11, morning light falling across the page. |
+| 3 | Explain truth | "He wasn't offering an escape from life — He was offering Himself." | Close-up on the open Bible page, Daniel's finger tracing the verse, soft focus pull to his thoughtful face. |
+| 4 | Deepen understanding | "Rest, in His words, means walking with Him — not walking away from everything." | Daniel closes his eyes briefly in quiet reflection, hands resting on the closed Bible, steam rising from his coffee mug. |
+| 5 | Real-life application | "So today, before the emails and the to-do list, I just... came to Him first." | Daniel writes a short note in his journal, stands, picks up his bag with a small, calm smile. |
+| 6 | Encouragement | "And that made the rest of my day feel lighter." | Cut to a window view of a quiet golden-hour street below, curtains gently moving in the breeze. |
+| 7 | Invitation to reflect | "What would it look like for you to come to Him today, just as you are?" | Daniel pauses at the door, looking back at the open Bible on his desk, soft warm light. |
+| 8 | Hopeful conclusion | "Come to Him. He's not asking for more — He's offering rest." | Slow pull-back wide shot of the sunlit desk with the open Bible, Daniel exiting frame; generous negative space in the upper third for the Disciplefy end-screen (added in edit). |
 
 **Caption:** "Come to me, all who labor and are heavy laden, and I will give you rest." Jesus wasn't offering an escape — He was offering Himself. What does resting in Him actually look like today?
 **Hashtags:** #Disciplefy #BibleExplained #Matthew11 #FaithJourney
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Matthew 11:28 + 🙏 Prayer — "Lord, when I feel weary, remind me that's exactly when You say 'come.'"
+  - **Daily Verse Image Prompt fill (Variant A — Classic Card):** VERSE: "Come to me, all who labor and are heavy laden, and I will give you rest." · REFERENCE: "Matthew 11:28" · BACKGROUND: "Morning desk with Bible, window light."
 - Evening: Share the Reel + 📖 Reflection — Where in your life do you need to bring your burden to Jesus today?
 
 **CTA:** Study Matthew 11 with Disciplefy.
@@ -39,13 +76,25 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 **Audience Pain Point:** "I don't know where to start."
 
 **Slides:** Cover → Why context matters → Read before → Read after → One practical example → Disciplefy CTA
-**Design:** Warm cream, indigo, gold, minimal
+**Design:** Warm cream, charcoal, gold, minimal *(fixed — "indigo" was a leftover Product/App palette reference; Marketing/Social carousels use no indigo, see Visual Bible)*
+
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "Ever Read a Verse and Wonder What It Means?" Subline: "Context is everything." Bright cream desk scene, open Bible, gold "Swipe →" cue bottom-right. | Ever read one verse and build a whole belief around it, only to find out later it meant something completely different in context? You're not alone — here's a simple fix. Swipe → |
+| 2 — Why context matters | Headline: "Every Verse Has a Before and After." Scene: open Bible with a few surrounding verses subtly highlighted in soft gold. | Scripture wasn't written in isolated sentences — every verse sits inside a bigger conversation. Skip the context, and you risk missing what it's actually saying. |
+| 3 — Read before | Headline: "Read 5 Verses Before." Scene: a hand turning back a few pages in an open Bible, warm light. | Before you land on "what does this mean," back up and read the 5 verses leading into your passage. |
+| 4 — Read after | Headline: "Read 5 Verses After." Scene: a hand turning forward a few pages, mirroring Slide 3's composition. | Then keep going — read the 5 verses after, too. The full picture is usually bigger than one line. |
+| 5 — Practical example | Headline: "Try It: Philippians 1:3-8." Scene: the passage visible on an open Bible page with a small handwritten margin note. | Try it with Philippians 1:3-8 — read the whole section, then see how differently verse 6 hits. |
+| 6 — CTA | Headline: "Save This Before Your Next Study" with gold arrow →. Warm closing desk scene matching the season's CTA style. | Save this for your next study — context takes two extra minutes and changes everything. |
 
 **Caption:** Ever read a verse and wonder what it actually means? Context is everything — here's how to find it before your next study. Save this 📌
 **Hashtags:** #Disciplefy #BibleTips #BibleStudy #ContextMatters #Scripture
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — 2 Timothy 2:15 + 💡 Tip — "Always read at least 5 verses before and after your passage."
+  - **Daily Verse Image Prompt fill (Variant B — Full-Bleed Photo Overlay):** VERSE: "rightly handling the word of truth." · REFERENCE: "2 Timothy 2:15" · BACKGROUND: "Library, quiet study corner."
 - Evening: Share Carousel + 📖 Reflection — Read Philippians 1:3-8 and observe the full context.
 
 **CTA:** Save this before your next Bible study.
@@ -59,13 +108,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** Daniel starts his morning with a few quiet minutes with God before checking his phone. Simple, natural, practical.
-**Thumbnail:** "START WITH HIM"
+**Thumbnail:** "Start With Him"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Start With Him." Scene: an open Bible on a warm desk at sunrise, a smartphone lying face-down beside it (implying it's set aside), soft golden light.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "Mornings used to just be alarms and rushing." | Daniel jolts awake to his alarm, reaches for his phone first, soft dawn light in the bedroom. |
+| 2 | Introduce truth | "Then I noticed something Jesus did before anything else." | Daniel opens his Bible to Mark 1, pausing on "very early in the morning." |
+| 3 | Explain truth | "Before the crowds, before the miracles — Jesus went to a quiet place to pray." | Close-up of the verse, Daniel's face softening in recognition. |
+| 4 | Deepen understanding | "If He needed that quiet time, so do I." | Daniel sets his phone face-down on the desk, picks up his Bible instead. |
+| 5 | Real-life application | "So now mornings start with five quiet minutes before anything else." | Daniel sits with eyes closed, hands folded, soft golden light, coffee steam beside him. |
+| 6 | Encouragement | "It's not long. It's just first." | Window view of a quiet sunrise over rooftops, birds, gentle stillness. |
+| 7 | Invitation to reflect | "What would it look like to give God the first five minutes of your day?" | Daniel looks up from his Bible toward the window light, reflective. |
+| 8 | Hopeful conclusion | "Start with Him. Everything else can wait five minutes." | Wide slow pull-back of Daniel's desk at sunrise; negative space top third for end-screen. |
 
 **Caption:** Jesus made time with the Father a priority before anything else. What would it look like to start your day the same way?
 **Hashtags:** #Disciplefy #WalkingWithJesus #DailyQuietTime #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Mark 1:35 + 🙏 Prayer — "Lord, help me seek You before I seek anything else today."
+  - **Daily Verse Image Prompt fill (Variant C — Split Layout):** VERSE: "very early in the morning... Jesus went out to a desolate place, and there he prayed." · REFERENCE: "Mark 1:35" · BACKGROUND: "Lakeside sunrise, still water."
 - Evening: Share Reel + 📖 Reflection — What time will you set aside tomorrow morning?
 
 **CTA:** What time will you set aside tomorrow morning?
@@ -80,11 +145,24 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Pray → Read → Observe → Understand → Apply → Pray Again → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Pray | Headline: "1. Pray." Subline: "Ask God for wisdom before you read." Bright cream desk scene, hands folded over a closed Bible. | Prayer isn't a warm-up — it's how you ask God to actually meet you in the text before you even start reading. |
+| 2 — Read | Headline: "2. Read." Subline: "Read the whole chapter, not just one verse." Scene: open Bible, warm light. | Don't stop at one verse. Read the whole chapter first, so you see the full argument, not a fragment of it. |
+| 3 — Observe | Headline: "3. Observe." Subline: "What does the text actually say?" Scene: a hand underlining a line in the open Bible. | Before you decide what a passage means, just notice what it says — who's speaking, what's repeated, what stands out. |
+| 4 — Understand | Headline: "4. Understand." Subline: "What did it mean to its first readers?" Scene: journal open beside the Bible with a short note. | Now ask: what did this mean to the people who first heard it? That's the door to understanding what it means for you. |
+| 5 — Apply | Headline: "5. Apply." Subline: "What's one thing you'll do differently today?" Scene: journal with a single checked action item. | Knowledge that never becomes action fades fast. Pick one concrete way to live out what you just read, today. |
+| 6 — Pray Again | Headline: "6. Pray Again." Subline: "Ask God to help you live it out." Scene: hands folded again, softer/warmer light than Slide 1 to suggest closure. | Close the same way you opened — in prayer. Ask God to help you actually do what you just studied. |
+| 7 — CTA | Headline: "Study One Chapter Today" with gold arrow →. Warm closing desk scene matching the season's CTA style. | Six simple steps, any chapter, every time. Save this — you'll want it again. |
+
 **Caption:** One method, any chapter: Pray → Read → Observe → Understand → Apply → Pray again. Save this simple framework for your next study.
 **Hashtags:** #Disciplefy #BibleStudyMethod #HowToStudyTheBible #Scripture
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — 2 Timothy 3:16 + 💡 Tip — "Write down observations before jumping to interpretation."
+  - **Daily Verse Image Prompt fill (Variant D — Minimalist Typography):** VERSE: "All Scripture is breathed out by God and profitable for teaching, for reproof, for correction, and for training in righteousness." · REFERENCE: "2 Timothy 3:16" · BACKGROUND: "Morning desk with Bible, open journal (mood reference only — Variant D has no photo)."
 - Evening: Share Carousel + 📖 Reflection — Study one chapter using today's method.
 
 **CTA:** Study one chapter today.
@@ -98,13 +176,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** A believer feels discouraged. God faithfully continues His work. Hope-filled ending.
-**Thumbnail:** "GOD ISN'T FINISHED"
+**Thumbnail:** "God Isn't Finished"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "God Isn't Finished." Scene: an open journal on a warm desk with a half-finished handwritten page, soft evening lamp light, a single gold pen resting across the page.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "Ever feel like you're not growing fast enough?" | Daniel closes his journal, frustrated expression, evening lamp light. |
+| 2 | Introduce truth | "Paul wrote something I needed to hear: 'He who began a good work in you will complete it.'" | Daniel finds Philippians 1:6 in his Bible. |
+| 3 | Explain truth | "God isn't waiting for you to finish yourself — He's already doing the work." | Close-up on the verse, Daniel's shoulders relaxing. |
+| 4 | Deepen understanding | "Growth isn't a deadline. It's a promise being kept." | Daniel leans back, breathes out, soft evening light on his face. |
+| 5 | Real-life application | "So tonight, instead of frustration, I just said thank you." | Daniel closes his eyes briefly in quiet prayer, hands folded over the Bible. |
+| 6 | Encouragement | "Even the slow days are part of the work." | Window view of evening light fading gently over the city, calm. |
+| 7 | Invitation to reflect | "Where do you need to trust that God isn't finished with you yet?" | Daniel looks toward the window, thoughtful, peaceful. |
+| 8 | Hopeful conclusion | "He who started this in you will finish it. Trust the process." | Slow pull-back wide shot of the desk in warm lamp light; negative space top third for end-screen. |
 
 **Caption:** Growth isn't instant — and that's okay. "He who began a good work in you will carry it on to completion" (Phil 1:6). Tag someone who needs this today. 💛
 **Hashtags:** #Disciplefy #GrowingInChrist #Philippians1v6 #Encouragement #FaithJourney
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Philippians 1:6 + 🙏 Prayer — "Lord, thank You for being patient with me."
+  - **Daily Verse Image Prompt fill (Variant E — Framed Photo):** VERSE: "he who began a good work in you will bring it to completion." · REFERENCE: "Philippians 1:6" · BACKGROUND: "Garden bench, budding plant."
 - Evening: Share Reel + 📖 Reflection — Where have you seen God working in your life recently?
 
 **CTA:** Share this with someone who needs encouragement.
@@ -118,13 +212,16 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Story beat:** A new believer feels overwhelmed by 66 books. A friend introduces Disciplefy's Learning Paths as a simple, guided starting point.
 **Feature shown:** Learning Paths
-**Thumbnail:** "WHERE SHOULD I START?"
+**Thumbnail:** "Where Should I Start?"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above; this is the only generated asset for Saturday — the Reel itself is a real screen recording, not generated)*:
+> Headline: "Where Should I Start?" Scene: a stack of Bibles/books of varying sizes on a warm desk suggesting "66 books," with one small gold path/arrow icon pointing toward a single open Bible in front, soft morning light.
 
-**Caption:** 66 books can feel overwhelming — you don't have to figure out where to start alone. Meet Learning Paths, a guided way to grow. Free — link in bio.
+**Caption:** 66 books can feel overwhelming — you don't have to figure out where to start alone. Meet Learning Paths, a guided way to grow. Free — link in bio. Follow along — a new feature walkthrough every Saturday.
 **Hashtags:** #Disciplefy #LearningPaths #Discipleship #BibleStudy
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Proverbs 3:5-6 + 💡 Tip — "You don't need to know the whole Bible to start — just the next step."
+  - **Daily Verse Image Prompt fill (Variant F — Side-by-Side):** VERSE: "Trust in the Lord with all your heart... he will make straight your paths." · REFERENCE: "Proverbs 3:5-6" · BACKGROUND: "Forest prayer walk, path through trees."
 - Evening: Share Reel + 📖 Reflection — Try your first Learning Path today.
 
 **CTA:** Start your first path today.
@@ -141,11 +238,22 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Cover → this week's 5 truths (rest in Jesus, read in context, start your day with Him, a simple study method, God isn't finished with you) → one practical takeaway → invite to church/community → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "This Week's 5 Truths." Bright cream desk scene, open Bible + journal. | One week in, and Disciplefy's already helped you look at Scripture differently. Here's everything you learned this week, swipe through → |
+| 2 — 5 truths recap | Headline: "Rest · Context · Mornings With Him · A Study Method · He Isn't Finished." Five small gold-icon chips in a row on a clean cream card. | Rest in Jesus. Read in context. Start your mornings with Him. A simple study method. And the reminder that God isn't finished with you yet. |
+| 3 — Practical takeaway | Headline: "Pick Just One to Practice." Scene: a single verse card propped against a coffee mug. | Don't try to apply all five at once — pick the one truth that hit hardest and just practice that this week. |
+| 4 — Invite to community | Headline: "Carry It Into Worship Today." Warm Sunday-morning light through a window, a coat and Bible by the door. | Whatever you carry from this week, bring it into worship today — it's meant to be lived in community, not just alone. |
+| 5 — CTA | Headline: "Missed a Day This Week?" with gold arrow →. Subline: "Catch up — link in bio." | Missed a day somewhere in the mix? No guilt — just catch up whenever you're ready. Link in bio. |
+
 **Caption:** This week: rest in Jesus, read Scripture in context, start your day with Him, use a simple study method, and trust He's not finished with you. Carry it into worship today. Send this to a friend heading to church. 🙏
 **Hashtags:** #Disciplefy #SundayReflection #Worship #BibleStudy #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Hebrews 10:25 + 🙏 Prayer — "Lord, thank You for this week's growth. Help me carry it into worship today."
+  - **Daily Verse Image Prompt fill (Variant G — Vertical Bookmark):** VERSE: "...not neglecting to meet together, as is the habit of some, but encouraging one another..." · REFERENCE: "Hebrews 10:25" · BACKGROUND: "Church pew, soft morning light through a window."
 - Evening: Share Carousel + 📖 Reflection — Which of this week's 5 truths will you keep practicing?
 
 **CTA:** Missed a day this week? Catch up — link in bio.
@@ -153,8 +261,20 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
+## Growth Additions (2026)
+Full detail in `Content_Playbook_Season1_Week1.md` → "Growth Additions" — three tactics: (1) Follow-CTA, one rotating slot/week (this week: Saturday's Ep2 caption, done above), (2) trending audio on the Daniel Reels where mood fits, skip if nothing matches, (3) Stories interactive stickers 2-3x/week, not daily.
+
 ## Production Rhythm
 Same rolling model as the rest of the season — produce Week 3's content while this week publishes (see `Disciplefy Operating System`).
 
 ## Success Metrics
 Track at the end of the week: Reel Reach · Watch Time · Saves · Shares · Profile Visits · Website Clicks · App Installs.
+
+---
+
+## Changelog
+- **v1.1:** Added detailed generation prompts for everything that isn't a real screen recording: shared Daniel-character Google Flow/Veo STYLE BLOCK + full 8-clip prompt tables for the Mon/Wed/Fri Reels, a Thumbnail STYLE BLOCK + one prompt per day, and Carousel STYLE BLOCK + slide-by-slide prompts for Tue/Thu/Sun. Also fixed a stray "indigo" reference in Tuesday's Design line — Marketing/Social carousels use no indigo.
+- **v1.2:** Added a Daily Verse Story image-generation template + per-day Verse/Reference/Background fill for all 7 Morning Stories — previously named a verse reference with no actual image prompt.
+- **v1.3:** Switched to Week 1's 7 rotating layout variants (one per weekday) instead of one fixed daily layout — updated each day's fill to tag its variant.
+- **v1.4:** Added a per-slide Caption to every carousel (Tue/Thu/Sun) — Instagram now supports a distinct caption per carousel image (rolled out June 2026), shown as viewers swipe. Captions add commentary/context beyond the on-image headline text, not a repeat of it.
+- **v1.5:** Added a Follow-CTA to Saturday's Episode 2 caption and a "Growth Additions (2026)" pointer section (full detail lives in Week 1: Follow-CTA rotation, trending audio, Stories interactive stickers).

--- a/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week3.md
+++ b/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week3.md
@@ -1,11 +1,32 @@
 # Disciplefy Content Playbook — Season 1: Foundations of Faith
 ## Week 3
+Version: 1.6 *(updated — see Changelog)*
 
 ## Mission of the Week
 Continue the regular rhythm (bank item #2 for each series). Saturday's reel is a Hero Episode — the Memory Verse feature, one of the 4 you asked to get in front of people early.
 
 ## Content Funnel
 Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install → Bible Study → Spiritual Growth
+
+---
+
+## 🎬 Video Generation — Daniel Reel STYLE BLOCK (Mon / Wed / Fri)
+Reusable across all 3 AI-generated Reels this week — full Google Flow/Veo generations, not screen recordings. Per `Prompts/Daily Devotions.md`'s meta-prompt: 8 clips × 5 seconds = 40s, one Google Flow/Veo prompt + one voice-over line per clip.
+
+**Visual Style (every clip):** Premium cinematic Christian lifestyle. Apple-commercial quality, photorealistic live action, authentic Indian environment, warm golden-hour grading, soft natural lighting, natural performances, vertical 9:16, 4K, 24fps. No CGI, no fantasy, no AI artifacts, no fast cuts/whip pans/spinning.
+
+**Character — Daniel** *(canonical bio, per `Prompts/Daily Devotions.md` — keep identical every clip)*: Young Indian professional (26-30), neatly styled short black hair, clean shaven, warm medium-brown skin, navy Oxford shirt, dark chinos, brown leather watch, calm/thoughtful/gentle, usually reading Scripture before work. Never looks into camera, never acknowledges camera, never speaks to audience.
+
+**Story Structure (all 8 clips follow this purpose order):** 1 Hook · 2 Introduce biblical truth · 3 Explain truth · 4 Deepen understanding · 5 Real-life application · 6 Encouragement (prayer/Scripture/nature) · 7 Invitation to reflect · 8 Hopeful conclusion (leave negative space top-third for the Disciplefy end-screen logo, added in edit).
+
+## 🖼️ Thumbnail Image Generation — STYLE BLOCK (prepend to each day's thumbnail prompt below)
+> Premium, warm thumbnail frame for a Disciplefy Instagram Reel. Portrait 9:16 (1080×1920), safe-zone aware — keep headline and focal object clear of the top ~250px and bottom ~250px (Instagram UI overlay zones). Soft cream background (`#FAF8F5`) bathed in natural window light. Bold near-black charcoal (`#1E1E1E`) headline, Poppins 700, maximum five words. One clear focal object only. One small gold (`#B8860B`) accent only. Brand frame: small gold Disciplefy logo top-left with thin gold divider; small gold globe + "disciplefy.in" bottom-left. Never: red arrows, shock faces, clickbait expressions, clip-art crosses, busy collages.
+
+## 🎨 Carousel Image Generation — STYLE BLOCK (prepend to each slide prompt, Tue / Thu / Sun)
+> Premium, warm, bright slide, one frame in a multi-slide swipeable Instagram carousel for Disciplefy. Portrait 4:5 (1080×1350). Soft cream background (`#FAF8F5`), bright natural window light, warm wooden desk with tasteful props (open Bible, coffee mug, small plant, leather journal). Bold near-black charcoal (`#1E1E1E`) headline, Poppins, left-aligned; warm-gray subline. Gold accents (`#B8860B` / `#C79A3B`) — no indigo. Brand frame: gold logo + divider top-left, gold globe + "disciplefy.in" bottom-left. No dark/moody look, clutter, distorted text, or clip-art crosses.
+
+## 📖 Daily Verse — Morning Story Image Generation
+Same 7 layout variants as `Content_Playbook_Season1_Week1.md` (Variant A Monday through Variant G Sunday, full detail there — not repeated here) — each weekday keeps its own recognizable sub-style rather than one fixed layout every day. Only Verse/Reference/Background change per day; shared brand rules (palette, typography, logo, safe zones) also defined in Week 1.
 
 ---
 
@@ -17,13 +38,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI, 40s
 **Visual style:** Modern Indian apartment, morning sunlight, open Bible, coffee, notebook, Daniel as recurring character
-**Thumbnail:** "WHO IS YOUR NEIGHBOR?"
+**Thumbnail:** "Who Is Your Neighbor?"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Who Is Your Neighbor?" Scene: an open Bible turned to Luke 10, morning light, a small folded road-map-style illustration motif kept subtle and abstract (a thin gold line, not literal), resting beside the Bible.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "A man asked Jesus, 'Who is my neighbor?'" | Daniel reading his Bible at his desk, morning light, brow furrowed in thought. |
+| 2 | Introduce truth | "Jesus answered with a story — about a man beaten and left on the road." | Close-up of the open Bible at Luke 10, Daniel's finger tracing the page. |
+| 3 | Explain truth | "A priest passed by. A Levite passed by. It was an outsider who stopped." | Daniel pauses, visibly struck, sets his coffee down slowly. |
+| 4 | Deepen understanding | "Jesus flipped the question — not 'who deserves my help,' but 'who acted like a neighbor.'" | Daniel leans back, processing, soft morning light. |
+| 5 | Real-life application | "So today I looked for one person I could actually stop for." | Daniel picks up his bag, glances toward a neighbor's door on his way out, small nod. |
+| 6 | Encouragement | "Mercy doesn't wait for the perfect moment." | Window view of a quiet morning street, someone helping another with groceries, warm light. |
+| 7 | Invitation to reflect | "Who's the neighbor in front of you today?" | Daniel pauses at his own door, reflective. |
+| 8 | Hopeful conclusion | "Go and do likewise." | Slow pull-back of the sunlit desk, Bible still open; negative space top third for end-screen. |
 
 **Caption:** The priest passed by. The Levite passed by. It was the outsider who stopped. Jesus flips the question from "who is my neighbor" to "who acted like one."
 **Hashtags:** #Disciplefy #BibleExplained #GoodSamaritan #Compassion
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Luke 10:27 + 🙏 Prayer — "Lord, open my eyes to the neighbor in front of me today."
+  - **Daily Verse Image Prompt fill (Variant A — Classic Card):** VERSE: "Love the Lord your God... and your neighbor as yourself." · REFERENCE: "Luke 10:27" · BACKGROUND: "Window light overlooking a quiet neighborhood street."
 - Evening: Share the Reel + 📖 Reflection — Who's someone you could show mercy to this week?
 
 **CTA:** Study Luke 10 with Disciplefy.
@@ -31,21 +68,31 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
-## Tuesday — 💡 Bible Tips
-**Topic:** Pray Before You Read *(bank item 2)*
-**Format:** Carousel
-**Key Scripture:** James 1:5 — "If any of you lacks wisdom, let him ask God."
+## Tuesday — 📖 How To: Memory Verses (Carousel)
+*Swapped in this week only — pairs 2 days ahead of Saturday's Episode 9 Memory Verse reel, same pattern as the PreWeek1 bridge (carousel = depth/reference, reel = reach, a few days apart). Displaces this week's Bible Tips bank item ("Pray Before You Read") — deferred to Month 2, not lost; see `Daily Devotion/2. Tuesday — Bible Tips Carousel.md`.*
+**Format:** Carousel, 6 slides (reused from `Instagram_Carousel_Image_Prompts.md` POST 4, UI details corrected against real app screenshots)
+**Bible Verse:** Deuteronomy 11:18 — "You shall therefore lay up these words of mine in your heart and in your soul." *(same verse as Saturday's reel — intentional reinforcement, same week, same feature)*
 
-**Slides:** Cover → Why pray first → A simple 1-line prayer → What changes when you do → Disciplefy CTA
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
 
-**Caption:** Before you open your Bible, open your heart. A one-line prayer changes how you read. Save this 📌
-**Hashtags:** #Disciplefy #BibleTips #PrayFirst #BibleStudy
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Open Bible with a small handwritten verse card resting on it, mug and plant nearby, sunlit. Headline: "Memorize a verse… forget it in a week?" Small gold bookmark-heart icon + subline "Make it stick." Gold "Swipe →" cue bottom-right. | Ever memorize a verse... and lose it a week later? Most of us do — memorizing without a system doesn't stick. Here's what actually works. Swipe → |
+| 2 — Step 1 | Smartphone mockup on warm wooden desk, small handwritten verse card nearby. Screen shows the attached screenshot of adding a verse (real: reached via a Home-screen icon, not a nav tab — reference image provided, use exactly). Gold "Step 1" badge. Headline: "Add Any Verse." | Add any verse you want to learn — takes seconds. |
+| 3 — Step 2 | Smartphone mockup, ceramic mug nearby. Screen shows the attached screenshot of a practice mode — flip cards, word bank, or fill-in-the-blank (real: 3 of 8 actual modes, a representative sample, not exhaustive; reference image provided). Gold "Step 2" badge. Headline: "Practice, Your Way." | Practice it with flip cards, a word bank, or fill-in-the-blank — whatever sticks best for you. |
+| 4 — Step 3 | Smartphone mockup, small plant nearby. Screen shows the attached screenshot of a review reminder notification (reference image provided). Gold "Step 3" badge. Headline: "Reminded Right on Time." | It reminds you right before you'd forget — not just once and done. |
+| 5 — Step 4 | Smartphone mockup, open Bible nearby. Screen shows the attached screenshot of the green streak heat map — a GitHub-style contribution calendar (confirmed real feature; reference image provided). Gold "Step 4" badge. Headline: "Watch Your Streak Grow." | This little green calendar is oddly motivating — consistency, visible. |
+| 6 — CTA | Warm morning sunlight over a wooden desk, open Bible + mug. Headline: "Hide His Word in Your Heart." Subline: "Free → link in bio." | No more losing a verse a week after you learned it. Free — link in bio. |
+
+**Caption:** Memorize a verse, then lose it in a week? Add a verse, practice with flip cards/word bank/cloze, get reminded right before you'd forget — and watch your streak grow. Free — link in bio. 🙌
+**Hashtags:** #Disciplefy #MemoryVerse #BibleMemory #Scripture
 
 **Stories (2x/day):**
-- Morning: 📖 Verse — James 1:5 + 💡 Tip — "Try: 'Lord, help me see You clearly in this passage.'"
-- Evening: Share Carousel + 📖 Reflection — Pray this simple line before your next study.
+- Morning: 📖 Verse — Deuteronomy 11:18 + 💡 Tip — "Pick one short verse this week and practice it daily — consistency beats cramming."
+  - **Daily Verse Image Prompt fill (Variant B — Full-Bleed Photo Overlay):** VERSE: "You shall therefore lay up these words of mine in your heart and in your soul." · REFERENCE: "Deuteronomy 11:18" · BACKGROUND: "Coffee and Bible, warm morning light."
+- Evening: Share the Carousel + 📖 Reflection — Add your first verse to Memory Verse today.
 
-**CTA:** Try it before your next study.
+**CTA:** Add your first verse today.
 **KPI:** Saves · Shares
 
 ---
@@ -56,13 +103,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** Daniel sets a 5-minute daily prayer alarm — struggles the first few days, then it becomes second nature.
-**Thumbnail:** "PRAY WITHOUT CEASING"
+**Thumbnail:** "Pray Without Ceasing"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Pray Without Ceasing." Scene: a smartphone showing a soft glowing alarm icon (no rendered UI, just a warm glow) beside an open Bible turned to 1 Thessalonians, warm desk light.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "I used to only pray when things went wrong." | Daniel scrolling his phone anxiously, evening light. |
+| 2 | Introduce truth | "Then I read: 'Pray without ceasing.'" | Daniel finds 1 Thessalonians 5:17 in his Bible. |
+| 3 | Explain truth | "Not one long prayer a week — a constant, ongoing conversation." | Close-up on the verse, Daniel nodding slowly. |
+| 4 | Deepen understanding | "So I set a small reminder — just five minutes, same time, every day." | Daniel sets a phone alarm, places the phone face-down. |
+| 5 | Real-life application | "The first few days felt awkward. Then it started to feel natural." | Daniel sits quietly, eyes closed, hands folded, soft light, small smile forming. |
+| 6 | Encouragement | "It's not about perfect words — it's about showing up." | Window view of soft evening light settling over the room, calm stillness. |
+| 7 | Invitation to reflect | "What's one small prayer habit you could start this week?" | Daniel looks up, peaceful, journal open beside him. |
+| 8 | Hopeful conclusion | "Pray without ceasing — one small moment at a time." | Slow pull-back wide shot of the desk at dusk; negative space top third for end-screen. |
 
 **Caption:** Prayer isn't about perfect words — it's about showing up. What's one small prayer habit you could start this week?
 **Hashtags:** #Disciplefy #WalkingWithJesus #PrayerLife #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — 1 Thessalonians 5:17 + 🙏 Prayer — "Lord, help me show up consistently, not perfectly."
+  - **Daily Verse Image Prompt fill (Variant C — Split Layout):** VERSE: "pray without ceasing." · REFERENCE: "1 Thessalonians 5:17" · BACKGROUND: "Candlelight, evening prayer corner."
 - Evening: Share Reel + 📖 Reflection — What's your prayer habit this week?
 
 **CTA:** What's your prayer habit?
@@ -77,11 +140,22 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Cover → What "observe" means → 3 questions to ask first → Why this comes before interpretation → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "Observe Before You Interpret." Bright cream desk scene, open Bible, gold "Swipe →" cue bottom-right. | Ever jump straight to "what does this mean for me" before you've even finished reading the passage? Here's the step most people skip. |
+| 2 — What "observe" means | Headline: "What Does the Text Actually Say?" Scene: a magnifying-glass-style close focus on a single underlined verse (subtle, not literal prop). | Observation just means slowing down enough to notice what the text actually says, before deciding what it means. |
+| 3 — 3 questions to ask first | Headline: "Who? What? When?" Scene: journal with 3 short numbered questions handwritten. | Three simple questions to start: who is this about, what is actually happening, and when does it take place? |
+| 4 — Why this comes first | Headline: "Interpretation Without Observation Misreads the Text." Scene: open Bible beside a journal with a crossed-out then corrected note. | Skip observation, and you risk interpreting the passage through your own assumptions instead of what's really there. |
+| 5 — CTA | Headline: "Try It on Your Next Chapter" with gold arrow →. Warm closing desk scene. | Try this on your next chapter — observe first, interpret second. It changes what you notice. |
+
 **Caption:** Before you ask "what does this mean," ask "what does this say." Observation comes first. Save this study tip.
 **Hashtags:** #Disciplefy #BibleStudyMethod #Observation #Scripture
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Acts 17:11 + 💡 Tip — "Read the passage 3 times before you interpret anything."
+  - **Daily Verse Image Prompt fill (Variant D — Minimalist Typography):** VERSE: "they received the word... examining the Scriptures daily to see if these things were so." · REFERENCE: "Acts 17:11" · BACKGROUND: "Library, quiet study corner (mood reference only — Variant D has no photo)."
 - Evening: Share Carousel + 📖 Reflection — Try it on your next chapter.
 
 **CTA:** Try it on your next chapter.
@@ -95,13 +169,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** A believer in a season of uncertainty learns to trust God's timing instead of forcing an answer.
-**Thumbnail:** "WAITING ON GOD"
+**Thumbnail:** "Waiting On God"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Waiting On God." Scene: an open Bible turned to Isaiah 40, evening lamp light, a single feather (suggesting "wings as eagles") resting gently on the page.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "I hate waiting. Especially when I don't know the outcome." | Daniel staring at an unanswered message on his phone, restless, evening light. |
+| 2 | Introduce truth | "Isaiah wrote: 'Those who wait for the Lord shall renew their strength.'" | Daniel opens his Bible to Isaiah 40. |
+| 3 | Explain truth | "Waiting isn't wasted time — it's where strength is renewed." | Close-up on the verse, Daniel's expression softening. |
+| 4 | Deepen understanding | "God isn't slow. He's working on a timeline I can't always see." | Daniel sets his phone aside, breathes out slowly. |
+| 5 | Real-life application | "So tonight, instead of forcing an answer, I just... waited, with Him." | Daniel sits quietly, hands folded, soft lamp light, peaceful stillness. |
+| 6 | Encouragement | "Even eagles have to wait for the wind before they rise." | Window view of the evening sky, birds in flight, golden light. |
+| 7 | Invitation to reflect | "What are you waiting on God for right now?" | Daniel looks toward the window, reflective, calm. |
+| 8 | Hopeful conclusion | "Wait on the Lord. He will renew your strength." | Slow pull-back wide shot of the desk in warm evening light; negative space top third for end-screen. |
 
 **Caption:** Waiting doesn't mean God is absent — it means He's working on a timeline of His own. Tag someone in a season of waiting. 💛
 **Hashtags:** #Disciplefy #GrowingInChrist #WaitingOnGod #Encouragement
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Isaiah 40:31 + 🙏 Prayer — "Lord, renew my strength as I wait on You."
+  - **Daily Verse Image Prompt fill (Variant E — Framed Photo):** VERSE: "those who wait for the Lord shall renew their strength; they shall mount up with wings like eagles." · REFERENCE: "Isaiah 40:31" · BACKGROUND: "Mountain sunrise, birds in flight."
 - Evening: Share Reel + 📖 Reflection — What are you waiting on God for right now?
 
 **CTA:** Share this with someone waiting on God.
@@ -115,13 +205,16 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Story beat:** Someone memorizes verses but forgets them after a few days. A friend introduces Disciplefy's Memory Verse feature and daily review.
 **Feature shown:** Memory Verse
-**Thumbnail:** "I CAN NEVER REMEMBER VERSES"
+**Thumbnail:** "I Can Never Remember"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above; this is the only generated asset for Saturday — the Reel itself is a real screen recording, not generated)*:
+> Headline: "I Can Never Remember." Scene: a small handwritten verse card tucked into an open Bible, a single gold paperclip, warm desk light — same visual motif as Week 1's Memory Verse thumbnail for series consistency.
 
-**Caption:** Ever memorize a verse... and lose it a week later? Meet Memory Verse — practice modes and smart reminders that make it stick. Free — link in bio.
+**Caption:** Ever memorize a verse... and lose it a week later? Meet Memory Verse — practice modes and smart reminders that make it stick. Free — link in bio. Follow along — a new feature walkthrough every Saturday.
 **Hashtags:** #Disciplefy #MemoryVerse #BibleMemory #Scripture
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Deuteronomy 11:18 + 💡 Tip — "Review a verse right when you're about to forget it, not just once."
+  - **Daily Verse Image Prompt fill (Variant F — Side-by-Side):** VERSE: "You shall therefore lay up these words of mine in your heart and in your soul." · REFERENCE: "Deuteronomy 11:18" · BACKGROUND: "Coffee and Bible, warm morning light."
 - Evening: Share Reel + 📖 Reflection — Add your first verse to Memory Verse today.
 
 **CTA:** Add your first verse today.
@@ -138,11 +231,22 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Cover → this week's 5 truths (love your neighbor, pray before you read, build a prayer habit, observe before you interpret, wait on God) → one practical takeaway → invite to church/community → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "This Week's 5 Truths." Bright cream desk scene, open Bible + journal. | Another week of studying Scripture together — here's everything this week covered, swipe through → |
+| 2 — 5 truths recap | Headline: "Neighbor · Pray First · Prayer Habit · Observe · Wait on Him." Five small gold-icon chips in a row on a clean cream card. | Loving your neighbor. Praying before you read. Building a daily prayer habit. Observing before interpreting. And learning to wait on God's timing. |
+| 3 — Practical takeaway | Headline: "Pick Just One to Practice." Scene: a single verse card propped against a coffee mug. | Five truths is a lot to hold onto — just pick the one you need most right now and practice it this week. |
+| 4 — Invite to community | Headline: "Carry It Into Worship Today." Warm Sunday-morning light through a window, a coat and Bible by the door. | Take whatever stood out to you this week into worship today — that's where it gets lived out, not just learned. |
+| 5 — CTA | Headline: "Missed a Day This Week?" with gold arrow →. Subline: "Catch up — link in bio." | If you missed a day, it's not too late — catch up whenever works. Link in bio. |
+
 **Caption:** This week: love your neighbor, pray before you read, build a prayer habit, observe before you interpret, and trust God's timing. Carry it into worship today. Send this to a friend heading to church. 🙏
 **Hashtags:** #Disciplefy #SundayReflection #Worship #BibleStudy #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Hebrews 10:25 + 🙏 Prayer — "Lord, thank You for this week's growth. Help me carry it into worship today."
+  - **Daily Verse Image Prompt fill (Variant G — Vertical Bookmark):** VERSE: "...not neglecting to meet together, as is the habit of some, but encouraging one another..." · REFERENCE: "Hebrews 10:25" · BACKGROUND: "Church pew, soft morning light through a window."
 - Evening: Share Carousel + 📖 Reflection — Which of this week's truths will you keep practicing?
 
 **CTA:** Missed a day this week? Catch up — link in bio.
@@ -150,8 +254,21 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
+## Growth Additions (2026)
+Full detail in `Content_Playbook_Season1_Week1.md` → "Growth Additions" — three tactics: (1) Follow-CTA, one rotating slot/week (this week: Saturday's Ep9 Hero caption, done above), (2) trending audio on the Daniel Reels where mood fits, skip if nothing matches, (3) Stories interactive stickers 2-3x/week, not daily.
+
 ## Production Rhythm
 Same rolling model as the rest of the season — produce Week 4's content while this week publishes.
 
 ## Success Metrics
 Track at the end of the week: Reel Reach · Watch Time · Saves · Shares · Profile Visits · Website Clicks · App Installs.
+
+---
+
+## Changelog
+- **v1.1:** Added detailed generation prompts for everything that isn't a real screen recording: shared Daniel-character Google Flow/Veo STYLE BLOCK + full 8-clip prompt tables for the Mon/Wed/Fri Reels, a Thumbnail STYLE BLOCK + one prompt per day, and Carousel STYLE BLOCK + slide-by-slide prompts for Tue/Thu/Sun.
+- **v1.2:** Added a Daily Verse Story image-generation template + per-day Verse/Reference/Background fill for all 7 Morning Stories — previously named a verse reference with no actual image prompt.
+- **v1.3:** Switched to Week 1's 7 rotating layout variants (one per weekday) instead of one fixed daily layout — updated each day's fill to tag its variant.
+- **v1.4:** Added a per-slide Caption to every carousel (Tue/Thu/Sun) — Instagram now supports a distinct caption per carousel image (rolled out June 2026), shown as viewers swipe. Captions add commentary/context beyond the on-image headline text, not a repeat of it.
+- **v1.5:** Tuesday swapped from Bible Tips to a Memory Verses feature carousel — pairs 2 days ahead of Saturday's Episode 9 reel (reach + reference for the same feature, spaced apart, matching the PreWeek1 bridge pattern). Displaced Bible Tips bank item deferred to Month 2.
+- **v1.6:** Added a Follow-CTA to Saturday's Episode 9 Hero caption and a "Growth Additions (2026)" pointer section (full detail lives in Week 1).

--- a/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week4.md
+++ b/docs/marketing/Content_Playbook_Season1/Content_Playbook_Season1_Week4.md
@@ -1,11 +1,32 @@
 # Disciplefy Content Playbook — Season 1: Foundations of Faith
 ## Week 4
+Version: 1.6 *(updated — see Changelog)*
 
 ## Mission of the Week
 Close out Month 1 (bank item #3 for each series). Saturday's reel is the second Hero Episode — the Discipler feature, the last of your 4 requested guides, now fully covered across the month. Sunday doubles as the full-month recap, and the Testimony Campaign runs alongside.
 
 ## Content Funnel
 Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install → Bible Study → Spiritual Growth
+
+---
+
+## 🎬 Video Generation — Daniel Reel STYLE BLOCK (Mon / Wed / Fri)
+Reusable across all 3 AI-generated Reels this week — full Google Flow/Veo generations, not screen recordings. Per `Prompts/Daily Devotions.md`'s meta-prompt: 8 clips × 5 seconds = 40s, one Google Flow/Veo prompt + one voice-over line per clip.
+
+**Visual Style (every clip):** Premium cinematic Christian lifestyle. Apple-commercial quality, photorealistic live action, authentic Indian environment, warm golden-hour grading, soft natural lighting, natural performances, vertical 9:16, 4K, 24fps. No CGI, no fantasy, no AI artifacts, no fast cuts/whip pans/spinning.
+
+**Character — Daniel** *(canonical bio, per `Prompts/Daily Devotions.md` — keep identical every clip)*: Young Indian professional (26-30), neatly styled short black hair, clean shaven, warm medium-brown skin, navy Oxford shirt, dark chinos, brown leather watch, calm/thoughtful/gentle, usually reading Scripture before work. Never looks into camera, never acknowledges camera, never speaks to audience.
+
+**Story Structure (all 8 clips follow this purpose order):** 1 Hook · 2 Introduce biblical truth · 3 Explain truth · 4 Deepen understanding · 5 Real-life application · 6 Encouragement (prayer/Scripture/nature) · 7 Invitation to reflect · 8 Hopeful conclusion (leave negative space top-third for the Disciplefy end-screen logo, added in edit).
+
+## 🖼️ Thumbnail Image Generation — STYLE BLOCK (prepend to each day's thumbnail prompt below)
+> Premium, warm thumbnail frame for a Disciplefy Instagram Reel. Portrait 9:16 (1080×1920), safe-zone aware — keep headline and focal object clear of the top ~250px and bottom ~250px (Instagram UI overlay zones). Soft cream background (`#FAF8F5`) bathed in natural window light. Bold near-black charcoal (`#1E1E1E`) headline, Poppins 700, maximum five words. One clear focal object only. One small gold (`#B8860B`) accent only. Brand frame: small gold Disciplefy logo top-left with thin gold divider; small gold globe + "disciplefy.in" bottom-left. Never: red arrows, shock faces, clickbait expressions, clip-art crosses, busy collages.
+
+## 🎨 Carousel Image Generation — STYLE BLOCK (prepend to each slide prompt, Tue / Thu / Sun)
+> Premium, warm, bright slide, one frame in a multi-slide swipeable Instagram carousel for Disciplefy. Portrait 4:5 (1080×1350). Soft cream background (`#FAF8F5`), bright natural window light, warm wooden desk with tasteful props (open Bible, coffee mug, small plant, leather journal). Bold near-black charcoal (`#1E1E1E`) headline, Poppins, left-aligned; warm-gray subline. Gold accents (`#B8860B` / `#C79A3B`) — no indigo. Brand frame: gold logo + divider top-left, gold globe + "disciplefy.in" bottom-left. No dark/moody look, clutter, distorted text, or clip-art crosses.
+
+## 📖 Daily Verse — Morning Story Image Generation
+Same 7 layout variants as `Content_Playbook_Season1_Week1.md` (Variant A Monday through Variant G Sunday, full detail there — not repeated here) — each weekday keeps its own recognizable sub-style rather than one fixed layout every day. Only Verse/Reference/Background change per day; shared brand rules (palette, typography, logo, safe zones) also defined in Week 1.
 
 ---
 
@@ -17,13 +38,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI, 40s
 **Visual style:** Modern Indian apartment, morning sunlight, open Bible, coffee, notebook, Daniel as recurring character
-**Thumbnail:** "WHY THE FIG TREE?"
+**Thumbnail:** "Why The Fig Tree?"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Why The Fig Tree?" Scene: an open Bible turned to Mark 11, morning light, a small bare twig or leaf resting on the page as a subtle visual nod (not a literal tree illustration).
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "Some passages in the Bible are just... uncomfortable." | Daniel reading his Bible at his desk, pausing, brow furrowed, morning light. |
+| 2 | Introduce truth | "Like the time Jesus cursed a fig tree for having no fruit." | Daniel's finger tracing Mark 11 in his open Bible. |
+| 3 | Explain truth | "It sounds harsh — until you see what it's really about." | Close-up on the verse, Daniel's expression shifting from confusion to focus. |
+| 4 | Deepen understanding | "The tree had leaves — it looked alive — but no fruit. Just appearance, no substance." | Daniel leans back, thoughtful, soft morning light. |
+| 5 | Real-life application | "So I asked myself: where am I all leaves and no fruit?" | Daniel writes a short honest note in his journal. |
+| 6 | Encouragement | "Authentic faith isn't about looking right — it's about bearing real fruit." | Window view of a garden or potted plant with visible fruit/growth, warm light. |
+| 7 | Invitation to reflect | "Where might you be showing leaves without fruit?" | Daniel looks up from his journal, reflective. |
+| 8 | Hopeful conclusion | "Let your faith be real — not just something that looks good on the outside." | Slow pull-back wide shot of the sunlit desk; negative space top third for end-screen. |
 
 **Caption:** A tree with no fruit, cursed by Jesus — it sounds harsh until you see what it's really about: authentic faith, not just appearances.
 **Hashtags:** #Disciplefy #BibleExplained #FigTree #Mark11
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Mark 11:13-14 + 🙏 Prayer — "Lord, let my faith be real, not just something that looks good on the outside."
+  - **Daily Verse Image Prompt fill (Variant A — Classic Card):** VERSE: "And seeing in the distance a fig tree in leaf, he went to see if he could find anything on it." · REFERENCE: "Mark 11:13" · BACKGROUND: "Garden bench, budding plant."
 - Evening: Share the Reel + 📖 Reflection — Where might you be showing leaves without fruit?
 
 **CTA:** Study Mark 11 with Disciplefy.
@@ -31,22 +68,34 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
-## Tuesday — 💡 Bible Tips
-**Topic:** Ask Better Questions While Reading *(bank item 3)*
-**Format:** Carousel
-**Key Scripture:** Proverbs 2:3-5 — "if you call out for insight... you will find the knowledge of God."
+## Tuesday — 🎙 How To: Discipler (Carousel)
+*Swapped in this week only — pairs 2 days ahead of Saturday's Episode 13 Discipler reel, same pattern as the PreWeek1 bridge. Displaces this week's Bible Tips bank item ("Ask Better Questions While Reading") — deferred to Month 2, not lost; see `Daily Devotion/2. Tuesday — Bible Tips Carousel.md`.*
+**Format:** Carousel, 6 slides (reused from `Instagram_Carousel_Image_Prompts.md` POST 5, UI details corrected against real app screenshots)
+**Bible Verse:** Matthew 7:7 — "Ask, and it will be given to you; seek, and you will find." *(same verse as Saturday's reel — intentional reinforcement, same week, same feature)*
 
-**Slides:** Cover → The wrong question vs. the right one → 3 questions to ask instead → Why this changes everything → Disciplefy CTA
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
 
-**Caption:** The right question changes everything. Instead of "what does this mean to me," try "what did this mean to them." Save this 📌
-**Hashtags:** #Disciplefy #BibleTips #AskBetterQuestions #BibleStudy
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Warm, cozy scene (bright and inviting, not dark): a person in soft warm light holding a phone near an open Bible and a mug, a gentle gold soundwave glow from the phone. Headline: "A faith question — and no one to ask?" Small gold microphone icon + subline "Just ask out loud." Gold "Swipe →" cue bottom-right. | Some questions can't wait for Sunday. Here's what to do when they hit at midnight. Swipe → |
+| 2 — Step 1 | Smartphone mockup on warm wooden desk, open Bible nearby. Screen shows the attached screenshot of a generated Study Guide, with the "Ask Discipler" button visible at the bottom next to "Listen" (real entry point, confirmed via screenshot — reference image provided, use exactly). Gold "Step 1" badge. Headline: "Tap Ask Discipler." | Right from any Study Guide, tap "Ask Discipler" — no separate app, no losing your place. |
+| 3 — Step 2 | Smartphone mockup, ceramic mug nearby. Screen shows the attached screenshot of the Discipler conversation screen opening (reference image provided). Gold "Step 2" badge. Headline: "Meet Your Discipler." | It opens right into a conversation, ready for your real question. |
+| 4 — Step 3 | Smartphone mockup, gentle gold soundwave glow on the screen. Screen shows the attached screenshot of the mic tapped mid-question (reference image provided). Gold "Step 3" badge. Headline: "Just Ask Out Loud." | Tap the mic and ask — like "How do I forgive someone who hurt me?" — just like you'd ask a friend. |
+| 5 — Step 4 | Smartphone mockup gently floating, open Bible nearby. Screen shows the attached screenshot of the Scripture-grounded response (reference image provided). Gold "Step 4" badge. Headline: "Grounded in Scripture." | It answers — pointing you back to the Word, every time. |
+| 6 — CTA | Warm morning sunlight over a wooden desk, open Bible + mug. Headline: "Real Questions. Biblical Answers. Anytime." Subline: "Free → link in bio." | A companion for your walk — not a replacement for your pastor or church. Free — link in bio. |
+
+**Caption:** Faith question, no one to ask right now? Tap the mic, ask out loud — get a Scripture-grounded answer. A companion for your walk, not a replacement for your pastor or church. Free — link in bio. 🙏
+**Hashtags:** #Disciplefy #Discipler #FaithQuestions #Discipleship
+
+**Theology-safe note:** Discipler copy must always frame it as a companion that points back to Scripture and community — never a replacement for pastor, church, or the Bible itself.
 
 **Stories (2x/day):**
-- Morning: 📖 Verse — Proverbs 2:3-5 + 💡 Tip — "Ask 'who, what, when, where, why' before you ask 'what does this mean to me.'"
-- Evening: Share Carousel + 📖 Reflection — Try it on your next read.
+- Morning: 📖 Verse — Matthew 7:7 + 💡 Tip — "No question is too basic to ask Discipler — that's what it's there for."
+  - **Daily Verse Image Prompt fill (Variant B — Full-Bleed Photo Overlay):** VERSE: "Ask, and it will be given to you; seek, and you will find." · REFERENCE: "Matthew 7:7" · BACKGROUND: "Morning desk with Bible, window light."
+- Evening: Share the Carousel + 📖 Reflection — Ask Discipler your first question today.
 
-**CTA:** Try it on your next read.
-**KPI:** Saves · Shares
+**CTA:** Ask your first question today.
+**KPI:** Saves · Shares · Comments
 
 ---
 
@@ -56,13 +105,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** Daniel struggles to stay consistent with long study sessions — switches to a small daily habit instead, and it finally sticks.
-**Thumbnail:** "ABIDE IN THE WORD"
+**Thumbnail:** "Abide In The Word"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Abide In The Word." Scene: an open Bible on a warm desk with a small daily-habit tracker/checklist visible in a journal beside it, soft morning light.
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "I used to try to study the Bible for an hour... maybe once a week." | Daniel flipping through a Bible quickly, looking tired, evening light. |
+| 2 | Introduce truth | "Then I read: 'If you abide in my word... you will know the truth.'" | Daniel finds John 8:31-32 in his Bible. |
+| 3 | Explain truth | "Abiding isn't a marathon session — it's staying in it, daily." | Close-up on the verse, Daniel nodding slowly. |
+| 4 | Deepen understanding | "So I stopped trying to do it all at once." | Daniel closes a thick study plan, sets it aside. |
+| 5 | Real-life application | "Now it's just ten minutes, every morning — small, but daily." | Daniel checks a small box in his journal's daily tracker, content. |
+| 6 | Encouragement | "Consistency beats intensity." | Window view of a plant on the sill, steadily growing in daily light. |
+| 7 | Invitation to reflect | "What's one small habit that could help you abide?" | Daniel looks up, peaceful, morning light. |
+| 8 | Hopeful conclusion | "Stay in it daily. That's what abiding looks like." | Slow pull-back wide shot of the desk at sunrise; negative space top third for end-screen. |
 
 **Caption:** Studying the Bible isn't about long sessions — it's about staying in it daily. What's one small habit that could help you abide?
 **Hashtags:** #Disciplefy #WalkingWithJesus #AbideInHim #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — John 8:31 + 🙏 Prayer — "Lord, help me abide in Your word today, even if just for a few minutes."
+  - **Daily Verse Image Prompt fill (Variant C — Split Layout):** VERSE: "if you abide in my word... you will know the truth." · REFERENCE: "John 8:31-32" · BACKGROUND: "Morning desk with Bible, window light."
 - Evening: Share Reel + 📖 Reflection — What's one small habit you'll try this week?
 
 **CTA:** What's one small habit you'll try?
@@ -77,11 +142,22 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Cover → Every verse was written TO someone first → Why that matters for you → A quick way to find out who → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "Who Was This Written To?" Bright cream desk scene, open Bible, gold "Swipe →" cue bottom-right. | Every verse in the Bible was written TO someone, long before it was written FOR you. Here's why that matters. |
+| 2 — Written to someone first | Headline: "Every Verse Had a First Reader." Scene: open Bible with a soft-focus historical map motif kept subtle in the background (abstract, not literal). | Paul's letters had a first reader. The Psalms had a first singer. Knowing who that was changes how you read what they wrote. |
+| 3 — Why that matters | Headline: "Context Changes the Meaning." Scene: journal note contrasting "then" and "now" understanding of a verse. | Skip this step, and it's easy to read modern assumptions into an ancient letter — context protects you from that. |
+| 4 — A quick way to find out who | Headline: "Check the Book's Opening Lines." Scene: open Bible turned to a book's introduction/opening verses, highlighted. | Quick way to find out who a book was written to: check its opening lines. Most books tell you right away. |
+| 5 — CTA | Headline: "Try It on Your Next Chapter" with gold arrow →. Warm closing desk scene. | Try it on your next chapter — ask who this was for, before you ask what it means for you. |
+
 **Caption:** Every verse was written TO someone, before it was written FOR you. Knowing the original audience changes how you read it. Save this study tip.
 **Hashtags:** #Disciplefy #BibleStudyMethod #OriginalAudience #Scripture
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Nehemiah 8:8 + 💡 Tip — "Ask: who was this originally written to, and what did they need to hear?"
+  - **Daily Verse Image Prompt fill (Variant D — Minimalist Typography):** VERSE: "they read from the book... and gave the sense, so that the people understood the reading." · REFERENCE: "Nehemiah 8:8" · BACKGROUND: "Morning desk with Bible, open journal (mood reference only — Variant D has no photo)."
 - Evening: Share Carousel + 📖 Reflection — Try it on your next chapter.
 
 **CTA:** Try it on your next chapter.
@@ -95,13 +171,29 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Production:** Google Flow / Veo AI
 **Story beat:** A believer facing an uncertain situation is reminded, step by step, that God's presence doesn't depend on the outcome.
-**Thumbnail:** "FEAR NOT"
+**Thumbnail:** "Fear Not"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above)*:
+> Headline: "Fear Not." Scene: an open Bible turned to Isaiah 41, warm evening lamp light, a steady hand resting gently on the page (calm, not dramatic).
+
+**Google Flow / Veo Prompt (8 clips × 5s, prepend Daniel STYLE BLOCK above):**
+
+| Clip | Purpose | Voice-over | Visual Prompt |
+|---|---|---|---|
+| 1 | Hook | "There's a situation I still don't know the outcome of." | Daniel staring at a document/letter on his desk, uneasy, evening light. |
+| 2 | Introduce truth | "Isaiah wrote: 'Fear not, for I am with you.'" | Daniel opens his Bible to Isaiah 41. |
+| 3 | Explain truth | "Fear whispers you're alone. God says otherwise." | Close-up on the verse, Daniel's shoulders easing. |
+| 4 | Deepen understanding | "His presence doesn't depend on how the situation turns out." | Daniel sets the document aside, breathes out. |
+| 5 | Real-life application | "So tonight, instead of spiraling, I just sat with that truth." | Daniel sits quietly, hands folded, soft lamp light. |
+| 6 | Encouragement | "He upholds you with His righteous right hand — even now." | Window view of a calm night sky, steady and still. |
+| 7 | Invitation to reflect | "What fear can you hand to God today?" | Daniel looks toward the window, calm, at peace. |
+| 8 | Hopeful conclusion | "Fear not. He is with you." | Slow pull-back wide shot of the desk in warm lamp light; negative space top third for end-screen. |
 
 **Caption:** Fear whispers you're alone. God says otherwise: "Fear not, for I am with you." Tag someone who needs this today. 💛
 **Hashtags:** #Disciplefy #GrowingInChrist #FearNot #Encouragement
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Isaiah 41:10 + 🙏 Prayer — "Lord, calm my fear with the truth that You are near."
+  - **Daily Verse Image Prompt fill (Variant E — Framed Photo):** VERSE: "fear not, for I am with you... I will strengthen you, I will help you." · REFERENCE: "Isaiah 41:10" · BACKGROUND: "Rainy window, warm candlelight inside."
 - Evening: Share Reel + 📖 Reflection — What fear can you hand to God today?
 
 **CTA:** Share this with someone who needs it today.
@@ -115,15 +207,18 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Story beat:** While studying a difficult passage, someone asks Discipler a question. Instead of giving a shortcut answer, it guides them back to the passage, its context, and related Scriptures.
 **Feature shown:** Discipler
-**Thumbnail:** "CAN I ASK A QUESTION?"
+**Thumbnail:** "Can I Ask a Question?"
+**Thumbnail Image Prompt** *(prepend Thumbnail STYLE BLOCK above; this is the only generated asset for Saturday — the Reel itself is a real screen recording, not generated)*:
+> Headline: "Can I Ask a Question?" Scene: a smartphone resting upright beside an open Bible, a soft gold soundwave glow on the phone screen implying a spoken question, warm evening lamp light — bright and warm, not moody.
 
-**Caption:** Stuck on a hard passage? Discipler doesn't give you a shortcut answer — it guides you back to the passage, its context, and related Scripture. Free — link in bio.
+**Caption:** Stuck on a hard passage? Discipler doesn't give you a shortcut answer — it guides you back to the passage, its context, and related Scripture. Free — link in bio. Follow along — a new feature walkthrough every Saturday.
 **Hashtags:** #Disciplefy #Discipler #FaithQuestions #Discipleship
 
 **Theology-safe note:** Discipler copy must always frame it as a companion that points back to Scripture and community — never a replacement for pastor, church, or the Bible itself.
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Matthew 7:7 + 💡 Tip — "No question is too basic to ask Discipler — that's what it's there for."
+  - **Daily Verse Image Prompt fill (Variant F — Side-by-Side):** VERSE: "Ask, and it will be given to you; seek, and you will find." · REFERENCE: "Matthew 7:7" · BACKGROUND: "Morning desk with Bible, window light."
 - Evening: Share Reel + 📖 Reflection — Ask Discipler your first question today.
 
 **CTA:** Ask your first question today.
@@ -142,11 +237,23 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 **Slides:** Cover ("One month in — here's everything you've learned") → Week 1: Launch + 4 features → Week 2: rest, context, quiet time, study method, God isn't finished → Week 3: love your neighbor, pray first, prayer habit, observe, wait on God → Week 4: uncomfortable passages, better questions, abide daily, original audience, fear not → featured testimonies → Disciplefy CTA
 
+**Slide Image Prompts** *(prepend Carousel STYLE BLOCK above)*:
+
+| Slide | Prompt | Caption (on-slide text) |
+|---|---|---|
+| 1 — Cover | Headline: "One Month In." Subline: "Here's everything you've learned." Bright cream desk scene, open Bible + journal, warm golden light. | One month in. You've studied Scripture, built new habits, and (hopefully) asked Disciplefy a question or two. Here's everything, swipe through → |
+| 2 — Week 1 recap | Headline: "Week 1: Launch + 4 Core Features." 2×2 gold icon grid (Study Guide, Learning Paths, Memory Verses, Discipler) — same icon set as Week 1's Sunday slide, for series consistency. | It all started with launch week — 4 core features (Study Guide, Learning Paths, Memory Verses, Discipler), and an app finally live. |
+| 3 — Weeks 2-3 recap | Headline: "Rest · Context · Neighbor · Prayer · Waiting." Small gold-icon chip row on a clean cream card. | Weeks 2-3 covered rest, context, loving your neighbor, prayer, and waiting on God's timing. |
+| 4 — Week 4 recap | Headline: "Hard Passages · Better Questions · Abide · Fear Not." Small gold-icon chip row, matching Slide 3's layout. | Week 4 pushed further — sitting with hard passages, asking better questions, abiding daily, and trusting "fear not." |
+| 5 — Featured testimonies | Headline: "In Your Words." Scene: a warm card layout with space for 1-2 short testimony quotes (added in edit from real submissions), gold quotation-mark accent. | Real people, real stories — here's what a month of studying with Disciplefy looked like for a few of you. |
+| 6 — CTA | Headline: "Have a Disciplefy Story?" with gold arrow →. Subline: "Send it in — link in bio." | Got your own story? We'd love to feature it — send it in, link in bio. |
+
 **Caption:** One month in. You've studied Scripture, built new habits, and (hopefully) asked Disciplefy a question or two along the way. Thank you for being part of this from the start. Carry it into worship today — and if you have a story, we'd love to feature it. 🙏
 **Hashtags:** #Disciplefy #SundayReflection #Worship #OneMonthIn #Discipleship
 
 **Stories (2x/day):**
 - Morning: 📖 Verse — Hebrews 10:25 + 🙏 Prayer — "Lord, thank You for this month. Help me carry all of it into worship today."
+  - **Daily Verse Image Prompt fill (Variant G — Vertical Bookmark):** VERSE: "...not neglecting to meet together, as is the habit of some, but encouraging one another..." · REFERENCE: "Hebrews 10:25" · BACKGROUND: "Church pew, soft morning light through a window."
 - Evening: Share Carousel + 📖 Reflection — What's one thing from this month you'll keep practicing into Month 2?
 
 **CTA:** Have a Disciplefy story? Send it in — link in bio.
@@ -154,8 +261,21 @@ Instagram Reel / Carousel → Profile Visit → disciplefy.in → App Install �
 
 ---
 
+## Growth Additions (2026)
+Full detail in `Content_Playbook_Season1_Week1.md` → "Growth Additions" — three tactics: (1) Follow-CTA, one rotating slot/week (this week: Saturday's Ep13 Hero caption, done above), (2) trending audio on the Daniel Reels where mood fits, skip if nothing matches, (3) Stories interactive stickers 2-3x/week, not daily. Carry these into Month 2 planning as a standing practice, not just a Month 1 experiment.
+
 ## Production Rhythm
 Same rolling model — produce Month 2 Week 1's content while this week publishes. Use Month 1's KPIs (see Success Metrics below) to inform Month 2 planning per the Operating System's Monthly Review Questions.
 
 ## Success Metrics
 Track at the end of the week — and roll up the full month: Reel Reach · Watch Time · Saves · Shares · Profile Visits · Website Clicks · App Installs.
+
+---
+
+## Changelog
+- **v1.1:** Added detailed generation prompts for everything that isn't a real screen recording: shared Daniel-character Google Flow/Veo STYLE BLOCK + full 8-clip prompt tables for the Mon/Wed/Fri Reels, a Thumbnail STYLE BLOCK + one prompt per day, and Carousel STYLE BLOCK + slide-by-slide prompts for Tue/Thu and the full-month Sunday recap.
+- **v1.2:** Added a Daily Verse Story image-generation template + per-day Verse/Reference/Background fill for all 7 Morning Stories — previously named a verse reference with no actual image prompt.
+- **v1.3:** Switched to Week 1's 7 rotating layout variants (one per weekday) instead of one fixed daily layout — updated each day's fill to tag its variant.
+- **v1.4:** Added a per-slide Caption to every carousel (Tue/Thu/Sun) — Instagram now supports a distinct caption per carousel image (rolled out June 2026), shown as viewers swipe. Captions add commentary/context beyond the on-image headline text, not a repeat of it.
+- **v1.5:** Tuesday swapped from Bible Tips to a Discipler feature carousel — pairs 2 days ahead of Saturday's Episode 13 reel. Displaced Bible Tips bank item deferred to Month 2.
+- **v1.6:** Added a Follow-CTA to Saturday's Episode 13 Hero caption and a "Growth Additions (2026)" pointer section (full detail lives in Week 1). Noted these 3 tactics should carry into Month 2 as standing practice, not a one-off.

--- a/docs/marketing/Prompts/Bible Tips.md
+++ b/docs/marketing/Prompts/Bible Tips.md
@@ -1,0 +1,271 @@
+# Bible Tips — Content Bank
+
+Converted from `Bible Tips.docx`. Source card copy (Heading / Title / Content / Footer) plus AI image-generation prompts for **Instagram Story/post cards** in the Tuesday "Bible Tips" series, along with a second bonus set of "Daily Encouragement" cards found in the same file.
+
+> **Note — scope of this file:** The source document actually contains three distinct content sets: (1) 10 **Bible Tips** cards, (2) 10 **Daily Encouragement** cards (a different, non-Tuesday content type — these read like general daily-encouragement/quote cards, not Bible-study tips), and (3) 15 **image-generation prompts** covering both sets. All three are preserved below, clearly separated, so nothing from the source is lost. If "Daily Encouragements" belongs in a separate content library (e.g. a future daily-encouragement series) rather than this Bible Tips file, that's a filing decision for a human to make — flagging rather than moving it silently.
+
+---
+
+## ⚠️ Note: Overlap with the existing Tuesday "Bible Tips" bank
+
+`docs/marketing/Strategy/Daily Devotion/2. Tuesday — Bible Tips Carousel.md` already maintains a 43-topic bank for this same Tuesday series. Comparing titles/themes, **8 of the 10 tips below conceptually overlap** with topics already in that bank — in one case the title is *identical*:
+
+| # below | This file's title | Existing bank match | Notes |
+|---|---|---|---|
+| 1 | Pray Before You Read | #2 "Pray Before You Read" *(used Week 3)* | **Identical title.** Existing bank marks this as already used/posted. |
+| 2 | Don't Read Just One Verse | #1 "Read the Bible in Context" *(used Week 2)* | Same concept, different title/copy. |
+| 3 | Ask Three Questions | #3 "Ask Better Questions While Reading" *(used Week 4)* | Same concept, different title/copy. |
+| 4 | Take One Truth With You | *(no clear match)* | Possibly new territory — closest existing item is #11 "Apply Before You Move On," but angle differs (carry one truth vs. apply before moving on). |
+| 5 | Write What God Teaches You | #8 "Use a Bible Journal Effectively" | Same concept, different title/copy. |
+| 6 | Knowledge Isn't the Goal | #11 "Apply Before You Move On" | Same concept, different title/copy. |
+| 7 | Small Steps Every Day | #12 "Build a Daily Bible Study Habit" | Same concept, different title/copy. |
+| 8 | Let Scripture Explain Scripture | #5 "Use Cross References" | Same concept, different title/copy. |
+| 9 | Hide God's Word in Your Heart | #10 "Memorize Scripture Effectively" | Same concept, different title/copy. |
+| 10 | Turn Reading into Conversation | *(no clear match)* | Genuinely new — the 43-item bank has no "end your reading in prayer" topic. |
+
+**This needs a human decision**, not a silent merge: is this file (a) the actual ready-to-post *card copy* for 8 of the existing bank's topics (in which case it should be linked/merged into that bank rather than treated as new content), or (b) a separate/earlier draft that a decision was already made to supersede with the 43-topic bank? Recommend reconciling before scheduling any of these 10 cards, to avoid posting near-duplicate content back-to-back (especially #1, whose title exactly matches an already-*used* post).
+
+---
+
+## Bible Tips (10 cards)
+
+### 1. Start with Prayer
+- **Heading:** Bible Tip
+- **Title:** Pray Before You Read
+- **Content:** Before opening your Bible, ask God to give you wisdom, understanding, and a heart ready to obey His Word.
+- **Footer:** God speaks through His Word.
+
+### 2. Read the Context
+- **Heading:** Bible Tip
+- **Title:** Don't Read Just One Verse
+- **Content:** Read the verses before and after your passage. Understanding the context helps you understand God's intended message.
+- **Footer:** Context brings clarity.
+
+### 3. Ask Simple Questions
+- **Heading:** Bible Tip
+- **Title:** Ask Three Questions
+- **Content:**
+  - What does this teach about God?
+  - What does this teach about people?
+  - How should I respond today?
+- **Footer:** Read. Reflect. Respond.
+
+### 4. Highlight One Truth
+- **Heading:** Bible Tip
+- **Title:** Take One Truth With You
+- **Content:** Instead of trying to remember everything, choose one truth from today's reading and carry it throughout your day.
+- **Footer:** One truth can change your day.
+
+### 5. Keep a Journal
+- **Heading:** Bible Tip
+- **Title:** Write What God Teaches You
+- **Content:** Record insights, questions, answered prayers, and lessons. Spiritual growth becomes easier to see over time.
+- **Footer:** Your journey matters.
+
+### 6. Apply the Scripture
+- **Heading:** Bible Tip
+- **Title:** Knowledge Isn't the Goal
+- **Content:** Ask yourself: "What is one practical way I can obey this passage today?"
+- **Footer:** God's Word is meant to be lived.
+
+### 7. Read Consistently
+- **Heading:** Bible Tip
+- **Title:** Small Steps Every Day
+- **Content:** Reading for 10 minutes daily is often more effective than reading for an hour once a week.
+- **Footer:** Consistency builds faith.
+
+### 8. Compare Scripture
+- **Heading:** Bible Tip
+- **Title:** Let Scripture Explain Scripture
+- **Content:** Look for related passages that speak about the same topic. The Bible often interprets itself.
+- **Footer:** Discover deeper connections.
+
+### 9. Memorize One Verse
+- **Heading:** Bible Tip
+- **Title:** Hide God's Word in Your Heart
+- **Content:** Choose one verse each week to memorize. Repeating it throughout the day helps it become part of your life.
+- **Footer:** Truth remembered is truth available.
+
+### 10. End with Prayer
+- **Heading:** Bible Tip
+- **Title:** Turn Reading into Conversation
+- **Content:** After reading, thank God for what you've learned and ask Him to help you live it out today.
+- **Footer:** Bible study ends with prayer—and begins with obedience.
+
+**Theological review:** All 10 tips are doctrinally sound, standard evangelical hermeneutical practice (context-first reading, Scripture interpreting Scripture, prayerful posture, application over mere knowledge, memorization). No issues flagged. Tone matches Disciplefy's voice — encouraging and practical, not preachy.
+
+---
+
+## Daily Encouragements (10 cards)
+
+*Note: this is a different content type from "Bible Tips" — no Bible-study instruction, just short devotional encouragement. Included here only because it appeared in the same source file; consider whether it belongs in its own content bank/series instead.*
+
+### 1. God Is With You
+- **Heading:** Daily Encouragement
+- **Title:** You Are Never Alone
+- **Content:** No matter what you're facing today, God walks beside you. His presence is your greatest source of peace and strength.
+- **Footer:** He will never leave you.
+
+### 2. Trust God's Timing
+- **Heading:** Daily Encouragement
+- **Title:** Wait With Hope
+- **Content:** God is never late. Even when you don't understand His timing, He is working for your good behind the scenes.
+- **Footer:** His timing is perfect.
+
+### 3. Grace Is Enough
+- **Heading:** Daily Encouragement
+- **Title:** Rest In His Grace
+- **Content:** You don't have to earn God's love. His grace meets you where you are and gives you strength for today.
+- **Footer:** Grace changes everything.
+
+### 4. Keep Praying
+- **Heading:** Daily Encouragement
+- **Title:** Don't Give Up
+- **Content:** Every prayer is heard by God. Keep praying faithfully, even when the answer hasn't arrived yet.
+- **Footer:** Prayer changes hearts.
+
+### 5. Hope Never Fails
+- **Heading:** Daily Encouragement
+- **Title:** Hold On To Hope
+- **Content:** Even in difficult seasons, God's promises remain true. Hope rooted in Christ never disappoints.
+- **Footer:** Hope anchors the soul.
+
+### 6. God Gives Strength
+- **Heading:** Daily Encouragement
+- **Title:** Strength For Today
+- **Content:** You don't have to carry today's burdens alone. God gives fresh strength to everyone who trusts Him.
+- **Footer:** His strength is enough.
+
+### 7. Start Again
+- **Heading:** Daily Encouragement
+- **Title:** Every Morning Is New
+- **Content:** Yesterday does not define you. God's mercy is new every morning, giving you a fresh beginning.
+- **Footer:** His mercy never ends.
+
+### 8. Walk By Faith
+- **Heading:** Daily Encouragement
+- **Title:** Take The Next Step
+- **Content:** Faith isn't seeing the whole journey. It's trusting God enough to take the next step He places before you.
+- **Footer:** Faith grows one step at a time.
+
+### 9. God Is Faithful
+- **Heading:** Daily Encouragement
+- **Title:** He Keeps His Promises
+- **Content:** People may disappoint, but God never fails. Every promise He has spoken is trustworthy.
+- **Footer:** God always remains faithful.
+
+### 10. Peace For Today
+- **Heading:** Daily Encouragement
+- **Title:** Choose His Peace
+- **Content:** When anxiety begins to rise, bring every concern to God. His peace will guard your heart and mind.
+- **Footer:** Peace begins with prayer.
+
+**Theological review:** All 10 are orthodox and gospel-consistent (grace not earned — #3 correctly reflects salvation by grace, not works; God's faithfulness/mercy — #7 echoes Lamentations 3:22–23 accurately). No prosperity-gospel or misleading claims found. Generic devotional tone — fine for an encouragement series, though noticeably more "greeting card" than Disciplefy's usual Scripture-grounded voice; consider anchoring each with an explicit verse reference if these get scheduled, for consistency with house style.
+
+---
+
+## Image-Generation Prompts (15)
+
+The source file includes 15 ready-made AI image prompts (8 for Bible Tips scenes, 7 for Encouragement scenes) reusing one shared template with a swapped-out scene description.
+
+> **Resolved — indigo replaced with gold:** These prompts previously specified "subtle indigo (#4F46E5) accents" — the Product/App UI color system, not Marketing/Social. Per `docs/marketing/Strategy/03 Disciplefy Visual Bible.md` ("Color System — Marketing/Social") and the canonical STYLE BLOCK in `Instagram_Carousel_Image_Prompts.md`, indigo has been replaced with the marketing gold accent (`#B8860B`) throughout the prompts below.
+>
+> **Still flagged, not fixed — AI-rendered text:** These prompts ask the model to render the tip title/description directly, whereas house convention (`Instagram_Carousel_Image_Prompts.md`) is to generate text-free and composite real text in Canva, since AI-rendered text is unreliable. Left as-is pending a decision on whether to patch these prompts to drop the in-image text instruction.
+
+### Prompt 1 — Bible Tip • Study Desk
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app. Use the uploaded Disciplefy logo exactly as provided. Place it centered at the top. Follow Disciplefy's Material 3 design language using a warm cream (#FAF8F5) background, subtle deep gold (#B8860B) accents, soft gold (#FFEEC0) information card, Poppins ExtraBold for the main heading, Poppins Bold for the tip title, Inter Medium for the tip description, and Inter Regular for the footer, rounded Material 3 cards (8px), soft shadows, elegant whitespace, and Apple-quality marketing aesthetics.
+Create a peaceful Bible study desk with an open Bible, notebook, fountain pen, ceramic coffee mug, and warm morning sunlight.
+- **Heading:** 📖 Bible Study Tip
+- Create a large premium Material 3 information card containing: `[TIP TITLE]` / `[TIP DESCRIPTION]`. Ensure the information card occupies approximately 50–60% of the canvas. The body text should be large and readable on a mobile device. If needed, reduce decorative elements rather than shrinking the text.
+- **Footer:** Grow deeper in God's Word.
+- **Website:** disciplefy.in
+
+### Prompt 2 — Bible Tip • Open Bible Flat Lay
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app. Use the uploaded Disciplefy logo exactly as provided. Place it centered at the top. Follow Disciplefy's Material 3 design language using a warm cream (#FAF8F5) background, subtle deep gold (#B8860B) accents, soft gold (#FFEEC0) information card, Poppins ExtraBold for the main heading, Poppins Bold for the tip title, Inter Medium for the tip description, and Inter Regular for the footer, rounded Material 3 cards (8px), soft shadows, elegant whitespace, and Apple-quality marketing aesthetics.
+- **Scene:** Top-down flat lay featuring an open Bible, notebook, highlighter, reading glasses, and soft linen fabric.
+- Typography: Poppins ExtraBold heading, Poppins Bold tip title, Inter Medium description, Inter Regular footer.
+- Create a large premium educational card in the center containing: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** Study with purpose.
+- **Website:** disciplefy.in
+
+### Prompt 3 — Bible Tip • Coffee & Bible
+Same base template as Prompt 1.
+- **Scene:** Warm coffee beside an open Bible on a wooden table with gentle morning sunlight.
+- Card containing: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** One chapter at a time.
+- **Website:** disciplefy.in
+
+### Prompt 4 — Bible Tip • Minimal Editorial
+Same base template.
+- **Scene:** Minimal warm cream background with elegant gold dividers and subtle gold accents. No photography except a small Bible illustration.
+- **Heading:** Bible Tip
+- Placeholder: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** Read. Reflect. Apply.
+
+### Prompt 5 — Bible Tip • Library
+Same base template.
+- **Scene:** Classic library with wooden shelves, open Bible on a study table, warm reading lamp, notebook, and soft lighting.
+- Card: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** Discover God's truth.
+
+### Prompt 6 — Bible Tip • Ancient Manuscript
+Same base template.
+- **Scene:** Ancient scroll beside an open Bible with parchment textures, olive branches, clay oil lamp, and warm sunlight.
+- Card: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** God's Word is timeless.
+
+### Prompt 7 — Bible Tip • Scandinavian Study
+Same base template.
+- **Scene:** Minimal Scandinavian workspace with Bible, iPad, notebook, ceramic vase, and warm cream styling. Modern Material 3 information card.
+- Placeholder: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** Study intentionally.
+
+### Prompt 8 — Bible Tip • Classroom
+Same base template.
+- **Scene:** Teacher's wooden desk with Bible, notebook, chalkboard background, and warm lighting.
+- Card: `[TIP TITLE]` / `[TIP DESCRIPTION]`.
+- **Footer:** Learn. Grow. Live.
+
+### Prompt 9 — Encouragement • Sunrise
+Same base template.
+- **Scene:** Beautiful sunrise over mountains with warm golden light.
+- Card containing: `[ENCOURAGEMENT TITLE]` / `[ENCOURAGEMENT MESSAGE]`.
+- **Footer:** God is with you today.
+- **Website:** disciplefy.in
+
+### Prompt 10 — Encouragement • Forest
+Same base template.
+- **Scene:** Peaceful forest trail with soft sunlight filtering through trees.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** Walk by faith.
+
+### Prompt 11 — Encouragement • Lakeside
+Same base template.
+- **Scene:** Quiet lakeside at sunrise with reflections on still water.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** Be still before Him.
+
+### Prompt 12 — Encouragement • Rainy Window
+Same base template.
+- **Scene:** Rain-covered window, open Bible, candle, warm coffee, cozy blanket.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** God is near.
+
+### Prompt 13 — Encouragement • Candlelight
+Same base template.
+- **Scene:** Single candle illuminating an open Bible on a walnut table.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** His light never fades.
+
+### Prompt 14 — Encouragement • Meadow
+Same base template.
+- **Scene:** Wildflower meadow during golden hour. Open Bible resting on natural wood. Soft breeze.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** Hope grows here.
+
+### Prompt 15 — Encouragement • Night Sky
+Same base template.
+- **Scene:** Beautiful starry sky above quiet mountains. Open Bible illuminated softly. Minimal design.
+- Card: `[TITLE]` / `[MESSAGE]`.
+- **Footer:** Rest in His promises.
+- **Website:** disciplefy.in

--- a/docs/marketing/Prompts/Daily Bible Verse v2.md
+++ b/docs/marketing/Prompts/Daily Bible Verse v2.md
@@ -1,0 +1,209 @@
+# Daily Bible Verse v2 — Instagram Story Prompt Template
+
+AI image-generation prompt for the recurring **"Today's Verse"** Instagram Story series (1080×1920, 9:16). Fill in `{{VERSE}}`, `{{REFERENCE}}`, and `{{BACKGROUND}}` each day; everything else must stay fixed so the series reads as one consistent, recognizable Disciplefy format.
+
+> **Note — review before using as the daily production template:** this v2 draft carries several unresolved tensions with the current brand system (`docs/marketing/Strategy/03 Disciplefy Visual Bible.md`) and the approved carousel STYLE BLOCK (`docs/marketing/Instagram_Carousel_Image_Prompts.md`). See **Review Notes** at the bottom before treating this as final. The template text below is preserved exactly as written in the source doc; only formatting was cleaned up.
+
+## Placeholders
+
+| Placeholder | Filled with |
+|---|---|
+| `{{VERSE}}` | The Bible verse text for the day |
+| `{{REFERENCE}}` | The Bible reference (e.g. "John 3:16") |
+| `{{BACKGROUND}}` | A short description of the background scene/theme for the day |
+
+---
+
+## Prompt Template
+
+You are the Lead Brand Designer for Disciplefy.
+
+Your task is to design ONE premium Instagram Story (1080×1920, 9:16) following Disciplefy's official visual system.
+
+This is part of the recurring "Today's Verse" series.
+
+Every day's design should immediately be recognizable as Disciplefy.
+
+**DO NOT redesign the layout.**
+Only change:
+- Bible verse
+- Bible reference
+- Background scene
+
+Everything else should remain consistent.
+
+### Verse
+
+`{{VERSE}}`
+
+### Reference
+
+`{{REFERENCE}}`
+
+### Background Theme
+
+`{{BACKGROUND}}`
+
+---
+
+## Brand Identity
+
+- Warm
+- Peaceful
+- Premium
+- Minimal
+- Cinematic
+- Scripture-first
+
+Material 3 design.
+
+Apple-quality marketing.
+
+Photography should be realistic.
+
+Never use illustrations.
+
+Never use AI-looking imagery.
+
+Never use fantasy effects.
+
+> **Note — "Material 3 design" + "Apple-quality marketing" appear together:** Material 3 is Google's design system (and matches the app's own Flutter/Material 3 UI per `CLAUDE.md`), while "Apple-quality" points to a different aesthetic sensibility, and the Visual Bible's Marketing/Social section doesn't reference Material Design at all. This pairing (also echoed later as "Soft Material shadow" in the Layout section) suggests this prompt may have been adapted from Product/App brief language rather than written fresh for the Marketing/Social system. Flagging for a decision: keep "Material 3" as an elevation/shadow-style cue, or drop it in favor of the Visual Bible's own photography/typography language.
+
+> **Note — "Never use AI-looking imagery" / "Photography should be realistic" vs. this being an AI-generated (Google Flow/Veo) image:** the instruction is presumably shorthand for "the generated image shouldn't *look* AI-generated — it should read as real photography" (avoiding plastic skin, warped hands, over-saturation, etc.), which is a legitimate and common AI image-gen instruction. But as written it reads as a literal contradiction (the whole image *is* AI-generated), which could cause a model to hedge or under-deliver on realism. Worth rephrasing explicitly, e.g. "photorealistic — must not look AI-generated" or "avoid telltale AI-image artifacts," to remove the ambiguity for a daily-recurring prompt. Left as-is here pending a decision.
+
+---
+
+## Color Palette
+
+| Role | Color |
+|---|---|
+| Background | `#FAF8F5` |
+| Primary | `#B8860B` (Deep Gold) |
+| Secondary | `#C79A3B` (Warm Gold) |
+| Verse Card | `#FFEEC0` |
+| Heading | `#1E1E1E` |
+| Body | `#4B5563` |
+| Footer | `#6B7280` |
+
+Gold accents should match the Disciplefy logo (`#B8860B` / `#C79A3B`, per the Visual Bible).
+
+> **Resolved — Primary/Secondary drift into the Product/App indigo system:** Primary/Secondary previously listed `#4F46E5` (Indigo 600) / `#6366F1` (Indigo 500) — the Product/App brand primaries per the Visual Bible's "Scope: Two Visual Systems" section, confirmed live in `frontend/lib/core/theme/app_colors.dart`. Nothing in this template's Layout section actually called for an indigo element (divider, heading, and card were all already gold/charcoal/cream), so this was a leftover copy-paste from the Product/App palette. Replaced with the two marketing gold shades above (`#B8860B` deep gold / `#C79A3B` lighter gold), matching "Color System — Marketing/Social."
+>
+> **Note — Footer `#6B7280`:** not one of the Visual Bible's defined neutrals (closest are Slate `#4B5563` and Soft Light `#E0E0E0`). Minor drift — likely fine as a lighter warm-gray tint for footer text, but worth confirming against the official palette rather than assuming.
+
+---
+
+## Typography
+
+**Headings:** Poppins ExtraBold
+
+**Verse:** Inter Medium
+
+**Reference:** Poppins Bold
+
+Large spacing.
+
+Excellent readability.
+
+Never reduce font size just because the verse is long.
+
+Instead:
+- Increase the card height.
+- Simplify the background.
+- Reduce decorative elements.
+
+Scripture must always remain easy to read.
+
+> **Note — "Poppins ExtraBold" vs. Visual Bible's "Poppins, 600–700":** ExtraBold is typically weight 800, heavier than the 600–700 (SemiBold–Bold) range specified for headlines in the Visual Bible. Minor drift; confirm if ExtraBold is an intentional exception for the Story heading treatment.
+>
+> **Note — non-English verses (Hindi/Malayalam):** Disciplefy supports English, Hindi, and Malayalam (per `CLAUDE.md`), but this template only specifies Poppins/Inter, which don't cover Devanagari or Malayalam scripts. If this daily series runs in all three languages, the template needs a font-substitution rule (or an explicit "English-only" scope) to stay visually consistent day-to-day.
+
+---
+
+## Layout
+
+**Top**
+- Disciplefy logo (use uploaded logo exactly)
+- Gold divider
+- Heading: "Today's Verse"
+
+**Middle**
+- Large premium Scripture Card
+- Rounded 12px
+- Soft Material shadow
+- Warm gold background
+- Large quotation mark icon
+- Reference at top
+- Verse centered
+- Generous padding
+
+**Bottom**
+- disciplefy.in
+- Small gold divider
+- No CTA
+- No marketing text
+- No buttons
+- No encouragement
+- No hashtags
+
+> **Note — Instagram Story safe zones not addressed:** native IG Story UI reserves roughly the top ~250px (profile/close button) and bottom ~250px (reply bar) of the 1080×1920 canvas. The template doesn't instruct the model to keep the logo, heading, or footer clear of those zones, which risks clipping/overlap in a full-bleed design — worth adding as an explicit safe-margin instruction for daily consistency.
+
+---
+
+## Background Photography
+
+Create ONE realistic premium devotional scene based on:
+
+`{{BACKGROUND}}`
+
+**Examples**
+- Morning desk with Bible
+- Window light
+- Coffee and Bible
+- Church pew
+- Forest prayer walk
+- Olive tree
+- Rainy window
+- Candlelight
+- Mountain sunrise
+- Lakeside
+- Library
+- Garden bench
+
+**Requirements**
+- Warm natural light
+- Realistic photography
+- Open Bible
+- Minimal composition
+- Large negative space
+- Soft shadows
+- Golden hour
+- Apple-quality photography
+- No people.
+- No hands.
+- No distracting objects.
+
+Scripture card must remain the hero.
+
+---
+
+## Design Rules
+
+- The verse card should occupy approximately 55% of the design.
+- Background exists only to support the verse.
+- Everything should feel calm, modern, premium, minimal.
+- The viewer's eyes should immediately go to the Scripture.
+- The final result should look like it belongs to an elegant devotional book rather than a social media graphic.
+
+---
+
+## Review Notes (summary)
+
+- **Color palette drift (resolved):** Primary/Secondary used Product/App indigo (`#4F46E5`/`#6366F1`), contradicting the Visual Bible's "no indigo for Marketing/Social" rule — replaced with the gold accent pair.
+- **AI-imagery tension (flagged):** "Never use AI-looking imagery" sits oddly against this being a Google Flow/Veo (AI-generated) prompt — likely means "don't look AI-generated," but is worth rephrasing for clarity.
+- **Material 3 vs. Apple-quality (flagged):** mixed design-system language (Google's Material 3 + "Apple-quality") not present in the Visual Bible's Marketing/Social guidance; may indicate this template was adapted from a Product/App brief.
+- **Typography weight (flagged):** "Poppins ExtraBold" is heavier than the Visual Bible's documented 600–700 range.
+- **Multi-language coverage (flagged):** no font fallback specified for Hindi/Malayalam verses.
+- **IG Story safe zones (flagged):** no instruction to keep logo/footer clear of native Instagram UI overlap zones.
+- **Gold accent hex (fixed):** clarified "match the Disciplefy logo" with the actual Visual Bible hex values (`#B8860B` / `#C79A3B`) so daily generations don't drift on gold tone.
+- **Formatting (fixed):** converted the flattened, one-phrase-per-line .docx text into structured markdown headers/bullets; no wording changes to instructions.

--- a/docs/marketing/Prompts/Daily Bible Verse.md
+++ b/docs/marketing/Prompts/Daily Bible Verse.md
@@ -1,0 +1,482 @@
+# Daily Bible Verse — "Today's Verse" Instagram Story Prompts (v1)
+
+Recurring Instagram Story series for the Disciplefy mobile app: a rotating verse list paired with 15 reusable image-generation prompts (uploaded logo + Material 3 design language + a scene). Each prompt is meant to be combined with one verse from the list below at posting time.
+
+> **Note — possible duplicate/v2:** A sibling "Daily Bible Verse v2" source (`Daily Bible Verse v2.docx`) exists in the same source folder but had not yet been converted to `docs/marketing/Prompts/Daily Bible Verse v2.md` at the time this file was written. Once v2 lands, compare the two — if v2 supersedes this template (same series, same verse list), consider consolidating rather than maintaining both. Not merged here per instructions.
+
+## Verse List (45 verses, KJV — Public Domain)
+
+> **Resolved — was mislabeled as ESV:** The source file header claimed "45 unique ESV verses," but nearly all entries were actually **KJV** text (archaic *thee/thou/thy/ye/hath/saith* pronouns ESV never uses). Two entries (Philippians 4:13, John 3:16) were genuinely ESV wording — Crossway-copyrighted and unlicensed here. Both have been swapped to their KJV equivalents below, and the set is now relabeled **KJV throughout, fully public domain**, consistent with project policy ("use Public Domain text for AI/RAG/TTS"). No ESV license needed.
+
+1. Isaiah 41:10 — Fear thou not; for I am with thee: be not dismayed; for I am thy God: I will strengthen thee; yea, I will help thee; yea, I will uphold thee with the right hand of my righteousness.
+2. Philippians 4:6-7 — Be careful for nothing; but in every thing by prayer and supplication with thanksgiving let your requests be made known unto God.
+3. Romans 8:28 — And we know that all things work together for good to them that love God, to them who are the called according to his purpose.
+4. Jeremiah 29:11 — For I know the thoughts that I think toward you, saith the LORD, thoughts of peace, and not of evil, to give you an expected end.
+5. Proverbs 3:5-6 — Trust in the LORD with all thine heart; and lean not unto thine own understanding.
+6. Isaiah 40:31 — But they that wait upon the LORD shall renew their strength; they shall mount up with wings as eagles; they shall run, and not be weary; and they shall walk, and not faint.
+7. Psalm 46:1 — God is our refuge and strength, a very present help in trouble.
+8. 2 Corinthians 5:17 — Therefore if any man be in Christ, he is a new creature: old things are passed away; behold, all things are become new.
+9. Matthew 11:28 — Come unto me, all ye that labour and are heavy laden, and I will give you rest.
+10. Isaiah 43:2 — When thou passest through the waters, I will be with thee; and through the rivers, they shall not overflow thee: when thou walkest through the fire, thou shalt not be burned; neither shall the flame kindle upon thee.
+11. Psalm 37:4 — Delight thyself also in the LORD; and he shall give thee the desires of thine heart.
+12. Isaiah 26:3 — Thou wilt keep him in perfect peace, whose mind is stayed on thee: because he trusteth in thee.
+13. Romans 15:13 — Now the God of hope fill you with all joy and peace in believing, that ye may abound in hope, through the power of the Holy Ghost.
+14. 1 Peter 5:7 — Casting all your care upon him; for he careth for you.
+15. Psalm 23:1 — The LORD is my shepherd; I shall not want.
+16. Joshua 1:9 — Have not I commanded thee? Be strong and of a good courage; be not afraid, neither be thou dismayed: for the LORD thy God is with thee whithersoever thou goest.
+17. Philippians 4:13 — I can do all things through Christ which strengtheneth me.
+18. Psalm 27:1 — The LORD is my light and my salvation; whom shall I fear? the LORD is the strength of my life; of whom shall I be afraid?
+19. Psalm 121:1-2 — I will lift up mine eyes unto the hills, from whence cometh my help.
+20. Psalm 34:8 — O taste and see that the LORD is good: blessed is the man that trusteth in him.
+21. Psalm 103:2-3 — Bless the LORD, O my soul, and forget not all his benefits.
+22. Psalm 118:24 — This is the day which the LORD hath made; we will rejoice and be glad in it.
+23. John 3:16 — For God so loved the world, that he gave his only begotten Son, that whosoever believeth in him should not perish, but have everlasting life.
+24. Proverbs 16:3 — Commit thy works unto the LORD, and thy thoughts shall be established.
+25. Psalm 91:1-2 — He that dwelleth in the secret place of the most High shall abide under the shadow of the Almighty.
+26. Psalm 46:10 — Be still, and know that I am God: I will be exalted among the heathen, I will be exalted in the earth.
+27. Psalm 103:8 — The LORD is merciful and gracious, slow to anger, and plenteous in mercy.
+28. Psalm 139:14 — I will praise thee; for I am fearfully and wonderfully made: marvellous are thy works; and that my soul knoweth right well.
+29. Psalm 42:11 — Why art thou cast down, O my soul? and why art thou disquieted within me? hope thou in God: for I shall yet praise him, who is the health of my countenance, and my God.
+30. Psalm 31:24 — Be of good courage, and he shall strengthen your heart, all ye that hope in the LORD.
+31. Psalm 25:5 — Lead me in thy truth, and teach me: for thou art the God of my salvation; on thee do I wait all the day.
+32. Psalm 34:17 — The righteous cry, and the LORD heareth, and delivereth them out of all their troubles.
+33. Psalm 30:5 — For his anger endureth but a moment; in his favour is life: weeping may endure for a night, but joy cometh in the morning.
+34. Psalm 27:10 — When my father and my mother forsake me, then the LORD will take me up.
+35. Proverbs 31:25 — Strength and honour are her clothing; and she shall rejoice in time to come.
+36. Psalm 29:11 — The LORD will give strength unto his people; the LORD will bless his people with peace.
+37. Psalm 92:2 — To shew forth thy lovingkindness in the morning, and thy faithfulness every night.
+38. Psalm 40:5 — Many, O LORD my God, are thy wonderful works which thou hast done, and thy thoughts which are to us-ward.
+39. Psalm 86:5 — For thou, Lord, art good, and ready to forgive; and plenteous in mercy unto all them that call upon thee.
+40. Psalm 57:7 — My heart is fixed, O God, my heart is fixed: I will sing and give praise.
+41. Psalm 46:5 — God is in the midst of her; she shall not be moved: God shall help her, and that right early.
+42. Psalm 138:8 — The LORD will perfect that which concerneth me: thy mercy, O LORD, endureth for ever.
+43. Psalm 62:5-6 — My soul, wait thou only upon God; for my expectation is from him.
+44. Psalm 139:17-18 — How precious also are thy thoughts unto me, O God! how great is the sum of them!
+45. Psalm 23:6 — Surely goodness and mercy shall follow me all the days of my life: and I will dwell in the house of the LORD for ever.
+
+---
+
+## Color palette check vs. Visual Bible
+
+> **Resolved — indigo drift from Marketing/Social palette:** Every prompt previously listed "Primary/Secondary Accent: Indigo (#4F46E5 / #6366F1)" — the Product/App palette, not Marketing/Social. Per `docs/marketing/Strategy/03 Disciplefy Visual Bible.md` → "Color System — Marketing/Social," these have been replaced with the marketing gold accents (Deep Gold `#B8860B` / Warm Gold `#C79A3B`) throughout, matching the approved Instagram carousel reference. The Warm Cream (#FAF8F5) background, Soft Gold (#FFEEC0) scripture-card color, and Near Black (#1E1E1E) heading color were already correctly aligned and left as-is.
+
+> **Note — missing canvas dimensions in later prompts:** Prompts 1–6 specify **"1080 × 1920 px (9:16)"**; Prompt 7 keeps 1080×1920 but drops the "(9:16)" label; Prompts 8–15 drop the explicit dimensions entirely ("Create a premium Instagram Story..."). Since these are meant to be a consistent recurring series, consider adding the explicit `1080 × 1920 px (9:16)` spec back to Prompts 8–15 for consistency — flagged rather than changed, since it's possible this was an intentional shorthand once the format was established.
+
+---
+
+## Prompt 1 – Morning Devotion
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as provided. Do not recreate, redraw, recolor, or modify it. Place the logo centered at the top with generous spacing. Use the same gold color from the logo for decorative dividers, quotation marks, and subtle accent icons.
+
+Follow Disciplefy's Material 3 design language.
+
+**Design Style:**
+- Warm
+- Peaceful
+- Modern
+- Premium
+- Spiritually inspiring
+- Minimal
+- Apple-quality marketing aesthetic
+
+**Color Palette:**
+- Background: Warm Cream (#FAF8F5)
+- Primary Accent: Deep Gold (#B8860B)
+- Secondary Accent: Warm Gold (#C79A3B)
+- Scripture Card: Soft Gold (#FFEEC0)
+- Heading: Near Black (#1E1E1E)
+- Body Text: Dark Gray (#4B5563)
+- Footer: Muted Gray (#6B7280)
+
+Use indigo only as a subtle accent. Never use bright purple typography or heavy purple backgrounds.
+
+**Typography:**
+- Poppins ExtraBold for headings
+- Inter for verse text and supporting text
+- Rounded Material 3 cards (8px)
+- Soft natural shadows
+- Elegant whitespace
+
+**Scene:** Create a peaceful morning devotional setting featuring an open Bible resting on a warm wooden table. Soft golden morning sunlight streams through a nearby window. Include a ceramic coffee mug, a notebook with a fountain pen, and a small olive branch. Keep the atmosphere calm, hopeful, and inviting with soft natural shadows.
+
+**Layout:**
+- Disciplefy logo centered at the top with generous spacing.
+- Large heading: "Today's Verse"
+- Create a large premium Material 3 Scripture card with a soft gold background (#FFEEC0).
+- The Scripture card should occupy approximately 50–60% of the canvas.
+- Insert the supplied Bible verse inside the card.
+- Display the Bible reference at the top of the card using Poppins Bold.
+- Display the verse text using Inter Medium with generous line spacing and comfortable padding.
+- Ensure the Scripture is easily readable on a mobile device.
+- If the verse is long, increase the card size or simplify the background instead of reducing the font size.
+- Maintain generous padding inside the card (48–64px).
+
+The final artwork should feel warm, peaceful, elegant, and professionally designed.
+
+---
+
+## Prompt 2 – Candlelight Prayer
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as provided and place it centered at the top. Use the same gold tone from the logo for decorative accents.
+
+Follow Disciplefy's Material 3 design language.
+
+**Design Style:**
+- Warm
+- Reflective
+- Peaceful
+- Premium
+- Spiritually inspiring
+- Minimal
+
+**Use the Disciplefy brand colors:**
+- Warm Cream (#FAF8F5)
+- Deep Gold (#B8860B)
+- Soft Gold (#FFEEC0)
+- Near Black (#1E1E1E)
+
+**Typography:**
+- Poppins ExtraBold for the main heading
+- Poppins Bold for the Bible reference
+- Inter Medium for the verse text
+- Inter Regular for the footer
+- Rounded Material 3 cards (8px)
+- Soft natural shadows
+- Elegant whitespace
+
+**Scene:** Create a quiet evening devotional setting with an open Bible illuminated by a single candle. Place it on a dark walnut wooden table alongside a prayer journal and ceramic mug. Use soft amber lighting with gentle shadows to create an intimate atmosphere.
+
+**Layout:**
+- Disciplefy logo centered at the top with generous spacing.
+- Large heading: "Today's Verse"
+- Create a large premium Material 3 Scripture card with a soft gold background (#FFEEC0).
+- The Scripture card should occupy approximately 50–60% of the canvas.
+- Insert the supplied Bible verse inside the card.
+- Display the Bible reference at the top of the card using Poppins Bold.
+- Display the verse text using Inter Medium with generous line spacing and comfortable padding.
+- Ensure the Scripture is easily readable on a mobile device.
+- If the verse is long, increase the card size or simplify the background instead of reducing the font size.
+- Maintain generous padding inside the card (48–64px).
+
+The final artwork should feel intimate, peaceful, and encouraging.
+
+---
+
+## Prompt 3 – Minimal Study Desk
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as provided.
+
+Follow Disciplefy's Material 3 design language.
+
+**Design Style:**
+- Minimal
+- Modern
+- Premium
+- Warm
+- Peaceful
+
+**Color Palette:**
+- Warm Cream (#FAF8F5)
+- Deep Gold (#B8860B)
+- Soft Gold (#FFEEC0)
+- Near Black (#1E1E1E)
+
+**Typography:**
+- Poppins ExtraBold for the main heading
+- Poppins Bold for the Bible reference
+- Inter Medium for the verse text
+- Inter Regular for the footer
+- Rounded Material 3 cards (8px)
+- Soft natural shadows
+- Elegant whitespace
+
+**Scene:** Create a bright Scandinavian-inspired study desk with an open Bible resting on a warm cream linen cloth. Include a notebook, fountain pen, small ceramic vase, olive leaves, and natural daylight. Keep the composition uncluttered with generous whitespace.
+
+**Layout:**
+- Disciplefy logo centered at the top with generous spacing.
+- Large heading: "Today's Verse"
+- Create a large premium Material 3 Scripture card with a soft gold background (#FFEEC0).
+- The Scripture card should occupy approximately 50–60% of the canvas.
+- Insert the supplied Bible verse inside the card.
+- Display the Bible reference at the top of the card using Poppins Bold.
+- Display the verse text using Inter Medium with generous line spacing and comfortable padding.
+- Ensure the Scripture is easily readable on a mobile device.
+- If the verse is long, increase the card size or simplify the background instead of reducing the font size.
+- Maintain generous padding inside the card (48–64px).
+
+The overall design should feel clean, elegant, modern, and premium.
+
+---
+
+## Prompt 4 – Church Window
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as supplied.
+
+Follow Disciplefy's Material 3 design language.
+
+**Theme:**
+- Warm
+- Sacred
+- Elegant
+- Peaceful
+- Premium
+
+**Use the Disciplefy color palette:**
+- Warm Cream (#FAF8F5)
+- Deep Gold (#B8860B)
+- Soft Gold (#FFEEC0)
+- Near Black (#1E1E1E)
+
+**Typography:**
+- Poppins ExtraBold for the main heading
+- Poppins Bold for the Bible reference
+- Inter Medium for the verse text
+- Inter Regular for the footer
+- Rounded Material 3 cards (8px)
+- Soft natural shadows
+- Elegant whitespace
+
+**Scene:** Create the interior of a quiet church with warm sunlight streaming through stained-glass windows. Place an open Bible on a polished wooden pew with subtle rays of light and gentle dust particles. Keep the environment minimal and realistic.
+
+**Layout:**
+- Disciplefy logo centered at the top with generous spacing.
+- Large heading: "Today's Verse"
+- Create a large premium Material 3 Scripture card with a soft gold background (#FFEEC0).
+- The Scripture card should occupy approximately 50–60% of the canvas.
+- Insert the supplied Bible verse inside the card.
+- Display the Bible reference at the top of the card using Poppins Bold.
+- Display the verse text using Inter Medium with generous line spacing and comfortable padding.
+- Ensure the Scripture is easily readable on a mobile device.
+- If the verse is long, increase the card size or simplify the background instead of reducing the font size.
+- Maintain generous padding inside the card (48–64px).
+
+The final artwork should feel reverent, elegant, and calming.
+
+---
+
+## Prompt 5 – Mountain Sunrise
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as provided.
+
+Follow Disciplefy's Material 3 design language.
+
+**Theme:**
+- Warm
+- Inspiring
+- Peaceful
+- Premium
+- Spiritually uplifting
+
+**Color Palette:**
+- Warm Cream (#FAF8F5)
+- Deep Gold (#B8860B)
+- Soft Gold (#FFEEC0)
+- Near Black (#1E1E1E)
+
+**Typography:**
+- Poppins ExtraBold for the main heading
+- Poppins Bold for the Bible reference
+- Inter Medium for the verse text
+- Inter Regular for the footer
+- Rounded Material 3 cards (8px)
+- Soft natural shadows
+- Elegant whitespace
+
+**Scene:** Create a breathtaking mountain sunrise with soft golden light, gentle mist, and an open Bible resting on a natural wooden surface. Add subtle wildflowers and maintain a minimalist composition with no people.
+
+**Layout:**
+- Disciplefy logo centered at the top with generous spacing.
+- Large heading: "Today's Verse"
+- Create a large premium Material 3 Scripture card with a soft gold background (#FFEEC0).
+- The Scripture card should occupy approximately 50–60% of the canvas.
+- Insert the supplied Bible verse inside the card.
+- Display the Bible reference at the top of the card using Poppins Bold.
+- Display the verse text using Inter Medium with generous line spacing and comfortable padding.
+- Ensure the Scripture is easily readable on a mobile device.
+- If the verse is long, increase the card size or simplify the background instead of reducing the font size.
+- Maintain generous padding inside the card (48–64px).
+
+The final design should inspire hope, peace, and quiet reflection while maintaining Disciplefy's premium visual identity.
+
+---
+
+## Prompts 6–15 — Reusable Scene Variants
+
+*Source note: these ten prompts were introduced as a follow-up batch ("10 more reusable premium prompts that match Disciplefy's branding... use the same design language as your first five, so your entire Instagram feed will feel cohesive"). They intentionally reuse the same Design/Color/Typography/Layout blocks as Prompts 1–5 and vary only the **Scene** description — only the scene text differs per prompt below.*
+
+### Prompt 6 – Garden Bench Devotion
+
+Create a premium 1080 × 1920 px (9:16) Instagram Story for the Disciplefy mobile app.
+
+Use the uploaded Disciplefy logo exactly as provided. Place it centered at the top with generous spacing and use its gold color for decorative dividers and subtle accent icons.
+
+Follow Disciplefy's Material 3 design language.
+
+**Design Style:** Warm · Peaceful · Premium · Modern · Spiritually inspiring · Minimal
+
+**Use Disciplefy's brand palette:**
+- Background: Warm Cream (#FAF8F5)
+- Primary Accent: Deep Gold (#B8860B)
+- Scripture Card: Soft Gold (#FFEEC0)
+- Heading: Near Black (#1E1E1E)
+- Body: Dark Gray (#4B5563)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** Create a peaceful wooden garden bench surrounded by lush greenery and blooming flowers. An open Bible rests beside a notebook and pen. Soft morning sunlight filters through the trees, creating a tranquil atmosphere.
+
+**Layout:** (same as Prompt 1 — logo top center, "Today's Verse" heading, 50–60%-canvas soft-gold Scripture card with reference in Poppins Bold + verse in Inter Medium, 48–64px padding, mobile-readable.)
+
+---
+
+### Prompt 7 – Lakeside Reflection
+
+Create a premium 1080 × 1920 px Instagram Story following Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** An open Bible resting on a wooden dock beside a calm lake at sunrise. Gentle reflections shimmer on the water while mist rises softly. Minimal composition with peaceful natural colors.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 8 – Rainy Window Devotion
+
+Create a premium Instagram Story using Disciplefy's brand identity. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** An open Bible placed beside a rain-covered window. A warm cup of coffee, candle, and notebook create a cozy indoor devotional setting. Soft daylight filters through the rain, producing a comforting atmosphere.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 9 – Cozy Reading Corner
+
+Create a premium Instagram Story following Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** A cozy reading corner with an armchair, warm throw blanket, open Bible, ceramic mug, and soft lamp lighting. Rich textures, warm cream tones, and minimal décor create a peaceful place for devotion.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 10 – Wheat Field Sunrise
+
+Create a premium Instagram Story using Disciplefy's branding. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** Golden wheat field at sunrise with an open Bible resting on a rustic wooden surface. Warm sunlight illuminates the pages while a gentle breeze moves the wheat in the background.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 11 – Forest Prayer Walk
+
+Create a premium Instagram Story for Disciplefy. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** A peaceful forest trail during early morning. An open Bible rests on a moss-covered log beside a small notebook. Warm sunlight shines through tall trees creating beautiful rays of light.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 12 – Fireplace Devotion
+
+Create a premium Instagram Story using Disciplefy's Material 3 theme. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** An open Bible resting on a wooden coffee table near a cozy fireplace. Soft golden light fills the room. Include a candle, notebook, and ceramic mug for a warm devotional atmosphere.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 13 – Ancient Stone Church
+
+Create a premium Instagram Story following Disciplefy's brand identity. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** An open Bible placed on an old stone altar inside a beautiful historic church. Warm sunlight enters through stained-glass windows creating soft colorful reflections while maintaining a clean, minimal composition.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 14 – Mountain Cabin Morning
+
+Create a premium Instagram Story using Disciplefy's Material 3 design language. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** A wooden cabin overlooking snow-capped mountains. An open Bible sits beside a steaming mug of coffee near a large window with warm morning sunlight filling the room.
+
+**Layout:** (same as Prompt 1.)
+
+---
+
+### Prompt 15 – Olive Grove
+
+Create a premium Instagram Story following Disciplefy's branding. Follow Disciplefy's Material 3 design language.
+
+**Theme:** Warm · Inspiring · Peaceful · Premium · Spiritually uplifting
+
+**Color Palette:** Warm Cream (#FAF8F5) · Deep Gold (#B8860B) · Soft Gold (#FFEEC0) · Near Black (#1E1E1E)
+
+**Typography:** Poppins ExtraBold (main heading) · Poppins Bold (Bible reference) · Inter Medium (verse text) · Inter Regular (footer) · Rounded Material 3 cards (8px) · Soft natural shadows · Elegant whitespace
+
+**Scene:** An open Bible resting beneath an ancient olive tree. Warm Mediterranean sunlight filters through the branches. Olive leaves, a clay oil lamp, and natural stone textures create a timeless biblical atmosphere while remaining clean and modern.
+
+**Layout:** (same as Prompt 1 — logo top center, "Today's Verse" heading, 50–60%-canvas soft-gold Scripture card with reference in Poppins Bold + verse in Inter Medium, 48–64px padding, mobile-readable.)

--- a/docs/marketing/Prompts/Daily Devotions.md
+++ b/docs/marketing/Prompts/Daily Devotions.md
@@ -1,0 +1,253 @@
+# Disciplefy Daily Devotional Reel Generator
+
+You are the Creative Director and Film Director for Disciplefy.
+
+You will receive a Disciplefy blog article. Your task is **not** to summarize the article. Instead, identify the single most important biblical truth and transform it into a 40-second premium cinematic devotional for:
+
+- Instagram Reels
+- Facebook Reels
+- YouTube Shorts
+
+Generate 8 connected video clips, each exactly 5 seconds, with:
+
+- A natural voice-over sentence
+- A Google Flow / Veo prompt
+
+The final result must feel like one professionally directed short film, not eight separate clips.
+
+> **Note:** 8 clips × 5 seconds = 40 seconds — this duration math is consistent everywhere it's referenced in this doc (Core Objective, Output Format, Final Quality Checklist). No contradicting durations found.
+
+## Core Objective
+
+Read the article carefully. Internally determine:
+
+- the single central biblical truth
+- the complete story arc (beginning → middle → end)
+- recurring characters
+- locations
+- transitions
+- emotional progression
+- recurring objects
+
+Do not output this planning.
+
+Every visual, narration, action, transition, and camera movement must reinforce one biblical truth only. The viewer should finish remembering one clear, life-changing lesson.
+
+## Audience
+
+- Young Christians
+- New believers
+- Seekers
+- Busy professionals
+- Social media viewers
+
+## Tone
+
+Warm, hopeful, conversational, biblically accurate, encouraging, simple English.
+
+Never:
+
+- preachy
+- manipulative
+- overly dramatic
+- filled with unexplained church jargon
+
+## Visual Style
+
+Premium cinematic Christian lifestyle.
+
+- Apple commercial quality
+- Photorealistic live action
+- Authentic Indian environments
+- Warm golden-hour grading
+- Soft natural lighting
+- Natural performances
+- Vertical 9:16
+- 4K
+- 24 fps
+- No CGI
+- No fantasy
+- No AI artifacts
+
+> **Note — pacing alignment with the Visual Bible:** the Visual Bible's *Video Language* / *Motion Language* sections require every video to feel **slow, intentional, peaceful** and explicitly call for fade, rise, slow zoom, soft dissolve — while avoiding fast cuts, flash transitions, spinning, whip pans, and aggressive animation. This meta-prompt doesn't restate that pacing language directly; it only implies it through the Continuity rules below (no jump cuts, camera "continues... naturally"). The Camera Continuity list (push-in, slider, dolly, gimbal follow, tripod, over-the-shoulder) is compatible with the Visual Bible but doesn't rule out a fast push-in or a whip-style follow. **Recommend** adding an explicit line here — e.g. "All camera movement must be slow and deliberate; never whip pans, spins, or fast cuts" — to close this gap rather than leaving it implicit.
+
+## Continuity (Critical)
+
+Treat the devotional as one continuous film.
+
+### Character Continuity
+
+If a character appears across consecutive clips:
+
+- continue from the previous frame
+- preserve clothing, hairstyle, accessories and appearance
+- maintain movement direction
+- continue interactions with objects naturally
+- never reset poses
+- never teleport
+
+**Example:** Clip 2 ends with Daniel closing his Bible. Clip 3 begins with him placing it into his backpack.
+
+### Scene Continuity
+
+When remaining in the same location, preserve:
+
+- lighting
+- weather
+- time of day
+- furniture
+- object placement
+- background activity
+- camera orientation
+
+The environment should feel continuously filmed.
+
+### Camera Continuity
+
+Avoid jump cuts. Continue previous camera language naturally using movements such as:
+
+- push-in
+- slider
+- dolly
+- gimbal follow
+- tripod
+- over-the-shoulder
+
+### Natural Transitions
+
+Location changes must be motivated visually. Examples:
+
+- walking through a doorway
+- leaving home
+- entering transport
+- arriving at work
+- sitting after walking
+- opening gates
+- indoor → outdoor
+
+Never instantly change locations.
+
+### Object Continuity
+
+Props remain consistent. Examples:
+
+- Bible stays open until closed
+- coffee mug remains in hand
+- backpack stays worn
+- notebook continues being written in
+
+Objects never appear or disappear randomly.
+
+### Emotional Continuity
+
+Emotions develop naturally. Avoid abrupt shifts.
+
+### Editing Rule
+
+Each clip should begin where the previous clip ended. The last frame should naturally become the first frame of the next. Movement should continue across edits.
+
+## Recurring Characters
+
+> **Note — character consistency check:** this doc references two named recurring characters, **Daniel** and **Sarah**. Both names are already in use elsewhere in the marketing library — `Content_Playbook_Season1_Week2.md` uses "Daniel" as the recurring character for Bible Explained / Walking with Jesus Reels, and `Reel_Scripts_Feature_ProblemSolution.md` uses "Sarah" as its recurring character across multiple Reel scripts. **No naming conflict** — this is consistent reuse, not a contradiction. However, no other marketing doc currently defines Daniel's or Sarah's physical appearance (age, hair, clothing, etc.) in detail, so the descriptions below appear to be the **first canonical physical description** of both characters. Recommend treating this section as the source of truth going forward, and cross-linking it from `Content_Playbook_Season1_Week2.md` / `Reel_Scripts_Feature_ProblemSolution.md` so future scripts don't invent conflicting appearances.
+
+### Daniel
+
+Young Indian professional (26–30).
+
+- neatly styled short black hair
+- clean shaven
+- warm medium-brown skin
+- navy Oxford shirt
+- dark chinos
+- brown leather watch
+- calm, thoughtful, gentle
+- usually reading Scripture before work
+
+Maintain identical appearance throughout.
+
+### Sarah
+
+Young Indian woman (24–28).
+
+- long dark hair loosely tied
+- cream cardigan
+- sage green dress
+- gold cross necklace
+- warm medium-brown skin
+- joyful, peaceful
+
+Maintain identical appearance throughout.
+
+Characters never:
+
+- look into camera
+- acknowledge camera
+- speak to audience
+
+## Story Structure
+
+| Clip | Purpose |
+|------|---------|
+| 1 | Hook |
+| 2 | Introduce biblical truth |
+| 3 | Explain truth |
+| 4 | Deepen understanding |
+| 5 | Real-life application |
+| 6 | Encouragement using prayer, Scripture or nature |
+| 7 | Invitation to reflect |
+| 8 | Hopeful conclusion with negative space for Disciplefy end screen (no text/logo) |
+
+## Output Format (Repeat for All 8 Clips)
+
+**Clip Number**
+
+**Duration** — Exactly 5 seconds
+
+**Voice-over** — One conversational sentence that comfortably fits within five seconds.
+
+**Google Flow / Veo Prompt** — use the following sections:
+
+1. **Scene & Setting** — Describe location, architecture, furniture, textures, colours, weather, time of day, atmosphere, subtle background activity. Environment should feel lived in.
+
+2. **Character** — Always include the complete recurring character description. Never shorten it.
+
+3. **Action Timeline** — Break into:
+   - **0–2 sec:** Initial action.
+   - **2–4 sec:** Natural continuation.
+   - **4–5 sec:** Movement ending that flows directly into the next clip.
+
+   Describe only visible actions. Examples: reading Scripture, turning Bible pages, making coffee, writing notes, opening doors, packing a bag, helping someone, praying, walking, sitting, waiting for transport.
+
+   Avoid internal emotions such as: reflects, thinks, feels emotional.
+
+4. **Eye Direction** — Always specify what the character is looking at and why.
+
+5. **Facial Expression** — Natural, subtle, realistic.
+
+6. **Body Language** — Hands interact with real objects. Avoid theatrical gestures.
+
+7. **Camera Direction** — Specify starting framing, lens/composition, focus, movement, ending composition.
+
+8. **Composition** — Include rule of thirds, foreground, background depth, leading lines, frame balance, negative space.
+
+9. **Environmental Motion** — Always include subtle movement: curtains, steam, birds, traffic, people, leaves, water, wind. Nothing should appear frozen.
+
+10. **Lighting** — Only realistic lighting: soft window light, morning sunlight, golden hour, warm household lamps. No coloured or dramatic lighting.
+
+11. **Cinematic Style** — End every prompt with:
+
+    > Photorealistic live-action. Premium Apple commercial quality. Warm golden-hour colour grading. Authentic Indian environment. Natural skin tones. Realistic human movement. Vertical 9:16. 4K. 24 fps. No AI artifacts. No fantasy. No CGI. No text. No logos. Characters never look into the camera or speak directly to it.
+
+## Final Quality Checklist
+
+Before responding, verify:
+
+- Exactly one biblical truth.
+- Every clip advances the story.
+- Seamless continuity between clips.
+- No repeated actions or camera setups.
+- Every action has purpose.
+- Every eye movement has a visible reason.
+- Every environment feels alive.
+- Prompts are detailed enough for Veo without guessing.
+- Ending leaves clean negative space for Disciplefy branding.

--- a/docs/marketing/Prompts/Grace Collection.md
+++ b/docs/marketing/Prompts/Grace Collection.md
@@ -1,0 +1,323 @@
+# Grace Asset Library
+
+Reusable Google Flow / Veo video-generation prompts for **Grace**, a recurring Disciplefy character. Each asset is a standalone 10-second cinematic clip built from the same Character / Scene / Camera / Lighting / Style / Mood fields, so Grace stays visually identical across every generation.
+
+> **Note — this is a stylized 3D animated character, not a live-action one (most important finding):** every asset below specifies **"Premium stylized 3D animation," "semi-realistic proportions," "Apple-quality rendering," "Material 3 inspired colours."** This directly contradicts the visual system already established for this marketing library's *other* recurring characters:
+> - `Daily Devotions.md` (this same `docs/marketing/Prompts/` folder) requires, verbatim, **"Photorealistic live action… No CGI… No fantasy… No AI artifacts"** for its recurring characters Daniel and Sarah.
+> - `Content_Playbook_Season1/Content_Playbook_Season1_Week2.md` uses **Daniel** (the same live-action character) for Google Flow/Veo Reels in the identical content pillars this Grace library would compete for (Bible Explained, Walking with Jesus).
+> - The Disciplefy Visual Bible's **Video Language**, **Motion Language**, and **Google Flow / Veo Guidelines** sections (`docs/marketing/Strategy/03 Disciplefy Visual Bible.md`) describe only real-world staging — homes, churches, coffee shops, nature, golden-hour streets, natural window light — and never mention a stylized/animated character, "Apple-quality rendering," or a Material-3-inspired render palette for video. It has no section documenting an animated-character system at all.
+> - A `Joshua Collection.docx` also exists alongside this file, and the in-source production note before Asset 009 (preserved below) directly compares Grace's role to Joshua's — confirming Grace and Joshua are a **second, animated character family**, parallel to (and stylistically incompatible with) the live-action Daniel/Sarah family.
+>
+> **This reads as two parallel video systems that were never reconciled**, not one deliberately documented sub-brand: the Visual Bible already models "two systems, don't mix them" for color (Product indigo vs. Marketing warm-cream), but no equivalent scope note exists for video style. Before producing more Grace/Joshua assets, this should be resolved explicitly — either (a) document a second, intentional video system in the Visual Bible (e.g., "3D-animated characters for the encouragement/rest pillar, live-action for teaching/explanation"), or (b) convert one track to match the other so Reels don't visually contradict each other in the same feed.
+
+## Table of Contents
+
+| Asset | Description |
+|---|---|
+| [001](#asset-001--grace-reading-the-bible) | Grace reads Scripture at her desk during a golden-hour morning devotion. |
+| [002](#asset-002--grace-writing-bible-notes) | Grace journals observations from her Bible reading, pausing to reflect. |
+| [003](#asset-003--grace-turning-bible-pages) | Macro close-up of Grace slowly turning pages while searching for a passage. |
+| [004](#asset-004--grace-highlighting-scripture) | Grace highlights a verse in yellow and rereads it before setting the highlighter down. |
+| [005](#asset-005--grace-quiet-reflection) | Grace sits in silent reflection beside her open Bible and journal. |
+| [006](#asset-006--grace-beginning-her-devotion) | Grace carries her Bible and journal to her study corner to begin reading. |
+| [007](#asset-007--grace-ending-her-devotion) | Grace closes her Bible and journal at the end of her morning devotion. |
+| [008](#asset-008--grace-reading-by-the-window) | Grace reads by a sunlit apartment window as a breeze moves the curtains. |
+| [009](#asset-009--grace-enjoying-gods-creation) | Grace walks through a botanical garden at golden hour, admiring God's creation. |
+| [010](#asset-010--grace-sitting-beside-a-lake) | Grace sits on a lakeside dock at sunrise, Bible beside her. |
+| [011](#asset-011--grace-drinking-coffee-before-devotion) | Grace enjoys coffee by the window before her devotion, watching the sunrise. |
+| [012](#asset-012--grace-watching-the-rain) | Grace watches gentle rain slide down her apartment window. |
+| [013](#asset-013--grace-looking-at-the-night-sky) | Grace looks up at a clear, star-filled night sky from her balcony. |
+| [014](#asset-014--grace-resting-after-bible-study) | Grace leans back, content, after finishing her Bible study. |
+| [015](#asset-015--grace-walking-through-a-sunlit-forest) | Grace walks a golden-hour forest path, carrying her closed Bible. |
+
+## Consistency Review
+
+**Asset numbering:** Sequential, no gaps or duplicates — 001 through 015, all present, in order.
+
+**Character appearance:** No asset in this file states Grace's concrete physical traits (hair color, eye color, age, clothing color/style) — every asset instead defers to "maintain the exact same appearance… established previously" / "the official Disciplefy [animated] character." That means appearance consistency can't be verified from this document alone; it depends entirely on an external reference (turnaround sheet / prior generation) not included here.
+
+**"Never redesign" safeguard — inconsistently reinforced:** The explicit safeguard line appears in full only in **Asset 001** ("Maintain the exact same appearance, hairstyle, facial features, clothing, body proportions and animation style established previously. Never redesign the character.") and, in a shortened form, in **Asset 009** ("Maintain the exact same appearance, clothing, hairstyle, body proportions and animation style" — note this drops "facial features" and the explicit "never redesign" sentence). Assets 002–008 and 010–015 compress this to a single line ("Use the official Disciplefy Grace character" / "Use the official Disciplefy character"). Since each Flow/Veo generation is a fresh, memory-less prompt, this weakens the guardrail for 13 of 15 assets — worth restating the full safeguard in every asset rather than only the first two.
+
+**Style vs. camera/lighting:** All 15 assets consistently declare "Premium stylized 3D animation," so there's no internal contradiction within this file's Style field (no asset drifts into photorealistic/live-action wording). A few assets (003, 010, 012, 014) omit the "Material 3 inspired colours" line that most others include — a minor, non-contradictory gap, not a conflict. Separately, the library directs a "virtual camera" with real-world cinematography vocabulary (35mm/50mm/85mm lenses, macro close-up, push-ins, orbits, slider, pull-back) — a normal technique for guiding Flow/Veo, not an inconsistency, but worth flagging since it borrows live-action camera language for an animated deliverable.
+
+**Formatting normalization (fixed in this conversion):** The source alternated between a full "Character" header (Assets 001, 009) and a single inline sentence folded into the opening line (all other assets). Every asset below has been normalized into the same Character / Scene / Camera / Lighting / Style / Mood layout for scanability — no wording was changed, only re-labeled consistently.
+
+---
+
+## Asset 001 — Grace Reading the Bible
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace, the official Disciplefy animated character. Maintain the exact same appearance, hairstyle, facial features, clothing, body proportions and animation style established previously. Never redesign the character.
+
+**Scene:** Grace sits quietly at her wooden Bible study desk inside her modern apartment during early morning. An open Bible rests beside a leather journal, ceramic coffee mug and fountain pen. Grace calmly reads Scripture with full attention. She slowly turns one page before continuing to read. Her body language is peaceful, focused and natural. No dramatic emotions.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm golden sunrise entering through a nearby window. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic proportions. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Peaceful. Focused. Hopeful.
+
+No dialogue. No subtitles. No text.
+
+## Asset 002 — Grace Writing Bible Notes
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace quietly writes observations inside her leather journal while occasionally looking back at her open Bible. She pauses briefly to reflect before continuing to write. Everything feels calm and intentional.
+
+**Camera:** Single side slider. 50mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Thoughtful. Peaceful. Reflective.
+
+No dialogue. No subtitles. No text.
+
+## Asset 003 — Grace Turning Bible Pages
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace slowly turns several pages of her open Bible while carefully searching for another passage. She gently places one finger on the page before turning it. Everything feels slow, natural and peaceful.
+
+**Camera:** Macro close-up. Single slow push-in. 85mm lens.
+
+**Lighting:** Warm natural sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic colour grading.
+
+**Mood:** Quiet. Reflective. Natural.
+
+No dialogue. No subtitles. No text.
+
+## Asset 004 — Grace Highlighting Scripture
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace quietly highlights a passage in her Bible using a yellow highlighter. She rereads the highlighted verse before gently placing the highlighter beside the Bible. Everything feels calm and intentional.
+
+**Camera:** Top-down cinematic shot. Very slow movement.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Focused. Peaceful. Intentional.
+
+No dialogue. No subtitles. No text.
+
+## Asset 005 — Grace Quiet Reflection
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace sits quietly beside her open Bible. Her journal remains open. She simply reflects in silence while looking toward the nearby window. Her breathing is calm. Her expression is peaceful. Avoid dramatic emotions.
+
+**Camera:** Single slow orbit. 50mm lens.
+
+**Lighting:** Golden morning sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Stillness. Peace. Reflection.
+
+No dialogue. No subtitles. No text.
+
+## Asset 006 — Grace Beginning Her Devotion
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace walks into her study corner carrying her Bible and journal. She gently places them on the wooden desk. She sits comfortably and opens the Bible, preparing to begin reading. Everything feels calm and unhurried.
+
+**Camera:** Wide shot. Slow push-in. 35mm lens.
+
+**Lighting:** Warm sunrise.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Fresh beginning. Peaceful. Hopeful.
+
+No dialogue. No subtitles. No text.
+
+## Asset 007 — Grace Ending Her Devotion
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace gently closes her Bible after finishing her morning devotion. She closes her journal and quietly smiles before picking up both and leaving the room. The study desk remains tidy and peaceful.
+
+**Camera:** Single slow pull-back. 50mm lens.
+
+**Lighting:** Warm golden morning light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Peace. Contentment. Hope.
+
+No dialogue. No subtitles. No text.
+
+## Asset 008 — Grace Reading by the Window
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Use the official Disciplefy Grace character.
+
+**Scene:** Grace stands beside a large apartment window holding an open Bible. She quietly reads while warm sunlight softly illuminates the pages. A gentle breeze moves the curtains. Everything feels calm and intimate.
+
+**Camera:** Single slow side tracking shot. 50mm lens.
+
+**Lighting:** Golden sunrise. Warm natural light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Hope. Peace. Reflection.
+
+No dialogue. No subtitles. No text.
+
+---
+
+> **Production note (preserved from source):** "Yes. Right now Grace is mostly shown reading and studying, which overlaps too much with Joshua. Grace should represent encouragement, peace, trust, hope, and resting in God's presence. Her assets should feel softer and more contemplative while still being reusable. Here are additional Grace-specific assets."
+>
+> This note appears in the source between Assets 008 and 009 and explains the tonal shift in Assets 009–015 (creation, rest, rain, night sky) away from the reading/study focus of 001–008. It also confirms **Joshua** is a separate recurring character (see `Joshua Collection.docx`, not yet converted) who overlaps with Grace's original reading/study material — i.e., Grace and Joshua are siblings in the same stylized-3D-animation family, distinct from the live-action Daniel/Sarah family used elsewhere in this marketing library.
+
+---
+
+## Asset 009 — Grace Enjoying God's Creation
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace, the official Disciplefy animated character. Maintain the exact same appearance, clothing, hairstyle, body proportions and animation style.
+
+**Scene:** Grace walks slowly through a peaceful botanical garden during golden hour. She gently brushes her fingertips across tall grass and wildflowers while admiring God's creation. She occasionally looks upward toward the sunlight filtering through the trees. Everything feels calm, peaceful and unhurried.
+
+**Camera:** Single slow tracking shot. 50mm lens.
+
+**Lighting:** Warm golden-hour sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Wonder. Peace. Hope.
+
+No dialogue. No subtitles. No text.
+
+## Asset 010 — Grace Sitting Beside a Lake
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace sits quietly on a wooden dock beside a peaceful lake during sunrise. An open Bible rests beside her. She watches the calm water while gently smiling. The gentle breeze creates small ripples across the lake.
+
+**Camera:** Single slow push-in. 35mm lens.
+
+**Lighting:** Golden sunrise.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic colour grading.
+
+**Mood:** Stillness. Hope. Trust.
+
+No dialogue. No subtitles. No text.
+
+## Asset 011 — Grace Drinking Coffee Before Devotion
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace sits comfortably beside a large apartment window. She slowly enjoys a warm cup of coffee while her open Bible and journal rest on the nearby table. She quietly watches the sunrise before setting the mug down. The atmosphere feels peaceful and welcoming.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm sunrise.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Rest. Peace. Hope.
+
+No dialogue. No subtitles. No text.
+
+## Asset 012 — Grace Watching the Rain
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace stands quietly beside a large apartment window while gentle rain falls outside. She peacefully watches the raindrops sliding down the glass. An open Bible rests on the nearby table. Everything feels quiet, comforting and hopeful.
+
+**Camera:** Single slow push-in. 85mm lens.
+
+**Lighting:** Soft rainy daylight. Warm interior lighting.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic grading.
+
+**Mood:** Comfort. Peace. Trust.
+
+No dialogue. No subtitles. No text.
+
+## Asset 013 — Grace Looking at the Night Sky
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace stands on the balcony of her apartment after sunset. She quietly looks toward a clear night sky filled with stars. She simply enjoys the peaceful evening without speaking. A gentle breeze softly moves her hair.
+
+**Camera:** Single slow orbit. 50mm lens.
+
+**Lighting:** Soft moonlight with warm ambient apartment lighting.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours.
+
+**Mood:** Wonder. Peace. Hope.
+
+No dialogue. No subtitles. No text.
+
+## Asset 014 — Grace Resting After Bible Study
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace gently closes her Bible and leans back comfortably in her chair. She quietly smiles while reflecting on what she has read. The journal remains open beside the Bible. Nothing else happens. The scene feels restful and content.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic grading.
+
+**Mood:** Contentment. Peace. Reflection.
+
+No dialogue. No subtitles. No text.
+
+## Asset 015 — Grace Walking Through a Sunlit Forest
+
+Create a premium 10-second cinematic animated video.
+
+**Character:** Grace. Use the official Disciplefy character.
+
+**Scene:** Grace walks slowly along a peaceful forest path during golden hour. Warm sunlight filters through the trees. She quietly enjoys the beauty around her while carrying a closed Bible naturally in one hand. The atmosphere feels hopeful and refreshing.
+
+**Camera:** Single tracking shot. 35mm lens.
+
+**Lighting:** Golden-hour sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Joy. Peace. Hope.
+
+No dialogue. No subtitles. No text.

--- a/docs/marketing/Prompts/Joshua Collection.md
+++ b/docs/marketing/Prompts/Joshua Collection.md
@@ -1,0 +1,734 @@
+# Joshua Collection — Google Flow / Veo Video Prompts
+
+Asset library of Google Flow / Veo video-generation prompts featuring **Joshua**, a recurring Disciplefy 3D-animated character, and (starting at Part 2) **Grace**, his female counterpart. Every asset instructs the generator to keep the character's appearance identical to what was "established previously" and to never redesign him/her — the actual appearance spec (hair, exact clothing, age, etc.) lives outside this document (presumably a character model sheet), so this file only carries the *reminder* instruction, not the reference itself.
+
+The source document numbers assets in **two separate sequences that both restart at 001** — see Finding 1 below. This conversion keeps the original numbering but disambiguates the two runs as **Part 1 (Solo Joshua, 001–023)** and **Part 2 (Joshua & Grace, 001–017)**, matching the order they appear in the source file.
+
+## Consistency & Structural Findings
+
+> **Note — two visual systems, not obviously reconciled.** This library's `Style` field is "Premium stylized 3D animation" (Apple-quality rendering, Material 3–inspired colours, semi-realistic proportions) on every single asset. Nothing else in the marketing library uses 3D animation: the Visual Bible (`Strategy/03 Disciplefy Visual Bible.md`) only ever describes photography/live-action guidance (Photography Style, Video Language, Google Flow/Veo Guidelines all reference real light, real locations, real props — animation is never mentioned), the `Daily Devotions.md` prompt generator explicitly requires **"Photorealistic live action... No CGI... No fantasy"**, and `Content_Playbook_Season1_Week2.md` uses **Daniel**, a live-action recurring character, for the same "modern apartment, morning sunlight, open Bible, coffee, notebook" scenario Joshua occupies here almost beat-for-beat (compare Week 2 Monday's visual style to Asset 001/006 below). Joshua/Grace and Daniel appear to be **two unreconciled character tracks for near-identical scenes** — either this is a deliberate second (animated) visual system that the Visual Bible hasn't caught up to documenting yet, or Joshua/Grace should have been unified with Daniel and weren't. Flagging rather than resolving.
+>
+> **Note — Joshua and Grace are a matched pair, confirmed in this same file.** Part 2 of this document (originally still inside "Joshua Collection.docx") is a set of 17 assets starring "Joshua and Grace, the official Disciplefy animated characters" together, with the same "never redesign" boilerplate applied to both. So the pairing isn't speculative — it's explicit in the source. A standalone `Grace Collection.md` doesn't exist in `docs/marketing/Prompts/` yet (only `Grace Collection.docx`), so cross-checking Grace's solo asset set for drift against her appearance here wasn't possible in this pass.
+
+**Finding 1 — duplicate asset numbering (structural, not fixed).** The source restarts numbering at "Asset 001" partway through the file: Solo Joshua assets run 001–023 sequentially with no gaps or duplicates, then a new "Asset 001 — Studying Scripture Together" begins the Joshua & Grace duo set, which itself runs 001–017 sequentially with no gaps or duplicates. Within each of the two runs the numbering is clean; across the whole document, asset numbers 001–017 each occur **twice** referring to entirely different videos. Kept as two labeled parts here rather than renumbered, since renumbering would break any existing references to "Asset 00X" elsewhere.
+
+**Finding 2 — the "never redesign the character" boilerplate itself drifts in wording.** Five different phrasings of the same continuity instruction appear across the file (list, not just word order, changes each time):
+- Asset 001 (Solo): "Maintain the exact same appearance, **hairstyle, facial features, clothing, body proportions** and animation style established previously... Never redesign the character."
+- Asset 006 (Solo): same idea, but drops "facial features" and "established previously."
+- Asset 011 (Solo) and Asset 019 (Solo): drops "facial features" and shortens "body proportions" to "proportions"; **both also drop the "Never redesign the character" sentence entirely.**
+- Asset 001 (Duo): "appearance, clothing, body proportions, **hairstyles** (plural), facial features and animation style established previously... Never redesign the **characters**."
+- Asset 009 (Duo): same list as Duo-001 but drops "established previously."
+
+None of this changes what the character actually looks like (no hair colour, clothing colour, or age is ever specified in this document), but the safeguard sentence meant to *prevent* redesign is itself inconsistently copy-pasted — including two assets (011, 019) that quietly drop the explicit "never redesign" instruction altogether. Flagging as a real drift, fixed only cosmetically here (original wording preserved verbatim per asset, not harmonized).
+
+**Finding 3 — formatting collapses in the back half of Part 2.** Duo Assets 001–009 use full labeled fields (Characters/Scene/Camera/Lighting/Style/Mood, plus an implicit Output line). Starting at **Duo Asset 010** through **Duo Asset 017**, the source drops all field labels, the "Create a premium 10-second cinematic animated video" opener, and — inconsistently — the Mood and Output fields (some of 010–017 keep a "No dialogue" line, most don't; none have a Mood line). This reads as the source document getting terser over time rather than a deliberate format. Reconstructed field labels for 010–017 below from context; fields absent in the source are marked *(not specified in source)*.
+
+**Finding 4 — camera/lens language is uniform but photographic.** Every asset (both parts) pairs "Premium stylized 3D animation" with live-action camera vocabulary — 35mm/50mm/85mm lens, "natural handheld feel" (Asset 001, Solo), dolly/orbit/slider/crane moves. This is consistent throughout (not a drift — no asset breaks from stylized-3D to describe photoreal skin/material detail), so it isn't a contradiction between assets, but it is worth noting as a house convention: this whole library speaks in cinematographer's terms about a rendered/animated character, which is unusual and should be intentional rather than a copy-paste leftover from a live-action prompt template.
+
+**Finding 5 — redundant/near-duplicate scenes worth consolidating.** Given the volume, several clusters cover almost the same beat:
+- Solo prayer set (Assets 011, 012, 013, 014, 015, 016, 017) — seven variations on "Joshua prays quietly" distinguished mainly by location (desk, balcony, park, kneeling, evening chair, church). Could likely be trimmed to 3–4 without losing coverage.
+- Solo Assets 001 and 006 ("Joshua Reading the Bible" / "Joshua Studying with a Notebook") describe essentially the same desk scene and beat sequence (read → write note → pause → continue).
+- Duo "Grace points at something in the Bible" motif recurs four times (Assets 009, 011, 014, 016 — context, cross-reference, Joshua's observation, a question) with very similar staging.
+- Duo Asset 012 ("Looking at the Same Bible") largely restates Duo Asset 001 ("Studying Scripture Together").
+
+No content was deleted for this — all assets are preserved below — this is a flag for a future editorial pass, not an action taken here.
+
+**Minor fixes made during conversion:** merged fragmented one-sentence-per-line prose into readable paragraphs per field (no wording changed or removed); labeled previously-unlabeled trailing "No dialogue / no text" lines as an **Output** field for consistency with the assets that do label it; normalized field order (Character → Scene → Camera → Lighting → Style → Mood → Output) where the source had it reordered (e.g. Duo Asset 017).
+
+---
+
+## Table of Contents
+
+### Part 1 — Solo Joshua (Assets 001–023)
+- [001 — Joshua Reading the Bible](#asset-001--joshua-reading-the-bible)
+- [002 — Joshua Writing Notes](#asset-002--joshua-writing-notes)
+- [003 — Joshua Turning Bible Pages](#asset-003--joshua-turning-bible-pages)
+- [004 — Joshua Highlighting Scripture](#asset-004--joshua-highlighting-scripture)
+- [005 — Joshua Reflecting](#asset-005--joshua-reflecting)
+- [006 — Joshua Studying with a Notebook](#asset-006--joshua-studying-with-a-notebook)
+- [007 — Joshua Comparing Scripture](#asset-007--joshua-comparing-scripture)
+- [008 — Joshua Reading by the Window](#asset-008--joshua-reading-by-the-window)
+- [009 — Joshua Beginning His Devotion](#asset-009--joshua-beginning-his-devotion)
+- [010 — Joshua Ending His Devotion](#asset-010--joshua-ending-his-devotion)
+- [011 — Joshua Beginning Prayer](#asset-011--joshua-beginning-prayer)
+- [012 — Joshua Prayer Before Bible Study](#asset-012--joshua-prayer-before-bible-study)
+- [013 — Joshua Balcony Prayer](#asset-013--joshua-balcony-prayer)
+- [014 — Joshua Silent Prayer Walk](#asset-014--joshua-silent-prayer-walk)
+- [015 — Joshua Kneeling in Prayer](#asset-015--joshua-kneeling-in-prayer)
+- [016 — Joshua Evening Prayer](#asset-016--joshua-evening-prayer)
+- [017 — Joshua Praying in Church](#asset-017--joshua-praying-in-church)
+- [018 — Joshua Looking Up in Gratitude](#asset-018--joshua-looking-up-in-gratitude)
+- [019 — Joshua Holding the Door](#asset-019--joshua-holding-the-door)
+- [020 — Joshua Giving His Seat](#asset-020--joshua-giving-his-seat)
+- [021 — Joshua Helping Carry Groceries](#asset-021--joshua-helping-carry-groceries)
+- [022 — Joshua Listening Attentively](#asset-022--joshua-listening-attentively)
+- [023 — Joshua Returning a Lost Wallet](#asset-023--joshua-returning-a-lost-wallet)
+
+### Part 2 — Joshua & Grace (Assets 001–017)
+- [001 — Studying Scripture Together](#asset-001--studying-scripture-together)
+- [002 — Discussing Scripture](#asset-002--discussing-scripture)
+- [003 — Writing Notes Together](#asset-003--writing-notes-together)
+- [004 — Walking After Bible Study](#asset-004--walking-after-bible-study)
+- [005 — Praying Together](#asset-005--praying-together)
+- [006 — Walking Into Church](#asset-006--walking-into-church)
+- [007 — Listening During a Bible Study](#asset-007--listening-during-a-bible-study)
+- [008 — Serving Together](#asset-008--serving-together)
+- [009 — Grace Points to the Context](#asset-009--grace-points-to-the-context)
+- [010 — Comparing Notes](#asset-010--comparing-notes)
+- [011 — Grace Finds a Cross Reference](#asset-011--grace-finds-a-cross-reference)
+- [012 — Looking at the Same Bible](#asset-012--looking-at-the-same-bible)
+- [013 — Grace Encourages Joshua to Keep Reading](#asset-013--grace-encourages-joshua-to-keep-reading)
+- [014 — Joshua Explains His Observation](#asset-014--joshua-explains-his-observation)
+- [015 — Discovering Something Together](#asset-015--discovering-something-together)
+- [016 — Grace Asks a Question](#asset-016--grace-asks-a-question)
+- [017 — Studying Different Passages Together](#asset-017--studying-different-passages-together)
+
+---
+
+# Part 1 — Solo Joshua Assets
+
+Create a premium 10-second cinematic animated video for each asset below unless noted otherwise.
+
+## Asset 001 — Joshua Reading the Bible
+
+**Character:** Joshua, the official Disciplefy animated character. Maintain the exact same appearance, hairstyle, facial features, clothing, body proportions and animation style established previously. Never redesign the character.
+
+**Scene:** Joshua is sitting alone at his wooden Bible study desk inside his modern apartment during early morning. An open Bible rests naturally on the table beside a leather notebook, fountain pen and ceramic coffee mug. Warm golden sunlight softly enters through the nearby window. Joshua quietly reads Scripture with complete focus. He slowly turns a page, pauses naturally, then continues reading. No exaggerated expressions, no dramatic acting — his body language is peaceful, relaxed and thoughtful.
+
+**Camera:** Single slow push-in. 35mm lens. Natural handheld feel.
+
+**Lighting:** Golden sunrise. Soft warm shadows. Cinematic.
+
+**Style:** Premium stylized 3D animation. Semi-realistic proportions. Apple-quality rendering. Material 3 inspired colours. Warm colour grading. Natural movement.
+
+**Mood:** Peaceful, reflective, hopeful.
+
+**Output:** No dialogue, no lip movement, no subtitles, no logos, no text.
+
+## Asset 002 — Joshua Writing Notes
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua is seated at the same Bible study desk. His Bible remains open. He quietly writes observations inside a leather notebook while occasionally looking back at the Bible. He underlines a sentence, thinks briefly, then continues writing naturally. The scene should feel calm and intentional.
+
+**Camera:** Single slow side slider movement. 50mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic lighting. Material 3 inspired colours.
+
+**Mood:** Focused, peaceful, reflective.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 003 — Joshua Turning Bible Pages
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua slowly turns multiple pages of his Bible while searching for another passage. He carefully places one finger on the page before turning it. His movements are slow, intentional and natural. The Bible remains the visual hero.
+
+**Camera:** Close-up. Very slow push-in. 85mm lens.
+
+**Lighting:** Warm natural sunlight. Soft cinematic shadows.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Minimal. Warm. Material 3 inspired.
+
+**Mood:** Quiet, thoughtful, natural.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 004 — Joshua Highlighting Scripture
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua quietly highlights a Bible passage using a yellow highlighter. He reads the verse once more before gently closing the highlighter. Everything feels slow and intentional.
+
+**Camera:** Top-down cinematic shot. Very subtle movement.
+
+**Lighting:** Warm morning light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Focused, intentional, peaceful.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 005 — Joshua Reflecting
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua quietly sits beside the open Bible. His notebook remains open. He simply reflects in silence while looking toward the nearby window. His breathing is calm. His expression is peaceful and thoughtful. Avoid dramatic emotions.
+
+**Camera:** Slow orbit. 50mm lens.
+
+**Lighting:** Golden morning sunlight. Soft shadows.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Stillness, peace, reflection.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 006 — Joshua Studying with a Notebook
+
+> **Note:** this asset's Character block drops "facial features" and "established previously" relative to Asset 001 — see Finding 2.
+
+**Character:** Joshua, the official Disciplefy animated character. Maintain the exact same appearance, hairstyle, clothing, body proportions and animation style. Never redesign the character.
+
+**Scene:** Joshua sits at his Bible study desk during early morning. An open Bible rests beside a leather notebook. Joshua slowly reads a passage, writes a short note in the notebook, pauses to think, then continues writing. His movements are calm, deliberate and natural. The notebook gradually fills with handwritten observations. The atmosphere feels peaceful and focused.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm golden sunrise entering through a nearby window. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic proportions. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Peaceful, focused, intentional.
+
+**Output:** No dialogue, no lip movement, no subtitles, no logos, no text.
+
+## Asset 007 — Joshua Comparing Scripture
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua studies an open Bible while comparing different passages. He gently flips between bookmarked pages. He occasionally glances at handwritten notes before returning to Scripture. His actions are patient and thoughtful. Avoid dramatic emotions.
+
+**Camera:** Single over-the-shoulder shot with a slow cinematic push-in. 35mm lens.
+
+**Lighting:** Warm morning sunlight. Soft cinematic shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm colour grading. Material 3 inspired colours.
+
+**Mood:** Curious, reflective, natural.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 008 — Joshua Reading by the Window
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua stands quietly beside a large apartment window during sunrise. He holds an open Bible with both hands and slowly reads. After reading, he pauses briefly while looking outside before continuing. Warm sunlight gently illuminates the pages. The room is minimal, modern and peaceful.
+
+**Camera:** Single slow side tracking shot. 50mm lens.
+
+**Lighting:** Golden sunrise. Warm natural light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Peaceful, hopeful, reflective.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 009 — Joshua Beginning His Devotion
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua arrives at his Bible study desk carrying his Bible and notebook. He gently places them on the table, sits down comfortably, opens the Bible, and prepares to begin studying. Everything feels calm and intentional. Avoid exaggerated acting.
+
+**Camera:** Wide shot with a slow push-in. 35mm lens.
+
+**Lighting:** Warm early morning sunlight. Soft shadows.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Fresh beginning, peaceful, calm.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 010 — Joshua Ending His Devotion
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua gently closes his Bible after finishing his study. He closes his notebook, takes a quiet moment of reflection, smiles softly, then stands up carrying both the Bible and notebook as he leaves the room. The study desk remains neat and peaceful.
+
+**Camera:** Single slow pull-back. 50mm lens.
+
+**Lighting:** Golden morning sunlight. Warm soft shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Peace, completion, hope.
+
+**Output:** No dialogue, no lip movement, no subtitles, no logos, no text.
+
+## Asset 011 — Joshua Beginning Prayer
+
+> **Note:** this asset's Character block drops "facial features" and shortens "body proportions" to "proportions" — and is the first asset to drop the "Never redesign the character" sentence entirely. See Finding 2.
+
+**Character:** Joshua, the official Disciplefy animated character. Maintain the exact same appearance, clothing, hairstyle, proportions and animation style.
+
+**Scene:** Joshua sits quietly at his Bible study desk during early morning. An open Bible rests on the wooden table beside a leather notebook, fountain pen and ceramic coffee mug. Joshua gently closes his eyes. He slowly folds both hands together. He remains still in silent prayer. The scene should feel peaceful and intimate. Avoid dramatic emotions.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm golden sunrise entering through a nearby window. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic proportions. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Peaceful, prayerful, hopeful.
+
+**Output:** No dialogue, no lip movement, no subtitles, no text, no logos.
+
+## Asset 012 — Joshua Prayer Before Bible Study
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua opens his Bible on the desk. Before reading, he gently places one hand on the Bible while quietly bowing his head in prayer. After a few peaceful moments, he slowly opens his eyes and begins reading. Everything feels natural and unhurried.
+
+**Camera:** Slow side slider. 35mm lens.
+
+**Lighting:** Warm early morning sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Quiet, focused, peaceful.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 013 — Joshua Balcony Prayer
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua stands alone on the balcony of his apartment during sunrise. He looks toward the horizon. After a few seconds he gently folds his hands and quietly prays. The wind softly moves his shirt. Trees sway gently in the distance. The city slowly wakes up below.
+
+**Camera:** Single slow orbit. 50mm lens.
+
+**Lighting:** Golden sunrise. Warm natural light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Hope, peace, reflection.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 014 — Joshua Silent Prayer Walk
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua walks slowly through a peaceful park during golden hour. He carries a closed Bible in one hand. His head is slightly lowered in quiet prayer and reflection. He occasionally looks toward the trees and sky before continuing his walk. The atmosphere is calm and restorative.
+
+**Camera:** Single tracking shot. 35mm lens.
+
+**Lighting:** Golden morning light.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Quiet, hopeful, reflective.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 015 — Joshua Kneeling in Prayer
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Inside his apartment beside the study desk, Joshua kneels quietly beside a chair. His Bible rests open on the seat. He remains still in silent prayer. The room is peaceful. Nothing dramatic happens. The scene communicates humility and dependence on God.
+
+**Camera:** Single slow push-in. 85mm lens.
+
+**Lighting:** Warm window light. Soft shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Reverent, peaceful, still.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 016 — Joshua Evening Prayer
+
+> **Note:** first asset to depart from the recurring golden-morning-sunrise lighting for an evening/lamp setting — an intentional variation, not a contradiction, but flagged since it breaks the otherwise-uniform time-of-day across the collection.
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua sits in a comfortable chair beside a softly lit lamp after sunset. His Bible is open on his lap. He quietly closes the Bible, folds his hands, and spends a few peaceful moments in silent evening prayer. The room feels warm and restful.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm table lamp. Soft ambient evening light.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Peace, rest, gratitude.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 017 — Joshua Praying in Church
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua sits quietly alone on a wooden church pew. An open Bible rests beside him. He bows his head in silent prayer. Warm sunlight shines through stained-glass windows, creating soft patterns of light across the floor. The church is empty, peaceful, and reverent.
+
+**Camera:** Single slow dolly-in. 50mm lens.
+
+**Lighting:** Natural sunlight through church windows. Warm cinematic tones.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours.
+
+**Mood:** Worship, peace, reverence.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 018 — Joshua Looking Up in Gratitude
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua stands outdoors during sunrise in a quiet open field. He closes his eyes briefly, takes a deep breath, then slowly looks toward the bright morning sky with a gentle smile of gratitude. His Bible remains tucked under one arm. The scene communicates thankfulness without dramatic emotion.
+
+**Camera:** Single slow crane movement. 35mm lens.
+
+**Lighting:** Golden sunrise. Warm natural light.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Gratitude, hope, joy.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 019 — Joshua Holding the Door
+
+> **Note:** like Asset 011, this Character block drops "facial features," shortens "body proportions" to "proportions," and omits "Never redesign the character." This asset also opens a new "everyday discipleship" mini-arc (019–023) that steps away from the apartment desk into public settings (office lobby, metro, neighbourhood, coffee shop, park) — a deliberate location expansion, not an appearance drift, but noted since it's the first clear departure from the established desk/apartment setting.
+
+**Character:** Joshua, the official Disciplefy animated character. Maintain the exact same appearance, clothing, hairstyle, proportions and animation style.
+
+**Scene:** Joshua stands outside the entrance of a modern office building. As another person approaches carrying several books, Joshua notices them and naturally holds the glass door open. He smiles politely while waiting. The other person walks through. Joshua then quietly follows. The interaction feels natural and unforced.
+
+**Camera:** Single medium-wide shot. Slow cinematic push-in. 35mm lens.
+
+**Lighting:** Warm morning sunlight. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Kindness, humility, everyday discipleship.
+
+**Output:** No dialogue, no lip movement, no subtitles, no text, no logos.
+
+## Asset 020 — Joshua Giving His Seat
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua sits on a metro train. He notices an elderly passenger entering. Without hesitation, Joshua stands up and respectfully offers his seat. He remains standing quietly while the elderly person sits down. The atmosphere feels calm and genuine.
+
+**Camera:** Single side shot. Slow tracking movement. 50mm lens.
+
+**Lighting:** Natural daylight through train windows.
+
+**Style:** Premium stylized 3D animation. Warm cinematic rendering. Material 3 inspired colours.
+
+**Mood:** Respect, kindness, humility.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 021 — Joshua Helping Carry Groceries
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua notices an elderly neighbour carrying several grocery bags. He politely offers to carry one of the bags. They walk together naturally for a few steps. Joshua hands the bag back near the apartment entrance. The interaction feels authentic and respectful.
+
+**Camera:** Single slow tracking shot. 35mm lens.
+
+**Lighting:** Golden evening sunlight.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm cinematic colour grading. Material 3 inspired colours.
+
+**Mood:** Service, compassion, kindness.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 022 — Joshua Listening Attentively
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua sits across from a friend in a quiet coffee shop. While the friend speaks, Joshua listens attentively without interrupting. He maintains eye contact, nods gently, and gives the speaker his full attention. The scene communicates care through listening rather than speaking.
+
+**Camera:** Single medium shot. Slow push-in. 50mm lens.
+
+**Lighting:** Warm café lighting.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Warm colour grading. Material 3 inspired colours.
+
+**Mood:** Compassion, presence, friendship.
+
+**Output:** No dialogue, no lip movement, no subtitles, no text.
+
+## Asset 023 — Joshua Returning a Lost Wallet
+
+**Character:** Use the official Disciplefy Joshua character.
+
+**Scene:** Joshua notices a wallet lying on a park bench. He picks it up, looks around, notices its owner nearby, and respectfully returns it. The owner smiles gratefully. Joshua smiles politely before continuing his walk. The interaction feels simple and honest.
+
+**Camera:** Single tracking shot. 35mm lens.
+
+**Lighting:** Warm afternoon sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Integrity, honesty, kindness.
+
+**Output:** No dialogue, no subtitles, no text.
+
+---
+
+# Part 2 — Joshua & Grace Duo Assets
+
+> **Note:** numbering restarts at 001 here in the source document — see Finding 1. Create a premium 10-second cinematic animated video for each asset below unless noted otherwise.
+
+## Asset 001 — Studying Scripture Together
+
+**Characters:** Joshua and Grace, the official Disciplefy animated characters. Maintain the exact same appearance, clothing, body proportions, hairstyles, facial features and animation style established previously. Never redesign the characters.
+
+**Scene:** Joshua and Grace sit across from each other at a wooden table inside a modern apartment during early morning. An open Bible rests between them beside a leather notebook, fountain pen and ceramic coffee mugs. Both quietly read the same Bible passage together. Joshua slowly turns one page while Grace follows along attentively. Neither character speaks. The interaction feels peaceful, natural and focused on God's Word.
+
+**Camera:** Single slow push-in. 35mm lens.
+
+**Lighting:** Warm golden sunrise entering through a nearby window. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic proportions. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Peaceful, focused, hopeful.
+
+**Output:** No dialogue, no lip movement, no subtitles, no text, no logos.
+
+## Asset 002 — Discussing Scripture
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace sit together at a wooden Bible study table. An open Bible lies between them. Grace gently gestures toward a passage while Joshua listens attentively with a thoughtful expression. Joshua nods naturally before both return their attention to the Bible. The interaction is quiet and respectful.
+
+**Camera:** Single medium shot. Slow cinematic push-in. 50mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic lighting. Material 3 inspired colours.
+
+**Mood:** Learning, friendship, reflection.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 003 — Writing Notes Together
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace sit side by side at a wooden study table. Both quietly write notes in separate journals while occasionally looking back at the same open Bible. Everything feels calm and intentional.
+
+**Camera:** Single side tracking shot. 50mm lens.
+
+**Lighting:** Warm natural morning light.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Wisdom, reflection, peace.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 004 — Walking After Bible Study
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace walk together through a peaceful park after finishing Bible study. Each carries a closed Bible naturally. They enjoy the quiet morning together without speaking. The atmosphere feels calm and encouraging.
+
+**Camera:** Single tracking shot. 35mm lens.
+
+**Lighting:** Golden morning sunlight filtering through trees.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic colour grading.
+
+**Mood:** Peace, friendship, hope.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 005 — Praying Together
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace sit beside each other at a wooden Bible study table. Their open Bibles remain on the table. Both quietly bow their heads in silent prayer. The room is peaceful and still.
+
+**Camera:** Single slow push-in. 50mm lens.
+
+**Lighting:** Warm sunrise. Soft natural shadows.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic lighting.
+
+**Mood:** Prayer, peace, reverence.
+
+**Output:** No dialogue, no lip movement, no subtitles, no text.
+
+## Asset 006 — Walking Into Church
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace walk side by side toward the entrance of a modern church on a bright Sunday morning. Each carries a Bible naturally. They smile warmly as they approach the church doors. The atmosphere feels welcoming and peaceful.
+
+**Camera:** Single wide tracking shot. 35mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Joy, community, hope.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 007 — Listening During a Bible Study
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace sit together in a small group Bible study. An open Bible rests on each of their laps. They listen attentively to someone speaking off-camera. Joshua occasionally nods while Grace quietly follows a passage in her Bible.
+
+**Camera:** Single medium shot. Slow cinematic push-in. 50mm lens.
+
+**Lighting:** Warm indoor lighting.
+
+**Style:** Premium stylized 3D animation. Apple-quality rendering. Material 3 inspired colours. Warm cinematic grading.
+
+**Mood:** Learning, community, peace.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 008 — Serving Together
+
+**Characters:** Use the official Disciplefy Joshua and Grace characters.
+
+**Scene:** Joshua and Grace arrange chairs inside a church hall before a Bible study gathering. They work together quietly and naturally. They occasionally exchange warm smiles while continuing to serve. The atmosphere feels peaceful and joyful.
+
+**Camera:** Single wide shot. Slow side slider. 35mm lens.
+
+**Lighting:** Warm natural daylight entering through church windows.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Material 3 inspired colours. Warm cinematic colour grading.
+
+**Mood:** Service, humility, community.
+
+**Output:** No dialogue, no subtitles, no text.
+
+## Asset 009 — Grace Points to the Context
+
+> **Note:** Output field here reads "No dialogue, no lip movement, no text" — omitting "no subtitles," present in most other assets' Output fields. Preserved as-is (not fabricated).
+
+**Characters:** Joshua and Grace, the official Disciplefy animated characters. Maintain the exact same appearance, clothing, hairstyles, body proportions, facial features and animation style.
+
+**Scene:** Joshua and Grace sit together at a wooden Bible study table. An open Bible lies between them. Joshua carefully reads a single verse while thinking quietly. Grace gently points to the surrounding verses on the same page, encouraging Joshua to continue reading the passage. Joshua smiles slightly and continues reading further down the page. The interaction feels natural, respectful and collaborative.
+
+**Camera:** Single over-the-shoulder shot. Slow cinematic push-in. 50mm lens.
+
+**Lighting:** Warm morning sunlight.
+
+**Style:** Premium stylized 3D animation. Semi-realistic. Apple-quality rendering. Warm cinematic colour grading.
+
+**Mood:** Discovery, learning, friendship.
+
+**Output:** No dialogue, no lip movement, no text.
+
+## Asset 010 — Comparing Notes
+
+> **Note:** from here through Asset 017, the source drops field labels, the "Create a premium 10-second..." opener, and the Mood field entirely — see Finding 3. Fields below are reconstructed from context; anything the source truly omitted is marked *(not specified in source)*.
+
+**Scene:** Joshua and Grace sit beside each other after reading Scripture. Each has a leather journal. Grace quietly slides her notebook toward Joshua. Joshua reads one observation, smiles with appreciation, then returns to his own notebook and continues writing. The interaction communicates learning from one another.
+
+**Camera:** Single slow push-in.
+
+**Lighting:** Warm sunrise.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** No dialogue, no text.
+
+## Asset 011 — Grace Finds a Cross Reference
+
+**Scene:** Joshua studies an open Bible while looking thoughtful. Grace quietly notices a cross-reference in the margin. She gently points to it. Joshua follows her finger, turns a few pages, and begins reading the referenced passage. Both continue studying together peacefully.
+
+**Camera:** Single slow side slider.
+
+**Lighting:** Warm morning light.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** No dialogue, no subtitles.
+
+## Asset 012 — Looking at the Same Bible
+
+**Scene:** Joshua and Grace stand together beside a wooden table. Both lean slightly toward the same open Bible. Joshua slowly turns the page while Grace follows along attentively. Neither speaks. The focus remains entirely on God's Word.
+
+**Camera:** Single slow push-in.
+
+**Lighting:** Warm cinematic lighting.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** *(not specified in source)*
+
+## Asset 013 — Grace Encourages Joshua to Keep Reading
+
+**Scene:** Joshua pauses after reading a short passage. Grace gently smiles and lightly gestures toward the next section of Scripture. Joshua nods naturally and continues reading. The interaction feels encouraging rather than instructional.
+
+**Camera:** Single medium shot.
+
+**Lighting:** Warm sunrise.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** *(not specified in source)*
+
+## Asset 014 — Joshua Explains His Observation
+
+**Scene:** Joshua quietly points to a verse in the Bible while Grace listens attentively. Grace looks thoughtfully at the passage before nodding in agreement. Both continue reading together. The interaction feels like two friends studying Scripture together.
+
+**Camera:** Single slow push-in.
+
+**Lighting:** Warm cinematic lighting.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** *(not specified in source)*
+
+## Asset 015 — Discovering Something Together
+
+**Scene:** Joshua and Grace both read an open Bible. After a few moments they naturally look at each other with quiet smiles before returning their attention to the Bible. The moment communicates shared understanding without exaggeration.
+
+**Camera:** Single cinematic push-in.
+
+**Lighting:** Golden morning sunlight.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** No dialogue, no subtitles.
+
+## Asset 016 — Grace Asks a Question
+
+**Scene:** Joshua reads Scripture quietly. Grace gently points toward a verse with a curious expression, as though asking a thoughtful question. Joshua looks back at the passage and begins reading the surrounding verses. Both remain focused on Scripture.
+
+**Camera:** Single over-the-shoulder shot.
+
+**Lighting:** Warm cinematic morning light.
+
+**Style:** Premium stylized 3D animation.
+
+**Mood:** *(not specified in source)*
+
+**Output:** *(not specified in source)*
+
+## Asset 017 — Studying Different Passages Together
+
+> **Note:** the source lists Style ("Premium stylized 3D animation") before what looks like a Lighting descriptor ("Warm cinematic colour grading"), and never gives a Lighting field at all. Reordered here for consistency; content unchanged. Also has no Mood or Output field.
+
+**Scene:** Joshua and Grace each have an open Bible. Joshua reads one passage while Grace reads another. After a few moments they exchange Bibles briefly to compare passages before continuing to study. Everything feels calm, natural and intentional.
+
+**Camera:** Single slow tracking shot.
+
+**Lighting:** *(not specified in source)*
+
+**Style:** Premium stylized 3D animation. Warm cinematic colour grading.
+
+**Mood:** *(not specified in source)*
+
+**Output:** *(not specified in source)*

--- a/docs/marketing/Strategy/01 Disciplefy Brand Bible.md
+++ b/docs/marketing/Strategy/01 Disciplefy Brand Bible.md
@@ -1,4 +1,5 @@
 # Disciplefy Brand Bible
+Version: 1.2 *(updated — see Changelog)*
 
 ## Purpose
 This document defines who Disciplefy is and why it exists. Every decision about the product, content, design, and marketing should align with this document.
@@ -28,6 +29,11 @@ Disciplefy helps believers understand God's Word, grow spiritually, and follow J
 Disciplefy is: Wise · Encouraging · Practical · Humble · Hope-filled · Christ-centered
 Never: Condemning · Clickbait · Political · Divisive · Fear-based
 
+## Language Rule — Never Say "AI"
+Confirmed against the live marketing site (`marketing/messages/en.json`): user-facing copy never uses the word "AI," "artificial intelligence," or similar — not even in feature names. The Technology section states it explicitly: "Disciplefy uses technology to generate Bible study content... The technology assists study; it does not interpret Scripture with authority. That authority belongs to Scripture alone." This is a theological stance, not a style preference — naming the tech "AI" risks implying it has interpretive authority over Scripture, which the brand explicitly rejects.
+
+Use instead: "Study Guides," "Voice Discipler" / "Voice Buddy," "Learning Paths," "Memory Verses," "generate," "technology" — never "AI-powered," "AI-generated," "artificial intelligence." Applies to all marketing copy: Instagram, ads, bios, captions, app-store listings.
+
 ## Core Message
 Knowing Jesus is the beginning. Becoming like Him is the journey. Disciplefy exists to help believers grow into true disciples.
 
@@ -35,9 +41,17 @@ Knowing Jesus is the beginning. Becoming like Him is the journey. Disciplefy exi
 Disciplefy is a discipleship platform that helps believers understand the Bible, apply it to everyday life, and grow closer to Jesus.
 
 ## Instagram Bio
-Helping believers become disciples of Jesus. 📖
-Bible Study • Spiritual Growth
-👇 Start your journey
+**Name field** (heaviest IG search weight — more than bio text): `Disciplefy — Bible Study App`
+
+**Bio** (SEO-keyworded, no "AI" per the Language Rule above, matches real site terms — 130 chars, under IG's 150 limit):
+```
+📖 Bible study guides & daily verses
+🌱 Learning paths, memory verses, faith Q&A
+✨ From Believer to Disciple
+👇 Free on Web & Android
+```
+
+*Previous version ("Helping believers become disciples of Jesus 📖 / Bible Study • Spiritual Growth / 👇 Start your journey") was warmer but keyword-light — kept here for reference, not deleted, in case brand-voice-first is preferred over SEO for a given season.*
 
 ## Success Statement
 When someone hears "Disciplefy," they should immediately think: **"This is where I grow closer to Jesus."**
@@ -50,4 +64,7 @@ Before launching anything, ask:
 - Does it align with our mission?
 
 ---
-*No contradictions found against other Strategy docs during review — converted as-is.*
+
+## Changelog
+- **v1.1:** Added "Language Rule — Never Say 'AI'" (confirmed against the live marketing site's actual copy — a theological stance, not a style choice). Updated Instagram Bio to an SEO-keyworded version consistent with that rule; kept the original warmer bio for reference.
+- **v1.2:** Trimmed the SEO bio from 153 to 130 characters — original draft exceeded Instagram's 150-char bio limit.

--- a/docs/marketing/Strategy/03 Disciplefy Visual Bible.md
+++ b/docs/marketing/Strategy/03 Disciplefy Visual Bible.md
@@ -1,5 +1,5 @@
 # Disciplefy Visual Bible
-Version: 1.1 *(updated — see Changelog)*
+Version: 1.2 *(updated — see Changelog)*
 
 This document defines the complete visual identity of Disciplefy across the app, website, marketing site, social media, videos, presentations, print, and future products.
 The goal is simple: **every Disciplefy asset should be recognizable without seeing the logo.**
@@ -85,6 +85,14 @@ Every generated scene should communicate: Hope · Grace · Reflection · Peace �
 Preferred locations: Homes · Churches · Coffee shops · Nature · Parks · Libraries · City mornings · Golden-hour streets
 Avoid fantasy-style religious imagery unless the creative concept explicitly calls for it.
 
+## Recurring Characters — Two Video Systems
+This doc's Video Language/Photography Style rules above (photorealistic, live-action, golden-hour) describe one system in active use. A second, separate system also exists and needs documenting here so it isn't rediscovered as "drift" again:
+
+- **Live-Action System — Daniel & Sarah.** Photorealistic Google Flow/Veo generation, following this doc's Video Language/Motion Language/Photography Style sections exactly (slow, intentional, golden-hour, no CGI). Used for the Bible Explained / Walking with Jesus / Growing in Christ Reels in `Content_Playbook_Season1_Week2.md` onward, and the meta-prompt in `Prompts/Daily Devotions.md`.
+- **Stylized 3D Animation System — Grace & Joshua.** "Premium stylized 3D animation," explicitly *not* photorealistic — a different rendering style from the Live-Action system above, with its own character-consistency rule ("never redesign the character") across every asset. Defined in `Prompts/Grace Collection.md` (15 assets) and `Prompts/Joshua Collection.md` (40 assets, including 17 Joshua+Grace duo scenes).
+
+**Open question, not resolved here:** both systems currently cover overlapping content beats (a character alone at a desk with an open Bible, morning light, coffee, journal) without any documented reason to pick one over the other for a given piece of content. Two ways this could be intentional — different formats each fitting a system (e.g. live-action for Reels, animation for a distinct stylized series) — but that mapping isn't written down anywhere yet. Before producing more assets in either system, decide: (a) both stay, with an explicit rule for which system each content type/series uses, or (b) consolidate to one. Whichever is decided, add it as a rule under this section.
+
 ## Social Media Design
 **Reels:** Large captions · Minimal overlays · Elegant scripture · Premium pacing · Warm grade
 **Carousels:** One idea per slide · Minimal text · Consistent margins · Simple illustrations
@@ -123,3 +131,4 @@ If the answer is yes, it belongs in Disciplefy.
 
 ## Changelog
 - **v1.1:** Added "Scope: Two Visual Systems" section clarifying Indigo-primary applies to Product/App (verified against live `app_colors.dart`), while Marketing/Social has since moved to a separate warm-cream-gold system (per the approved Instagram carousel reference). Previously this doc implied one universal palette, which no longer matched what's actually shipping in marketing assets.
+- **v1.2:** Added "Recurring Characters — Two Video Systems" documenting the previously-undocumented Live-Action (Daniel & Sarah) vs Stylized 3D Animation (Grace & Joshua) character tracks found in `Prompts/`. Flagged as an open question which system each content type should use — not resolved here.

--- a/docs/marketing/Strategy/Daily Devotion/2. Tuesday — Bible Tips Carousel.md
+++ b/docs/marketing/Strategy/Daily Devotion/2. Tuesday — Bible Tips Carousel.md
@@ -2,8 +2,8 @@
 Merged from two files (quick-tips primary + biblical-literacy reserve) into one ordered list. Items 1-13 are the quick, single-action tips (matches Tuesday's actual executed topics: "Read the Bible in Context," "Pray Before You Read"). Items 14-43 are the biblical-literacy topics (Bible organization, books, timeline, etc.) — post those once the first 13 are used up.
 
 1. Read the Bible in Context *(used Week 2)*
-2. Pray Before You Read *(used Week 3)*
-3. Ask Better Questions While Reading *(used Week 4)*
+2. Pray Before You Read *(displaced from Week 3 — that Tuesday swapped to a Memory Verses feature carousel instead, paired with Saturday's reel. Deferred to Month 2.)*
+3. Ask Better Questions While Reading *(displaced from Week 4 — that Tuesday swapped to a Discipler feature carousel instead, paired with Saturday's reel. Deferred to Month 2.)*
 4. Read the Whole Chapter
 5. Use Cross References
 6. Look for Repeated Words

--- a/docs/marketing/Strategy/July 2026/Disciplefy Content Calendar — Month 1 (Foundation Stage).md
+++ b/docs/marketing/Strategy/July 2026/Disciplefy Content Calendar — Month 1 (Foundation Stage).md
@@ -51,7 +51,7 @@ Build trust, establish Disciplefy as the go-to discipleship platform, and drive 
 | Day | Topic | Production |
 |---|---|---|
 | Monday | Bible Explained — The Good Samaritan | 🎬 AI |
-| Tuesday | Bible Tip — Pray Before You Read | Carousel |
+| Tuesday | How To: Memory Verses (Carousel, swapped in — pairs 2 days ahead of Saturday's Ep9 reel) | Carousel |
 | Wednesday | Walking with Jesus — Building a Daily Prayer Habit | 🎬 AI |
 | Thursday | Bible Study — Observe Before You Interpret | Carousel |
 | Friday | Growing in Christ — Waiting on God | 🎬 AI |
@@ -64,7 +64,7 @@ Build trust, establish Disciplefy as the go-to discipleship platform, and drive 
 | Day | Topic | Production |
 |---|---|---|
 | Monday | Bible Explained — Why Did Jesus Curse the Fig Tree? | 🎬 AI |
-| Tuesday | Bible Tip — Ask Better Questions While Reading | Carousel |
+| Tuesday | How To: Discipler (Carousel, swapped in — pairs 2 days ahead of Saturday's Ep13 reel) | Carousel |
 | Wednesday | Walking with Jesus — How to Study the Bible Effectively | 🎬 AI |
 | Thursday | Bible Study — Understand the Original Audience | Carousel |
 | Friday | Growing in Christ — Fear Not, God Is With You | 🎬 AI |


### PR DESCRIPTION
## Summary
- Add PreWeek1 Bridge playbook (Sat/Sun launch-gap carousels, UI-corrected, per-slide captions)
- Add Prompts/ library (Bible Tips, Daily Bible Verse v1/v2, Daily Devotions, Grace/Joshua Collections) — converted from docx, fixed ESV/KJV mislabeling and indigo→gold drift
- Add "Growth Additions (2026)" section to Week 1 (canonical) + pointer sections in Week 2-4/PreWeek1: Follow-CTA rotation, trending audio, Stories interactive stickers
- Minor Brand Bible / Visual Bible / Daily Devotion / Month 1 Calendar fixes carried from prior session
- Gitignore generated Season 1 PDFs (regenerate locally, not tracked)

## Test plan
- [x] Docs only, no code — n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added several new marketing and strategy documents for Season 1 content, including updated weekly playbooks, daily verse templates, devotional reel prompts, and character collection prompts.
  * Expanded the brand and visual guidelines with clearer rules for tone, layout, colors, recurring characters, and content structure.
  * Updated the content calendar and carousel planning so Tuesday topics align with the revised weekly series.
* **Chores**
  * Updated ignore rules for additional generated documentation assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->