### PR TITLE
debug(iap): surface full Apple JWS verification error detail

### DIFF
--- a/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
+++ b/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
@@ -134,8 +134,10 @@ export async function validateAppleReceipt(
         console.log('[APPLE] Verified against fallback environment:', fallbackEnv)
       } catch (fallbackError) {
         console.error('[APPLE] JWS verification failed (both environments):', primaryError, fallbackError)
+        const describe = (e: unknown) =>
+          e instanceof Error ? `${e.name}: ${e.message || '(empty message)'}` : String(e)
         return failure(
-          `Apple transaction verification failed: ${primaryError instanceof Error ? primaryError.message : 'invalid signature'}`
+          `Apple transaction verification failed — ${primaryEnv}: ${describe(primaryError)} | ${fallbackEnv}: ${describe(fallbackError)}`
         )
       }
     }


### PR DESCRIPTION
## Summary
Follow-up to the appAppleId fix (#313) — the retry still fails with `INVALID_RECEIPT` but the error message is empty (`Apple transaction verification failed:` with nothing after). This masks the real cause. Widening the failure message to include both the Production and Sandbox verification attempts' error name+message so we can see what's actually failing (likely the Sandbox fallback path, since TestFlight/debug builds always produce Sandbox transactions regardless of backend environment).

## Test plan
- [ ] Retry the same purchase on device once deployed, read the detailed error, fix root cause

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when Apple App Store receipt verification fails.
  * Failure messages now include details from both primary and fallback verification attempts, making issues easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->