### PR TITLE
fix: language persistence across cold start/logout + session refresh in router guard

### DIFF
--- a/frontend/lib/core/i18n/app_translations.dart
+++ b/frontend/lib/core/i18n/app_translations.dart
@@ -456,7 +456,9 @@ class AppTranslations {
       'report_purchase_issue': 'Report Purchase Issue',
       'report_purchase_issue_subtitle': 'Get help with credit purchases',
       'contact_us': 'Contact Us',
-      'contact_us_subtitle': 'contact@disciplefy.in',
+      'contact_us_subtitle': 'Email • Instagram • Facebook',
+      'contact_email': 'Email',
+      'contact_error': 'Could not open. Please try again.',
       'replay_walkthrough': 'Replay App Walkthrough',
       'replay_walkthrough_subtitle': 'Replay the guided tour for each screen',
       'replay_walkthrough_success':
@@ -2440,7 +2442,9 @@ class AppTranslations {
       'report_purchase_issue': 'खरीदारी समस्या रिपोर्ट करें',
       'report_purchase_issue_subtitle': 'क्रेडिट खरीदारी में मदद पाएं',
       'contact_us': 'हमसे संपर्क करें',
-      'contact_us_subtitle': 'contact@disciplefy.in',
+      'contact_us_subtitle': 'ईमेल • Instagram • Facebook',
+      'contact_email': 'ईमेल',
+      'contact_error': 'खोला नहीं जा सका। कृपया पुनः प्रयास करें।',
       'replay_walkthrough': 'ऐप वॉकथ्रू दोबारा देखें',
       'replay_walkthrough_subtitle':
           'प्रत्येक स्क्रीन का निर्देशित दौरा दोबारा चलाएं',
@@ -4449,7 +4453,9 @@ class AppTranslations {
       'report_purchase_issue': 'വാങ്ങൽ പ്രശ്നം റിപ്പോർട്ട് ചെയ്യുക',
       'report_purchase_issue_subtitle': 'ക്രെഡിറ്റ് വാങ്ങലിൽ സഹായം നേടുക',
       'contact_us': 'ഞങ്ങളെ ബന്ധപ്പെടുക',
-      'contact_us_subtitle': 'contact@disciplefy.in',
+      'contact_us_subtitle': 'ഇമെയിൽ • Instagram • Facebook',
+      'contact_email': 'ഇമെയിൽ',
+      'contact_error': 'തുറക്കാൻ കഴിഞ്ഞില്ല. വീണ്ടും ശ്രമിക്കുക.',
       'replay_walkthrough': 'ആപ്പ് ഗൈഡഡ് ടൂർ വീണ്ടും കാണുക',
       'replay_walkthrough_subtitle':
           'ഓരോ സ്ക്രീനിലും ഗൈഡഡ് ടൂർ വീണ്ടും ചലിപ്പിക്കുക',

--- a/frontend/lib/core/i18n/translation_keys.dart
+++ b/frontend/lib/core/i18n/translation_keys.dart
@@ -389,6 +389,8 @@ class TranslationKeys {
       'settings.report_purchase_issue_subtitle';
   static const settingsContactUs = 'settings.contact_us';
   static const settingsContactUsSubtitle = 'settings.contact_us_subtitle';
+  static const settingsContactEmail = 'settings.contact_email';
+  static const settingsContactError = 'settings.contact_error';
   static const settingsReplayWalkthrough = 'settings.replay_walkthrough';
   static const settingsReplayWalkthroughSubtitle =
       'settings.replay_walkthrough_subtitle';

--- a/frontend/lib/core/router/router_guard.dart
+++ b/frontend/lib/core/router/router_guard.dart
@@ -148,8 +148,27 @@ class RouterGuard {
       // SECURITY FIX: Validate session expiration for all auth types
       final isExpired = _isSessionExpired();
       if (isExpired) {
+        // The stored expiry tracks the ACCESS token (1h), not the session.
+        // With default Supabase settings sessions never expire, so an
+        // expired access token after long idle is normal — refresh it
+        // instead of forcing the user back to login.
+        final refreshed = await _tryRefreshExpiredSession();
+        if (refreshed) {
+          Logger.info(
+            'Access token expired but session refreshed successfully',
+            tag: 'AUTH_SECURITY',
+            context: {'user_id': user.id, 'user_type': 'supabase'},
+          );
+          return AuthenticationState(
+            isAuthenticated: true,
+            userType: 'supabase',
+            userId: user.id,
+            userEmail: user.email,
+          );
+        }
+
         Logger.info(
-          'User session expired',
+          'User session expired and refresh failed',
           tag: 'AUTH_SECURITY',
           context: {
             'user_id': user.id,
@@ -1261,6 +1280,54 @@ class RouterGuard {
         error: e,
       );
     }
+  }
+
+  // Serializes refresh attempts so concurrent guard evaluations don't fire
+  // parallel refreshSession() calls (refresh tokens are single-use).
+  static Future<bool>? _refreshInFlight;
+
+  /// Attempt to refresh an expired access token using the refresh token.
+  /// Returns true when a valid session was obtained. On success the new
+  /// expiry is written to Hive immediately (the tokenRefreshed event from
+  /// AuthNotifier also syncs it, but may arrive after the guard re-runs).
+  static Future<bool> _tryRefreshExpiredSession() {
+    final inFlight = _refreshInFlight;
+    if (inFlight != null) return inFlight;
+
+    final attempt = () async {
+      try {
+        final response = await Supabase.instance.client.auth.refreshSession();
+        final session = response.session;
+        if (session == null) return false;
+
+        final expiresAt = session.expiresAt;
+        if (expiresAt != null) {
+          final expiryTime =
+              DateTime.fromMillisecondsSinceEpoch(expiresAt * 1000);
+          if (DateTime.now().isAfter(expiryTime)) {
+            // Refresh "succeeded" but returned an expired session —
+            // the refresh token itself is no longer valid.
+            return false;
+          }
+          if (Hive.isBoxOpen(_hiveBboxName)) {
+            await Hive.box(_hiveBboxName).put(
+                _sessionExpiresAtKey, expiryTime.toUtc().toIso8601String());
+          }
+        }
+        return true;
+      } catch (e) {
+        Logger.warning(
+          'Session refresh attempt failed',
+          tag: 'AUTH_SECURITY',
+          context: {'error': e.toString()},
+        );
+        return false;
+      }
+    }();
+
+    _refreshInFlight = attempt;
+    attempt.whenComplete(() => _refreshInFlight = null);
+    return attempt;
   }
 
   /// SECURITY FIX: Check if the session has expired

--- a/frontend/lib/core/services/language_preference_service.dart
+++ b/frontend/lib/core/services/language_preference_service.dart
@@ -81,22 +81,39 @@ class LanguagePreferenceService {
         final dbLanguageResult =
             await _userProfileService.getLanguagePreference();
 
-        final dbLanguage = dbLanguageResult.fold(
+        var dbHasNoPreference = false;
+        final dbLanguage = dbLanguageResult.fold<AppLanguage?>(
           (failure) {
             Logger.warning(
                 '⚠️ [LANGUAGE_SERVICE] Database call failed: ${failure.message}');
             return null; // Failed to get from DB, fall back to local/cache
           },
-          (language) => language,
+          (language) {
+            // Profile exists but no language chosen yet (DB null) —
+            // keep the local choice instead of overwriting it.
+            if (language == null) dbHasNoPreference = true;
+            return language;
+          },
         );
 
         if (dbLanguage != null) {
           // Sync local storage with database value and cache it
+          final previousCode = _prefs.getString(_languagePreferenceKey);
           await _prefs.setString(_languagePreferenceKey, dbLanguage.code);
           _cachedLanguage = dbLanguage;
+          if (previousCode != dbLanguage.code) {
+            // Converge every listener (LocaleService, TranslationService,
+            // content BLoCs) that may have resolved an older local value
+            // before the DB was reachable.
+            _languageChangeController.add(dbLanguage);
+          }
           Logger.debug(
               '✅ [LANGUAGE_SERVICE] Retrieved from DB and cached: ${dbLanguage.displayName}');
           return dbLanguage;
+        }
+
+        if (dbHasNoPreference) {
+          _pushLocalLanguageToDatabase();
         }
       }
 
@@ -134,6 +151,37 @@ class LanguagePreferenceService {
 
       return AppLanguage.english;
     }
+  }
+
+  // Guards the one-shot local→DB sync when the profile has no language yet,
+  // so repeated getSelectedLanguage() calls don't spam the API.
+  bool _localToDbSyncAttempted = false;
+
+  /// When the DB profile exists but language_preference is null (e.g. the
+  /// earlier best-effort sync failed), push the locally chosen language up
+  /// so the DB never stays null and later logins restore the right language.
+  void _pushLocalLanguageToDatabase() {
+    if (_localToDbSyncAttempted) return;
+    final localCode = _prefs.getString(_languagePreferenceKey);
+    if (localCode == null) return;
+    _localToDbSyncAttempted = true;
+
+    final localLanguage = AppLanguage.fromCode(localCode);
+    unawaited(_userProfileService
+        .updateLanguagePreference(localLanguage)
+        .then((result) => result.fold(
+              (failure) {
+                // Allow a retry on a later call if this attempt failed.
+                _localToDbSyncAttempted = false;
+                Logger.warning(
+                    '⚠️ [LANGUAGE_SERVICE] Failed to push local language to DB: ${failure.message}');
+              },
+              (_) {
+                _authStateProvider.invalidateProfileCache();
+                Logger.debug(
+                    '✅ [LANGUAGE_SERVICE] Pushed local language to DB: ${localLanguage.displayName}');
+              },
+            )));
   }
 
   /// Save language preference to both local storage and database
@@ -379,10 +427,11 @@ class LanguagePreferenceService {
         // No cached data or language preference, fallback to API call
         final dbLanguageResult =
             await _userProfileService.getLanguagePreference();
-        dbLanguageResult.fold(
-          (failure) =>
+        await dbLanguageResult.fold(
+          (failure) async =>
               Logger.warning('No language preference found in database'),
           (language) async {
+            if (language == null) return;
             await _prefs.setString(_languagePreferenceKey, language.code);
             Logger.debug(
                 'Synced database language preference to local: ${language.displayName}');

--- a/frontend/lib/features/auth/data/repositories/local_store_repository_impl.dart
+++ b/frontend/lib/features/auth/data/repositories/local_store_repository_impl.dart
@@ -22,6 +22,14 @@ class LocalStoreRepositoryImpl implements LocalStoreRepository {
   @override
   Future<void> clearAll() async {
     try {
+      // Snapshot the device-level language setting before wiping the box so
+      // logout doesn't reset the Settings screen back to English.
+      Object? preservedSettingsLanguage;
+      if (Hive.isBoxOpen('app_settings')) {
+        preservedSettingsLanguage =
+            Hive.box('app_settings').get('settings_language');
+      }
+
       // Close all open Hive boxes
       await Hive.close();
 
@@ -40,6 +48,8 @@ class LocalStoreRepositoryImpl implements LocalStoreRepository {
       await appSettingsBox.putAll({
         'onboarding_completed': true,
         'app_version': '1.0.0',
+        if (preservedSettingsLanguage != null)
+          'settings_language': preservedSettingsLanguage,
       });
 
       // Clear SharedPreferences
@@ -88,12 +98,33 @@ class LocalStoreRepositoryImpl implements LocalStoreRepository {
     await Future.wait(clearTasks);
   }
 
+  /// SharedPreferences keys that are device-level preferences, not user data,
+  /// and must survive logout (losing them resets the app UI to English).
+  static const List<String> _preservedPrefsKeys = [
+    'user_language_preference',
+    'has_completed_language_selection',
+    'study_content_language',
+  ];
+
   @override
   Future<void> clearSharedPreferences() async {
     try {
       final prefs = await SharedPreferences.getInstance();
+      final preserved = <String, Object>{
+        for (final key in _preservedPrefsKeys)
+          if (prefs.get(key) != null) key: prefs.get(key)!,
+      };
       await prefs.clear();
-      Logger.debug('🗄️ [LOCAL STORE] ✅ SharedPreferences cleared');
+      for (final entry in preserved.entries) {
+        final value = entry.value;
+        if (value is String) {
+          await prefs.setString(entry.key, value);
+        } else if (value is bool) {
+          await prefs.setBool(entry.key, value);
+        }
+      }
+      Logger.debug(
+          '🗄️ [LOCAL STORE] ✅ SharedPreferences cleared (${preserved.length} language keys preserved)');
     } catch (e) {
       Logger.debug('🗄️ [LOCAL STORE] ❌ Failed to clear SharedPreferences: $e');
       rethrow;

--- a/frontend/lib/features/auth/data/repositories/storage_repository_impl.dart
+++ b/frontend/lib/features/auth/data/repositories/storage_repository_impl.dart
@@ -93,12 +93,33 @@ class StorageRepositoryImpl implements StorageRepository {
     }
   }
 
+  /// SharedPreferences keys that are device-level preferences, not user data,
+  /// and must survive logout (losing them resets the app UI to English).
+  static const List<String> _preservedPrefsKeys = [
+    'user_language_preference',
+    'has_completed_language_selection',
+    'study_content_language',
+  ];
+
   @override
   Future<void> clearSharedPreferences() async {
     try {
       final prefs = await SharedPreferences.getInstance();
+      final preserved = <String, Object>{
+        for (final key in _preservedPrefsKeys)
+          if (prefs.get(key) != null) key: prefs.get(key)!,
+      };
       await prefs.clear();
-      Logger.debug('🗄️ [STORAGE REPO] ✅ SharedPreferences cleared');
+      for (final entry in preserved.entries) {
+        final value = entry.value;
+        if (value is String) {
+          await prefs.setString(entry.key, value);
+        } else if (value is bool) {
+          await prefs.setBool(entry.key, value);
+        }
+      }
+      Logger.debug(
+          '🗄️ [STORAGE REPO] ✅ SharedPreferences cleared (${preserved.length} language keys preserved)');
     } catch (e) {
       Logger.debug(
           '🗄️ [STORAGE REPO] ❌ Failed to clear SharedPreferences: $e');

--- a/frontend/lib/features/settings/presentation/bloc/settings_bloc.dart
+++ b/frontend/lib/features/settings/presentation/bloc/settings_bloc.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../core/usecases/usecase.dart';
 import '../../../../core/utils/error_handler.dart';
@@ -21,6 +23,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   final LanguagePreferenceService languagePreferenceService;
 
   bool _hasInitialized = false;
+  StreamSubscription<AppLanguage>? _languageSubscription;
 
   SettingsBloc({
     required this.getSettings,
@@ -36,12 +39,26 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<ToggleNotifications>(_onToggleNotifications);
     on<LoadAppVersion>(_onLoadAppVersion);
     on<ClearAllSettings>(_onClearAllSettings);
+    on<LanguageChangedExternally>(_onLanguageChangedExternally);
+
+    // Keep settings in sync when the language changes outside this bloc
+    // (e.g. DB-driven convergence at startup or onboarding selection).
+    _languageSubscription =
+        languagePreferenceService.languageChanges.listen((language) {
+      add(LanguageChangedExternally(language.code));
+    });
 
     // Auto-initialize settings once when bloc is created
     if (!_hasInitialized) {
       _hasInitialized = true;
       add(LoadSettings());
     }
+  }
+
+  @override
+  Future<void> close() {
+    _languageSubscription?.cancel();
+    return super.close();
   }
 
   Future<void> _onLoadSettings(
@@ -162,6 +179,22 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         emit(SettingsError(message: 'Failed to update language: $e'));
       }
     }
+  }
+
+  Future<void> _onLanguageChangedExternally(
+    LanguageChangedExternally event,
+    Emitter<SettingsState> emit,
+  ) async {
+    if (state is! SettingsLoaded) return;
+    final currentState = state as SettingsLoaded;
+    if (currentState.settings.language == event.language) return;
+
+    // Update the Hive copy so the settings screen shows the right language
+    // next time, and refresh the current state for an open settings screen.
+    await settingsRepository.updateLanguage(event.language);
+    emit(SettingsLoaded(
+      settings: currentState.settings.copyWith(language: event.language),
+    ));
   }
 
   Future<void> _onToggleNotifications(

--- a/frontend/lib/features/settings/presentation/bloc/settings_event.dart
+++ b/frontend/lib/features/settings/presentation/bloc/settings_event.dart
@@ -37,6 +37,17 @@ class ToggleNotifications extends SettingsEvent {
   List<Object?> get props => [enabled];
 }
 
+/// Fired when the app language changed outside the settings screen
+/// (e.g. DB-driven sync at startup) so the settings state stays consistent.
+class LanguageChangedExternally extends SettingsEvent {
+  final String language;
+
+  const LanguageChangedExternally(this.language);
+
+  @override
+  List<Object?> get props => [language];
+}
+
 class LoadAppVersion extends SettingsEvent {}
 
 class ClearAllSettings extends SettingsEvent {}

--- a/frontend/lib/features/settings/presentation/pages/settings_screen.dart
+++ b/frontend/lib/features/settings/presentation/pages/settings_screen.dart
@@ -769,7 +769,7 @@ class _SettingsScreenContentState extends State<_SettingsScreenContent> {
               size: 16,
               color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
             ),
-            onTap: () => _launchContactEmail(),
+            onTap: () => _showContactSheet(context),
           ),
           _buildDivider(),
           // Replay App Walkthrough tile
@@ -819,12 +819,131 @@ class _SettingsScreenContentState extends State<_SettingsScreenContent> {
     }
   }
 
+  /// Show contact options (email, Instagram, Facebook) in a bottom sheet
+  void _showContactSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (builderContext) => Container(
+        decoration: BoxDecoration(
+          color: Theme.of(builderContext).colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        ),
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryColor.withOpacity(0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              context.tr(TranslationKeys.settingsContactUs),
+              style: AppFonts.inter(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+                color: Theme.of(builderContext).colorScheme.onBackground,
+              ),
+            ),
+            const SizedBox(height: 16),
+            _buildContactOption(
+              builderContext,
+              icon: Icons.email_outlined,
+              title: context.tr(TranslationKeys.settingsContactEmail),
+              subtitle: 'contact@disciplefy.in',
+              // Use the page context: the sheet context is deactivated after pop.
+              onTap: () => _launchContactEmail(context),
+            ),
+            _buildContactOption(
+              builderContext,
+              icon: Icons.camera_alt_outlined,
+              title: 'Instagram',
+              subtitle: '@disciplefy.in',
+              onTap: () => _launchContactUrl(
+                  context, 'https://www.instagram.com/disciplefy.in'),
+            ),
+            _buildContactOption(
+              builderContext,
+              icon: Icons.facebook,
+              title: 'Facebook',
+              subtitle: 'facebook.com/disciplefy',
+              onTap: () => _launchContactUrl(
+                  context, 'https://www.facebook.com/disciplefy'),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContactOption(
+    BuildContext sheetContext, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+  }) =>
+      ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: AppTheme.primaryColor.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(icon, color: AppTheme.primaryColor, size: 22),
+        ),
+        title: Text(
+          title,
+          style: AppFonts.inter(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: Theme.of(sheetContext).colorScheme.onBackground,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: AppFonts.inter(
+            fontSize: 13,
+            color:
+                Theme.of(sheetContext).colorScheme.onSurface.withOpacity(0.6),
+          ),
+        ),
+        onTap: () {
+          Navigator.of(sheetContext).pop();
+          onTap();
+        },
+      );
+
   /// Launch contact email
-  Future<void> _launchContactEmail() async {
+  Future<void> _launchContactEmail(BuildContext context) async {
     final uri = Uri.parse(
         'mailto:contact@disciplefy.in?subject=Disciplefy Support Request');
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
+    } else if (context.mounted) {
+      _showSnackBar(context, context.tr(TranslationKeys.settingsContactError),
+          Colors.red);
+    }
+  }
+
+  /// Launch a social/contact URL in the external app or browser
+  Future<void> _launchContactUrl(BuildContext context, String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else if (context.mounted) {
+      _showSnackBar(context, context.tr(TranslationKeys.settingsContactError),
+          Colors.red);
     }
   }
 

--- a/frontend/lib/features/user_profile/data/services/user_profile_service.dart
+++ b/frontend/lib/features/user_profile/data/services/user_profile_service.dart
@@ -72,14 +72,31 @@ class UserProfileService {
     return await _apiService.updateProfile(updates);
   }
 
-  /// Get user's language preference as AppLanguage
-  Future<Either<Failure, AppLanguage>> getLanguagePreference() async {
-    final profileResult = await getUserProfile();
+  /// Get user's language preference as AppLanguage.
+  /// Returns Right(null) when the profile exists but no language has been
+  /// chosen yet (DB value is null). Uses the raw profile map because the
+  /// typed UserProfileModel coerces a null language_preference to 'en',
+  /// which would make a new profile silently overwrite a local choice.
+  Future<Either<Failure, AppLanguage?>> getLanguagePreference() async {
+    final currentUser = _authService.currentUser;
+    if (!_authService.isAuthenticated || currentUser == null) {
+      return const Left(AuthenticationFailure(
+        message: 'User must be authenticated to access profile',
+      ));
+    }
 
-    return profileResult.fold(
-      (failure) => Left(failure),
-      (profile) => Right(AppLanguage.fromCode(profile.languagePreference)),
-    );
+    final rawProfile = await _apiService.getUserProfileRawMap();
+    if (rawProfile == null) {
+      return const Left(ServerFailure(
+        message: 'Failed to fetch user profile',
+      ));
+    }
+
+    final code = rawProfile['language_preference'] as String?;
+    if (code == null || code.isEmpty) {
+      return const Right(null);
+    }
+    return Right(AppLanguage.fromCode(code));
   }
 
   /// Check if user profile exists

--- a/frontend/test/features/auth/local_store_repository_impl_test.dart
+++ b/frontend/test/features/auth/local_store_repository_impl_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:disciplefy_bible_study/features/auth/data/repositories/local_store_repository_impl.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('LocalStoreRepositoryImpl.clearSharedPreferences', () {
+    test('preserves language preferences across logout', () async {
+      SharedPreferences.setMockInitialValues({
+        'user_language_preference': 'hi',
+        'has_completed_language_selection': true,
+        'study_content_language': 'default',
+        'user_id': 'abc-123',
+        'auth_token': 'token',
+      });
+
+      final repository = LocalStoreRepositoryImpl();
+      await repository.clearSharedPreferences();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('user_language_preference'), 'hi');
+      expect(prefs.getBool('has_completed_language_selection'), true);
+      expect(prefs.getString('study_content_language'), 'default');
+      expect(prefs.getString('user_id'), isNull);
+      expect(prefs.getString('auth_token'), isNull);
+    });
+
+    test('clears everything when no language keys are set', () async {
+      SharedPreferences.setMockInitialValues({
+        'user_id': 'abc-123',
+      });
+
+      final repository = LocalStoreRepositoryImpl();
+      await repository.clearSharedPreferences();
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getKeys(), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes two user-facing bugs after long-idle cold start: mixed English/Hindi UI and forced re-login.

### Mixed language after cold start (`a280c808`)
- **Root cause**: two independent i18n runtimes (`AppLocalizations`/`LocaleService` vs `TranslationService`/`context.tr`) resolved language at different moments relative to auth readiness; backend `language_preference` NULL was coerced to `'en'` and overwrote the local choice; logout wiped all SharedPreferences including language.
- `UserProfileService.getLanguagePreference()` now preserves DB NULL (raw profile map) instead of coercing to English
- `getSelectedLanguage()` emits on `languageChanges` when a DB-driven value differs from local, so both i18n runtimes and content BLoCs converge
- When DB language is NULL and a local choice exists, it is pushed to the DB (one-shot per session)
- Logout preserves `user_language_preference`, `has_completed_language_selection`, `study_content_language`, and Hive `settings_language`
- `SettingsBloc` syncs its state/Hive copy on external language changes

### Forced re-login after long idle (`9a7c0f7c`)
- **Root cause**: `RouterGuard` stored the access-token expiry (1h) as `session_expires_at` and treated it as session expiry, clearing the session without attempting refresh — discarding valid refresh tokens (Supabase sessions are configured to never expire).
- Guard now attempts `auth.refreshSession()` when the access token is expired and only signs the user out if refresh fails; concurrent guard evaluations share a single in-flight refresh.

## Testing
- `flutter analyze` clean, all 147 tests pass
- New regression test: language keys survive logout, user keys cleared (`local_store_repository_impl_test.dart`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNX4y7uoMv5YrpsHFxz3sN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expired sessions now attempt automatic token refresh before signing users out.
  * Language preferences now synchronize reliably between device storage, profiles, and settings.
  * Language selections are preserved during logout and storage cleanup.
  * Settings update when language changes outside the Settings screen.

* **Bug Fixes**
  * Prevented concurrent session refresh attempts.
  * Improved handling of profiles without a saved language preference.
  * Added coverage confirming authentication data is cleared while language preferences remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->