### PR TITLE
fix(iap): confirm Apple transactions via App Store Server API

### DIFF
--- a/.github/workflows/backend-deploy.yml
+++ b/.github/workflows/backend-deploy.yml
@@ -231,6 +231,12 @@ jobs:
         # Apple App Store Server Notifications V2 — bundle id allow-list + numeric app id
         APPLE_BUNDLE_ID=${{ secrets.APPLE_BUNDLE_ID }}
         APPLE_APP_APPLE_ID=${{ secrets.APPLE_APP_APPLE_ID }}
+        # Apple App Store Server API (In-App Purchase key) — used to confirm transactions
+        # server-to-server instead of local JWS cert-chain verification (Deno's Node compat
+        # layer doesn't implement crypto.X509Certificate.prototype.verify, which the local
+        # verification path requires).
+        APPLE_ISSUER_ID=${{ secrets.APPLE_ISSUER_ID }}
+        APPLE_IAP_KEY_ID=${{ secrets.APPLE_IAP_KEY_ID }}
 
         # SMS Configuration (${{ env.DEPLOY_ENV }})
         TWILIO_ACCOUNT_SID=${{ secrets.TWILIO_ACCOUNT_SID }}
@@ -256,6 +262,10 @@ jobs:
         ESCAPED_PK=$(printf '%s' "$FIREBASE_PRIVATE_KEY" | awk 'NR>1{printf "\\n"} {printf "%s", $0}')
         echo "FIREBASE_PRIVATE_KEY=${ESCAPED_PK}" >> .env.${{ env.DEPLOY_ENV }}
 
+        # APPLE_IAP_PRIVATE_KEY: same PEM-newline issue as FIREBASE_PRIVATE_KEY above.
+        ESCAPED_APPLE_PK=$(printf '%s' "$APPLE_IAP_PRIVATE_KEY" | awk 'NR>1{printf "\\n"} {printf "%s", $0}')
+        echo "APPLE_IAP_PRIVATE_KEY=${ESCAPED_APPLE_PK}" >> .env.${{ env.DEPLOY_ENV }}
+
         # GOOGLE_SERVICE_ACCOUNT_JSON: multi-line JSON breaks dotenv parsing.
         # Compact to a single-line JSON string before writing.
         python3 -c "import sys,json; print('GOOGLE_SERVICE_ACCOUNT_JSON=' + json.dumps(json.loads(sys.stdin.read())))" <<< "$GOOGLE_SERVICE_ACCOUNT_JSON" >> .env.${{ env.DEPLOY_ENV }}
@@ -264,6 +274,7 @@ jobs:
       env:
         FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
         GOOGLE_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_JSON }}
+        APPLE_IAP_PRIVATE_KEY: ${{ secrets.APPLE_IAP_PRIVATE_KEY }}
 
     - name: 📦 Run DB Migrations
       working-directory: ./backend

--- a/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
+++ b/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
@@ -12,6 +12,12 @@
 
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { SignedDataVerifier, Environment } from 'npm:@apple/app-store-server-library@1.4.0'
+// VerificationException/VerificationStatus aren't re-exported from the package root
+// (only SignedDataVerifier is) — import directly from the submodule that declares them.
+import {
+  VerificationException,
+  VerificationStatus,
+} from 'npm:@apple/app-store-server-library@1.4.0/dist/jws_verification'
 import { Buffer } from 'node:buffer'
 import { getIAPConfig } from './iap-config-service.ts'
 
@@ -134,8 +140,16 @@ export async function validateAppleReceipt(
         console.log('[APPLE] Verified against fallback environment:', fallbackEnv)
       } catch (fallbackError) {
         console.error('[APPLE] JWS verification failed (both environments):', primaryError, fallbackError)
-        const describe = (e: unknown) =>
-          e instanceof Error ? `${e.name}: ${e.message || '(empty message)'}` : String(e)
+        // VerificationException (thrown by SignedDataVerifier) carries no message —
+        // just a numeric `status` (+ optional `cause`) — so decode it explicitly.
+        const describe = (e: unknown) => {
+          if (e instanceof VerificationException) {
+            const statusName = VerificationStatus[e.status] ?? e.status
+            const causeMsg = e.cause instanceof Error ? ` (cause: ${e.cause.message})` : ''
+            return `VerificationException[${statusName}]${causeMsg}`
+          }
+          return e instanceof Error ? `${e.name}: ${e.message || '(empty message)'}` : String(e)
+        }
         return failure(
           `Apple transaction verification failed — ${primaryEnv}: ${describe(primaryError)} | ${fallbackEnv}: ${describe(fallbackError)}`
         )

--- a/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
+++ b/backend/supabase/functions/_shared/services/apple-appstore-validator.ts
@@ -1,28 +1,105 @@
 /**
- * Apple App Store Transaction Validation Service (StoreKit 2 / JWS)
+ * Apple App Store Transaction Validation Service (StoreKit 2 / App Store Server API)
  *
  * The app sends the StoreKit 2 signed transaction (JWSTransaction) obtained from
- * `PurchaseDetails.verificationData.serverVerificationData`. We verify it locally
- * against Apple's certificate chain using Apple's official app-store-server-library
- * (SignedDataVerifier) — no network round-trip to Apple, no App Store Server API
- * credentials, and the legacy verifyReceipt endpoint is no longer used.
+ * `PurchaseDetails.verificationData.serverVerificationData`. We decode (not verify)
+ * just its `transactionId`, then confirm the transaction directly with Apple via the
+ * App Store Server API's `getTransactionInfo` endpoint — an authenticated HTTPS call
+ * signed with our own In-App Purchase API key. Apple's response is trusted because it
+ * arrived over TLS in reply to our own authenticated request, so no local certificate
+ * chain verification is needed.
  *
- * Docs: https://developer.apple.com/documentation/appstoreserverapi/jwstransaction
+ * Local signature/chain verification (via the official `@apple/app-store-server-library`,
+ * `SignedDataVerifier`) was tried first but doesn't work here: it calls Node's
+ * `crypto.X509Certificate.prototype.verify()`, which Deno's Node-compat layer does not
+ * implement, on every code path regardless of `enableOnlineChecks`.
+ *
+ * The same library's `AppStoreServerAPIClient` (for calling this API) was tried next,
+ * but it signs its bearer JWT via the `jsonwebtoken` npm package, which rejected our
+ * ES256 EC private key with `"alg" parameter "ES256" requires curve "prime256v1"` —
+ * Deno's Node-compat `crypto.createPrivateKey()` apparently reports the P-256 curve
+ * under a different name than `jsonwebtoken` expects, so its strict curve-name check
+ * fails even though the key itself is a valid P-256 key.
+ *
+ * Both failures are Deno Node-compat gaps in the *library's* internals, not in the
+ * Apple API itself — so this signs the bearer JWT by hand using Deno's native Web
+ * Crypto (`crypto.subtle`), which is a first-class Deno API (not a Node shim) and
+ * makes the plain `fetch()` call directly, bypassing the npm library entirely.
+ *
+ * Docs: https://developer.apple.com/documentation/appstoreserverapi/get_transaction_info
  */
 
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
-import { SignedDataVerifier, Environment } from 'npm:@apple/app-store-server-library@1.4.0'
-// VerificationException/VerificationStatus aren't re-exported from the package root
-// (only SignedDataVerifier is) — import directly from the submodule that declares them.
-import {
-  VerificationException,
-  VerificationStatus,
-} from 'npm:@apple/app-store-server-library@1.4.0/dist/jws_verification'
-import { Buffer } from 'node:buffer'
 import { getIAPConfig } from './iap-config-service.ts'
 
+type AppleEnvironment = 'sandbox' | 'production'
+
+// Canonical domains since May 2026 (the older *.itunes.apple.com hosts still work
+// but are legacy — see the App Store Server API changelog).
+const API_BASE_URL: Record<AppleEnvironment, string> = {
+  production: 'https://api.storekit.apple.com',
+  sandbox: 'https://api.storekit-sandbox.apple.com',
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** Import a PKCS8 PEM (Apple's downloaded .p8 file contents) as a Web Crypto P-256
+ * signing key. */
+async function importApplePrivateKey(pem: string): Promise<CryptoKey> {
+  const der = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, '')
+    .replace(/-----END PRIVATE KEY-----/, '')
+    .replace(/\s+/g, '')
+  const binary = atob(der)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return await crypto.subtle.importKey(
+    'pkcs8',
+    bytes,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['sign']
+  )
+}
+
+/** Build and sign the ES256 bearer JWT the App Store Server API requires, per
+ * https://developer.apple.com/documentation/appstoreserverapi/generating_tokens_for_api_requests */
+async function createAppStoreServerAPIToken(
+  issuerId: string,
+  keyId: string,
+  bundleId: string,
+  privateKey: CryptoKey
+): Promise<string> {
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const header = { alg: 'ES256', kid: keyId, typ: 'JWT' }
+  const payload = {
+    iss: issuerId,
+    iat: nowSeconds,
+    exp: nowSeconds + 5 * 60,
+    aud: 'appstoreconnect-v1',
+    bid: bundleId,
+  }
+  const encoder = new TextEncoder()
+  const signingInput =
+    base64UrlEncode(encoder.encode(JSON.stringify(header))) +
+    '.' +
+    base64UrlEncode(encoder.encode(JSON.stringify(payload)))
+  // Web Crypto's ECDSA sign() output is the raw (r || s) format JWS/ES256 expects
+  // directly — no DER-to-raw conversion needed (unlike Node's crypto.sign()).
+  const signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    encoder.encode(signingInput)
+  )
+  return `${signingInput}.${base64UrlEncode(new Uint8Array(signature))}`
+}
+
 export interface AppleReceiptData {
-  receiptData: string  // StoreKit 2 JWSTransaction (compact JWS)
+  receiptData: string  // StoreKit 2 JWSTransaction (compact JWS) from the client
 }
 
 export interface AppleValidationResult {
@@ -39,28 +116,6 @@ export interface AppleValidationResult {
   error?: string
 }
 
-// Apple root certificates (public, stable). Fetched once per isolate and cached.
-// Verification pins the chain to these roots, so a forged/altered JWS fails.
-const APPLE_ROOT_CERT_URLS = [
-  'https://www.apple.com/certificateauthority/AppleRootCA-G3.cer',
-  'https://www.apple.com/certificateauthority/AppleRootCA-G2.cer',
-]
-let appleRootCertsCache: Buffer[] | null = null
-
-async function getAppleRootCerts(): Promise<Buffer[]> {
-  if (appleRootCertsCache) return appleRootCertsCache
-  const certs: Buffer[] = []
-  for (const url of APPLE_ROOT_CERT_URLS) {
-    const res = await fetch(url)
-    if (!res.ok) {
-      throw new Error(`Failed to fetch Apple root cert ${url}: ${res.status}`)
-    }
-    certs.push(Buffer.from(await res.arrayBuffer()))
-  }
-  appleRootCertsCache = certs
-  return certs
-}
-
 function failure(error: string, validationResponse: any = null): AppleValidationResult {
   return {
     isValid: false,
@@ -75,19 +130,41 @@ function failure(error: string, validationResponse: any = null): AppleValidation
   }
 }
 
+/** Decode (NOT verify) a compact JWS's payload segment. Only safe to use on a JWS
+ * whose contents you don't yet trust for authorization — here, just to pull the
+ * transactionId out of the client-submitted JWS before confirming it with Apple. */
+function decodeJWSPayload(jws: string): any {
+  const parts = jws.split('.')
+  if (parts.length !== 3) {
+    throw new Error('Malformed JWS (expected 3 dot-separated segments)')
+  }
+  const base64Url = parts[1]
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = base64 + '='.repeat((4 - (base64.length % 4)) % 4)
+  const json = atob(padded)
+  return JSON.parse(json)
+}
+
+function describeError(e: unknown): string {
+  return e instanceof Error ? `${e.name}: ${e.message || '(empty message)'}` : String(e)
+}
+
 /**
- * Validate an Apple StoreKit 2 signed transaction (JWS).
+ * Validate an Apple StoreKit 2 signed transaction by confirming it with Apple's
+ * App Store Server API.
  *
  * @param receipt.receiptData - the compact JWSTransaction string from the client
- * @param environment - resolved environment; the signed transaction's own
- *   environment claim must match, else validation fails.
+ * @param environment - resolved environment; if the transaction actually belongs to
+ *   the other environment (e.g. a TestFlight/debug build produces Sandbox
+ *   transactions even when the backend runs in production), the lookup is retried
+ *   against the other environment.
  */
 export async function validateAppleReceipt(
   supabase: SupabaseClient,
   receipt: AppleReceiptData,
   environment: 'sandbox' | 'production'
 ): Promise<AppleValidationResult> {
-  console.log('[APPLE] Verifying StoreKit 2 transaction for environment:', environment)
+  console.log('[APPLE] Confirming StoreKit 2 transaction via App Store Server API for environment:', environment)
 
   try {
     const config = await getIAPConfig(supabase, 'apple_appstore', environment)
@@ -97,67 +174,106 @@ export async function validateAppleReceipt(
       return failure('Malformed StoreKit 2 transaction (expected a compact JWS)')
     }
 
-    // bundleId is required to verify the transaction is for this app. Fail closed
-    // if it isn't configured rather than skip the check.
     if (!config.bundleId) {
       return failure('Apple bundle ID not configured — cannot verify transaction')
     }
-
-    // appAppleId (the numeric App Store Connect app identifier, e.g. from
-    // apps.apple.com/app/id<appAppleId>) is required by SignedDataVerifier when
-    // verifying against the Production environment — omitting it throws
-    // "appAppleId is required when the environment is Production" and every
-    // production purchase fails closed. It's not required for Sandbox.
-    if (!config.appAppleId) {
-      return failure('Apple app Apple ID not configured — cannot verify Production transactions')
+    if (!config.issuerId || !config.iapKeyId || !config.iapPrivateKey) {
+      return failure('Apple App Store Server API credentials not configured — cannot verify transaction')
     }
 
-    const appleRootCerts = await getAppleRootCerts()
-
-    // The signature + cert chain are environment-independent, but SignedDataVerifier
-    // also asserts the transaction's environment claim matches the one it was built
-    // with. A debug/TestFlight build produces Sandbox transactions even when the
-    // backend runs in production, so try the resolved environment first and fall
-    // back to the other — mirroring the legacy 21007/21008 sandbox re-routing.
-    const primaryEnv = environment === 'production' ? Environment.PRODUCTION : Environment.SANDBOX
-    const fallbackEnv = primaryEnv === Environment.PRODUCTION ? Environment.SANDBOX : Environment.PRODUCTION
-
-    const tryVerify = async (env: Environment) => {
-      // enableOnlineChecks=false → offline signature + cert-chain verification only.
-      // appAppleId is omitted for Sandbox (the library doesn't require it there).
-      const verifier = env === Environment.PRODUCTION
-        ? new SignedDataVerifier(appleRootCerts, false, env, config.bundleId!, config.appAppleId)
-        : new SignedDataVerifier(appleRootCerts, false, env, config.bundleId!)
-      return await verifier.verifyAndDecodeTransaction(signedTransaction)
-    }
-
-    let decoded: any
+    // Apple's getTransactionInfo accepts either identifier, but a plain transactionId
+    // isn't always independently queryable for a renewed/restored subscription — try
+    // it first, then fall back to originalTransactionId, per environment.
+    let candidateIds: string[]
     try {
-      decoded = await tryVerify(primaryEnv)
-    } catch (primaryError) {
-      try {
-        decoded = await tryVerify(fallbackEnv)
-        console.log('[APPLE] Verified against fallback environment:', fallbackEnv)
-      } catch (fallbackError) {
-        console.error('[APPLE] JWS verification failed (both environments):', primaryError, fallbackError)
-        // VerificationException (thrown by SignedDataVerifier) carries no message —
-        // just a numeric `status` (+ optional `cause`) — so decode it explicitly.
-        const describe = (e: unknown) => {
-          if (e instanceof VerificationException) {
-            const statusName = VerificationStatus[e.status] ?? e.status
-            const causeMsg = e.cause instanceof Error ? ` (cause: ${e.cause.message})` : ''
-            return `VerificationException[${statusName}]${causeMsg}`
-          }
-          return e instanceof Error ? `${e.name}: ${e.message || '(empty message)'}` : String(e)
-        }
-        return failure(
-          `Apple transaction verification failed — ${primaryEnv}: ${describe(primaryError)} | ${fallbackEnv}: ${describe(fallbackError)}`
-        )
-      }
+      const clientPayload = decodeJWSPayload(signedTransaction)
+      candidateIds = [clientPayload.transactionId, clientPayload.originalTransactionId]
+        .filter((id): id is string => typeof id === 'string' && id.length > 0)
+      candidateIds = [...new Set(candidateIds)]
+      if (candidateIds.length === 0) throw new Error('missing transactionId/originalTransactionId claims')
+    } catch (e) {
+      return failure(`Malformed StoreKit 2 transaction: ${describeError(e)}`)
     }
 
-    // Defense in depth: SignedDataVerifier already checks bundleId + environment,
-    // but re-assert here so a library behavior change can't silently loosen it.
+    const privateKey = await importApplePrivateKey(config.iapPrivateKey!)
+
+    // A TestFlight/debug build produces Sandbox transactions even when the backend
+    // resolves to production, so try the resolved environment first and fall back to
+    // the other — mirroring the legacy 21007/21008 sandbox re-routing.
+    const primaryEnv: AppleEnvironment = environment
+    const fallbackEnv: AppleEnvironment = environment === 'production' ? 'sandbox' : 'production'
+
+    const fetchTransactionById = async (env: AppleEnvironment, transactionId: string) => {
+      const token = await createAppStoreServerAPIToken(config.issuerId!, config.iapKeyId!, config.bundleId!, privateKey)
+      const res = await fetch(`${API_BASE_URL[env]}/inApps/v1/transactions/${transactionId}`, {
+        headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+      })
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`
+        try {
+          const body = await res.json()
+          if (body?.errorCode || body?.errorMessage) {
+            detail = `HTTP ${res.status} errorCode=${body.errorCode} ${body.errorMessage ?? ''}`.trim()
+          }
+        } catch {
+          // response body wasn't JSON — keep the plain HTTP status
+        }
+        throw new Error(detail)
+      }
+      const body = await res.json()
+      if (!body.signedTransactionInfo) {
+        throw new Error('Apple response missing signedTransactionInfo')
+      }
+      // Trusted: this JWS came directly from Apple over TLS in response to our own
+      // authenticated request, so decoding without re-verifying its signature is safe.
+      return decodeJWSPayload(body.signedTransactionInfo)
+    }
+
+    // Try every (environment, transactionId) combination — primary env first, each of
+    // its candidate IDs, then the fallback env with the same ID order.
+    const attempts: Array<{ env: AppleEnvironment; id: string }> = []
+    for (const env of [primaryEnv, fallbackEnv]) {
+      for (const id of candidateIds) attempts.push({ env, id })
+    }
+
+    const runAttempts = async () => {
+      const errors: string[] = []
+      let sawNotFound = false
+      for (const { env, id } of attempts) {
+        try {
+          const result = await fetchTransactionById(env, id)
+          if (env !== primaryEnv) console.log('[APPLE] Confirmed against fallback environment:', env)
+          return { decoded: result, errors, sawNotFound }
+        } catch (e) {
+          if (e instanceof Error && e.message.includes('errorCode=4040010')) sawNotFound = true
+          errors.push(`${env}[${id}]: ${describeError(e)}`)
+        }
+      }
+      return { decoded: null, errors, sawNotFound }
+    }
+
+    // A brand-new (especially sandbox) transaction can take a couple of minutes to
+    // become queryable via the Server API even though the purchase completed
+    // instantly on-device — a 404 4040010 right after purchase usually just means
+    // "not indexed yet". Retry a couple of times before failing; skip retries for
+    // pure auth failures (401s), which waiting won't fix.
+    const RETRY_DELAYS_MS = [5000, 10000]
+    let outcome = await runAttempts()
+    for (const delay of RETRY_DELAYS_MS) {
+      if (outcome.decoded || !outcome.sawNotFound) break
+      console.log(`[APPLE] Transaction not indexed yet — retrying in ${delay}ms`)
+      await new Promise((resolve) => setTimeout(resolve, delay))
+      outcome = await runAttempts()
+    }
+
+    const decoded: any = outcome.decoded
+    if (!decoded) {
+      console.error('[APPLE] Transaction lookup failed (all attempts):', outcome.errors)
+      return failure(`Apple transaction lookup failed — ${outcome.errors.join(' | ')}`)
+    }
+
+    // Defense in depth: re-assert bundle ID even though it's implied by using it to
+    // authenticate the API call, in case Apple's response ever includes a different app.
     if (config.bundleId && decoded.bundleId && decoded.bundleId !== config.bundleId) {
       return failure(
         `Bundle ID mismatch: transaction is for '${decoded.bundleId}', not '${config.bundleId}'`,
@@ -168,20 +284,33 @@ export async function validateAppleReceipt(
     const purchaseDate = decoded.purchaseDate ? new Date(decoded.purchaseDate) : new Date()
     const expiryDate = decoded.expiresDate ? new Date(decoded.expiresDate) : undefined
     const now = new Date()
-    const isActive = expiryDate ? expiryDate > now : true
+    // revocationDate present means Apple refunded/revoked the transaction (e.g. via
+    // Family Sharing removal or support refund) — never valid regardless of expiry.
+    const isActive = !decoded.revocationDate && (expiryDate ? expiryDate > now : true)
 
     // StoreKit 2 offer types: 1 = intro, 2 = promo, 3 = offer code. Trial is an
     // intro offer with a free payment mode; expose both flags for downstream use.
     const isIntroOffer = decoded.offerType === 1
     const isTrial = isIntroOffer
 
-    console.log('[APPLE] Verified transaction:', {
+    console.log('[APPLE] Confirmed transaction:', {
       transactionId: decoded.transactionId,
       productId: decoded.productId,
       environment: decoded.environment,
       expiryDate,
       isActive,
+      revocationDate: decoded.revocationDate,
     })
+
+    if (!isActive) {
+      const reason = decoded.revocationDate
+        ? `revoked at ${new Date(decoded.revocationDate).toISOString()}`
+        : `expired at ${expiryDate?.toISOString() ?? 'unknown'} (now: ${now.toISOString()})`
+      return failure(
+        `Apple confirmed the transaction but it is not currently active — ${reason}`,
+        decoded
+      )
+    }
 
     return {
       isValid: isActive,

--- a/backend/supabase/functions/_shared/services/iap-config-service.ts
+++ b/backend/supabase/functions/_shared/services/iap-config-service.ts
@@ -18,6 +18,9 @@ export interface IAPConfig {
   sharedSecret?: string         // Apple App Store (encrypted)
   bundleId?: string            // Apple App Store
   appAppleId?: number          // Apple App Store — numeric App Store Connect app id, required for Production JWS verification
+  issuerId?: string            // Apple App Store Server API — issuer ID (App Store Connect > Integrations > In-App Purchase key)
+  iapKeyId?: string            // Apple App Store Server API — key ID for the In-App Purchase key
+  iapPrivateKey?: string       // Apple App Store Server API — the .p8 private key contents (encrypted)
   packageName?: string         // Google Play
 }
 
@@ -71,10 +74,16 @@ function getConfigFromEnvVars(provider: IAPProvider, environment: IAPEnvironment
     const appAppleIdRaw = Deno.env.get(`APPLE_${envSuffix}_APP_APPLE_ID`) ??
       Deno.env.get('APPLE_APP_APPLE_ID')
     const appAppleId = appAppleIdRaw ? Number(appAppleIdRaw) : undefined
+    // App Store Server API credentials — same In-App Purchase key works against both the
+    // Sandbox and Production APIs (the environment is selected per-request, not per-key),
+    // so these are intentionally not env-suffixed.
+    const issuerId = Deno.env.get('APPLE_ISSUER_ID')
+    const iapKeyId = Deno.env.get('APPLE_IAP_KEY_ID')
+    const iapPrivateKey = Deno.env.get('APPLE_IAP_PRIVATE_KEY')
 
     if (sharedSecret) {
       console.log(`[IAP_CONFIG] Source: ENV_VARS | Provider: ${provider} | Env: ${environment} | Bundle: ${bundleId}`)
-      return { provider, environment, sharedSecret, bundleId, appAppleId }
+      return { provider, environment, sharedSecret, bundleId, appAppleId, issuerId, iapKeyId, iapPrivateKey }
     }
   }
 
@@ -153,6 +162,15 @@ export async function getIAPConfig(
         break
       case 'app_apple_id':
         config.appAppleId = Number(row.config_value)
+        break
+      case 'issuer_id':
+        config.issuerId = row.config_value
+        break
+      case 'iap_key_id':
+        config.iapKeyId = row.config_value
+        break
+      case 'iap_private_key':
+        config.iapPrivateKey = row.config_value
         break
       case 'package_name':
         config.packageName = row.config_value


### PR DESCRIPTION
## Summary
Replaces local StoreKit 2 JWS verification with server-to-server confirmation via Apple's App Store Server API (`GET /inApps/v1/transactions/{id}`) — **verified working end-to-end on a physical device**: sandbox purchase → Apple confirmation → subscription created (`plus_monthly`, active) → plan upgraded.

Why the rewrite was needed (both are Deno Node-compat gaps in Apple's official library):
- `SignedDataVerifier` requires `crypto.X509Certificate.prototype.verify()` — not implemented in Deno; every local verification threw
- `AppStoreServerAPIClient` signs its bearer JWT via `jsonwebtoken`, which rejects the key with `"ES256" requires curve "prime256v1"` under Deno's compat shim

Implementation:
- Bearer JWT (ES256, `aud=appstoreconnect-v1`, `bid`, 5-min expiry) signed by hand with Deno-native WebCrypto (`crypto.subtle`) — no Node shims
- Canonical API domains (`api.storekit.apple.com` / sandbox) per May 2026 changelog
- Decodes `transactionId`/`originalTransactionId` from the client JWS (decode only — trust comes from Apple's authenticated response), tries both IDs across both environments
- Retry with backoff (5s/10s) on `4040010 Transaction id not found` — new sandbox transactions take minutes to index
- Rejects revoked (`revocationDate`) and expired transactions with self-explanatory error messages
- New config: `APPLE_ISSUER_ID`, `APPLE_IAP_KEY_ID`, `APPLE_IAP_PRIVATE_KEY` (In-App Purchase key from App Store Connect) — set in Supabase + GitHub secrets; `backend-deploy.yml` wires them through (PEM newline handling mirrors `FIREBASE_PRIVATE_KEY`)

Known follow-up (separate issue): `apple-appstore-notifications` webhook still uses `SignedDataVerifier` and is broken by the same X509 gap — renewal/cancel/refund notifications need the same treatment.

## Test plan
- [x] Live sandbox purchase on physical iPhone: transaction 2000001203470411 confirmed by Apple, subscription created, user upgraded to plus
- [x] Expired transaction correctly rejected with explicit reason
- [x] Deleted (cleared-history) transaction correctly rejected as not found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Apple App Store transaction validation through Apple’s server API.
  * Added support for Apple App Store Server API credentials.
  * Transactions are now correctly identified as inactive when revoked or expired.

* **Bug Fixes**
  * Improved handling of transaction lookup retries, environment fallbacks, malformed data, and validation failures.
  * Added support for securely formatted private keys during production deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->