### PR TITLE
fix(iap): pass required appAppleId to StoreKit 2 JWS verifier

### DIFF
--- a/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
+++ b/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
@@ -97,6 +97,15 @@ export async function validateAppleReceipt(
       return failure('Apple bundle ID not configured — cannot verify transaction')
     }
 
+    // appAppleId (the numeric App Store Connect app identifier, e.g. from
+    // apps.apple.com/app/id<appAppleId>) is required by SignedDataVerifier when
+    // verifying against the Production environment — omitting it throws
+    // "appAppleId is required when the environment is Production" and every
+    // production purchase fails closed. It's not required for Sandbox.
+    if (!config.appAppleId) {
+      return failure('Apple app Apple ID not configured — cannot verify Production transactions')
+    }
+
     const appleRootCerts = await getAppleRootCerts()
 
     // The signature + cert chain are environment-independent, but SignedDataVerifier
@@ -109,7 +118,10 @@ export async function validateAppleReceipt(
 
     const tryVerify = async (env: Environment) => {
       // enableOnlineChecks=false → offline signature + cert-chain verification only.
-      const verifier = new SignedDataVerifier(appleRootCerts, false, env, config.bundleId!)
+      // appAppleId is omitted for Sandbox (the library doesn't require it there).
+      const verifier = env === Environment.PRODUCTION
+        ? new SignedDataVerifier(appleRootCerts, false, env, config.bundleId!, config.appAppleId)
+        : new SignedDataVerifier(appleRootCerts, false, env, config.bundleId!)
       return await verifier.verifyAndDecodeTransaction(signedTransaction)
     }
 

--- a/backend/supabase/functions/_shared/services/iap-config-service.ts
+++ b/backend/supabase/functions/_shared/services/iap-config-service.ts
@@ -17,6 +17,7 @@ export interface IAPConfig {
   serviceAccountKey?: string    // Google Play (encrypted)
   sharedSecret?: string         // Apple App Store (encrypted)
   bundleId?: string            // Apple App Store
+  appAppleId?: number          // Apple App Store — numeric App Store Connect app id, required for Production JWS verification
   packageName?: string         // Google Play
 }
 
@@ -67,10 +68,13 @@ function getConfigFromEnvVars(provider: IAPProvider, environment: IAPEnvironment
     const bundleId = Deno.env.get(`APPLE_${envSuffix}_BUNDLE_ID`) ??
       Deno.env.get('APPLE_BUNDLE_ID') ??
       bundleDefault
+    const appAppleIdRaw = Deno.env.get(`APPLE_${envSuffix}_APP_APPLE_ID`) ??
+      Deno.env.get('APPLE_APP_APPLE_ID')
+    const appAppleId = appAppleIdRaw ? Number(appAppleIdRaw) : undefined
 
     if (sharedSecret) {
       console.log(`[IAP_CONFIG] Source: ENV_VARS | Provider: ${provider} | Env: ${environment} | Bundle: ${bundleId}`)
-      return { provider, environment, sharedSecret, bundleId }
+      return { provider, environment, sharedSecret, bundleId, appAppleId }
     }
   }
 
@@ -146,6 +150,9 @@ export async function getIAPConfig(
         break
       case 'bundle_id':
         config.bundleId = row.config_value
+        break
+      case 'app_apple_id':
+        config.appAppleId = Number(row.config_value)
         break
       case 'package_name':
         config.packageName = row.config_value


### PR DESCRIPTION
## Summary
Production purchase validation was failing closed on every transaction: `SignedDataVerifier` (Apple's app-store-server-library) requires the app's numeric App Store Connect `appAppleId` when verifying against the Production environment, and the validator never passed it — confirmed live during device testing (`INVALID_RECEIPT - appAppleId is required when the environment is Production`).

- `apple-appstore-validator.ts`: pass `config.appAppleId` into `SignedDataVerifier` for the Production path; fail closed with a clear error if not configured (mirrors the existing bundleId check)
- `iap-config-service.ts`: source `appAppleId` from `APPLE_{ENV}_APP_APPLE_ID` / `APPLE_APP_APPLE_ID` env vars or the `iap_config` DB row (`app_apple_id`)
- `APPLE_APP_APPLE_ID` GitHub secret set to the app's numeric App Store Connect ID; `backend-deploy.yml` already wires it into `.env.production` and syncs it to Supabase function secrets on merge

## Test plan
- [x] Verified live on device: purchase flow reached `SignedDataVerifier` and failed with the exact `appAppleId` error before this fix
- [ ] After this merges and CI deploys, retry the same purchase flow on device and confirm the JWS verifies and the subscription is created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple App Store receipt validation for production environments by requiring the configured Apple App ID.
  * Added support for reading the Apple App ID from environment and database configuration.
  * Prevented production receipt verification from proceeding when the required App ID is missing, while preserving sandbox validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->