### PR TITLE
fix(blog): full-width editor/preview layout

### DIFF
--- a/admin-web/app/(dashboard)/blogs/[id]/page.tsx
+++ b/admin-web/app/(dashboard)/blogs/[id]/page.tsx
@@ -210,32 +210,6 @@ export default function EditBlogPostPage({ params }: { params: Promise<{ id: str
                 className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none focus:border-indigo-500"
               />
             </div>
-            <div>
-              <label className="block text-xs font-semibold uppercase tracking-wide text-indigo-400/70 mb-1.5">
-                Content (Markdown) <span className="text-red-400">*</span>
-              </label>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div>
-                  <textarea
-                    value={content}
-                    onChange={e => { setContent(e.target.value); markDirty() }}
-                    rows={24}
-                    className="w-full resize-y rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-sm text-white outline-none focus:border-indigo-500"
-                  />
-                  <p className="mt-1 text-xs text-indigo-400/50">
-                    {content.split(/\s+/).filter(Boolean).length} words · ~{Math.max(1, Math.ceil(content.split(/\s+/).filter(Boolean).length / 200))} min read
-                  </p>
-                </div>
-                <div className="rounded-lg border border-white/10 bg-white p-6 overflow-auto max-h-[70vh]">
-                  <BlogPreview
-                    content={content}
-                    title={title}
-                    tags={tagsInput.split(',').map(t => t.trim()).filter(Boolean)}
-                    status={post.status}
-                  />
-                </div>
-              </div>
-            </div>
           </div>
         </div>
 
@@ -369,6 +343,34 @@ export default function EditBlogPostPage({ params }: { params: Promise<{ id: str
             >
               {isDeleting ? 'Deleting…' : '🗑️ Delete Post'}
             </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content editor + live preview — full page width, 50/50 */}
+      <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-5">
+        <label className="block text-xs font-semibold uppercase tracking-wide text-indigo-400/70 mb-1.5">
+          Content (Markdown) <span className="text-red-400">*</span>
+        </label>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div>
+            <textarea
+              value={content}
+              onChange={e => { setContent(e.target.value); markDirty() }}
+              rows={28}
+              className="w-full resize-y rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-sm text-white outline-none focus:border-indigo-500"
+            />
+            <p className="mt-1 text-xs text-indigo-400/50">
+              {content.split(/\s+/).filter(Boolean).length} words · ~{Math.max(1, Math.ceil(content.split(/\s+/).filter(Boolean).length / 200))} min read
+            </p>
+          </div>
+          <div className="dark rounded-lg border border-white/10 bg-[#0F172A] p-6 overflow-auto max-h-[80vh]">
+            <BlogPreview
+              content={content}
+              title={title}
+              tags={tagsInput.split(',').map(t => t.trim()).filter(Boolean)}
+              status={post.status}
+            />
           </div>
         </div>
       </div>

--- a/admin-web/app/(dashboard)/blogs/new/page.tsx
+++ b/admin-web/app/(dashboard)/blogs/new/page.tsx
@@ -142,33 +142,6 @@ export default function NewBlogPostPage() {
                 className="w-full resize-none rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-indigo-400/50 outline-none focus:border-indigo-500"
               />
             </div>
-            <div>
-              <label className="block text-xs font-semibold uppercase tracking-wide text-indigo-400/70 mb-1.5">
-                Content (Markdown) <span className="text-red-400">*</span>
-              </label>
-              <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-                <div>
-                  <textarea
-                    value={content}
-                    onChange={e => setContent(e.target.value)}
-                    rows={20}
-                    placeholder="Write your post in Markdown…"
-                    className="w-full resize-y rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-sm text-white placeholder-indigo-400/50 outline-none focus:border-indigo-500"
-                  />
-                  <p className="mt-1 text-xs text-indigo-400/50">
-                    {content.split(/\s+/).filter(Boolean).length} words · ~{Math.max(1, Math.ceil(content.split(/\s+/).filter(Boolean).length / 200))} min read
-                  </p>
-                </div>
-                <div className="rounded-lg border border-white/10 bg-white p-6 overflow-auto max-h-[70vh]">
-                  <BlogPreview
-                    content={content}
-                    title={title}
-                    tags={tagsInput.split(',').map(t => t.trim()).filter(Boolean)}
-                    status={showSchedule ? 'scheduled' : status}
-                  />
-                </div>
-              </div>
-            </div>
           </div>
         </div>
 
@@ -274,6 +247,35 @@ export default function NewBlogPostPage() {
                 }`} />
               </button>
             </label>
+          </div>
+        </div>
+      </div>
+
+      {/* Content editor + live preview — full page width, 50/50 */}
+      <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-5">
+        <label className="block text-xs font-semibold uppercase tracking-wide text-indigo-400/70 mb-1.5">
+          Content (Markdown) <span className="text-red-400">*</span>
+        </label>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div>
+            <textarea
+              value={content}
+              onChange={e => setContent(e.target.value)}
+              rows={28}
+              placeholder="Write your post in Markdown…"
+              className="w-full resize-y rounded-lg border border-white/10 bg-white/5 px-3 py-2 font-mono text-sm text-white placeholder-indigo-400/50 outline-none focus:border-indigo-500"
+            />
+            <p className="mt-1 text-xs text-indigo-400/50">
+              {content.split(/\s+/).filter(Boolean).length} words · ~{Math.max(1, Math.ceil(content.split(/\s+/).filter(Boolean).length / 200))} min read
+            </p>
+          </div>
+          <div className="dark rounded-lg border border-white/10 bg-[#0F172A] p-6 overflow-auto max-h-[80vh]">
+            <BlogPreview
+              content={content}
+              title={title}
+              tags={tagsInput.split(',').map(t => t.trim()).filter(Boolean)}
+              status={showSchedule ? 'scheduled' : status}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Preview pane was cramped (~1/3 page, inside the narrow form column) and rendered on a stark white box against the dark dashboard.

- Moved the CONTENT editor + live preview out of the 2/3 form column into a full-page-width row below the meta grid → 50/50 split, each pane ~2x wider.
- Title/Slug/Excerpt + Publish/Language/Tags/Featured stay in the top grid.
- Preview surface now dark (`bg-[#0F172A]` + forced `dark` class) — matches the live dark-mode article and the dashboard; article still capped at 68ch reading width.
- Applied to both new and edit blog pages.

## Verification
- admin-web `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Refreshed the blog post content editor layout on both new post and edit pages.
  * Added a more spacious Markdown editing area with a clearer live preview section.

* **UI Improvements**
  * Updated the editor to use a full-width, responsive layout.
  * Improved preview panel styling for better readability and a more polished dark theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->