### PR TITLE
fix(ci): monotonic store build numbers (fixes Play Store rollout block)

### DIFF
--- a/.github/workflows/android-deploy-playstore-beta.yml
+++ b/.github/workflows/android-deploy-playstore-beta.yml
@@ -37,11 +37,11 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # 20000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
+          # 10000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
           # Android workflow, so any track can always upgrade over any older build.
           # (Per-workflow run numbers are independent counters and Play rejected a
           # beta bundle whose versionCode was below production's run_number+10000.)
-          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
+          BUILD_NUMBER=$(( 10000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/android-deploy-playstore-beta.yml
+++ b/.github/workflows/android-deploy-playstore-beta.yml
@@ -37,9 +37,14 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
+          # Minutes since epoch: one monotonic versionCode source shared by every
+          # Android workflow, so any track can always upgrade over any older build.
+          # (Per-workflow run numbers are independent counters and Play rejected a
+          # beta bundle whose versionCode was below production's run_number+10000.)
+          BUILD_NUMBER=$(( $(date +%s) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
-          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
-          echo "✅ Version: $VERSION+${{ github.run_number }}"
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+          echo "✅ Version: $VERSION+$BUILD_NUMBER"
 
       - name: ✅ Validate release notes
         env:

--- a/.github/workflows/android-deploy-playstore-beta.yml
+++ b/.github/workflows/android-deploy-playstore-beta.yml
@@ -37,11 +37,11 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Minutes since epoch: one monotonic versionCode source shared by every
+          # 20000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
           # Android workflow, so any track can always upgrade over any older build.
           # (Per-workflow run numbers are independent counters and Play rejected a
           # beta bundle whose versionCode was below production's run_number+10000.)
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/android-deploy-playstore-production.yml
+++ b/.github/workflows/android-deploy-playstore-production.yml
@@ -41,9 +41,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Minutes since epoch: one monotonic versionCode source shared by every
+          # 20000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
           # Android workflow (see android-deploy-playstore-beta.yml).
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/android-deploy-playstore-production.yml
+++ b/.github/workflows/android-deploy-playstore-production.yml
@@ -41,9 +41,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # 20000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
+          # 10000 + minutes since 2026-07-11 UTC: one monotonic versionCode source shared by every
           # Android workflow (see android-deploy-playstore-beta.yml).
-          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
+          BUILD_NUMBER=$(( 10000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/android-deploy-playstore-production.yml
+++ b/.github/workflows/android-deploy-playstore-production.yml
@@ -41,8 +41,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Offset by 10000 to ensure production build numbers always exceed beta
-          BUILD_NUMBER=$(( ${{ github.run_number }} + 10000 ))
+          # Minutes since epoch: one monotonic versionCode source shared by every
+          # Android workflow (see android-deploy-playstore-beta.yml).
+          BUILD_NUMBER=$(( $(date +%s) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/android-deploy-testers.yml
+++ b/.github/workflows/android-deploy-testers.yml
@@ -76,7 +76,7 @@ jobs:
             --dart-define=FLUTTER_ENV=development \
             --dart-define=GOOGLE_CLOUD_TTS_API_KEY=${{ secrets.GOOGLE_CLOUD_TTS_API_KEY }} \
             --build-name=1.0.${{ github.run_number }} \
-            --build-number=$(( $(date +%s) / 60 ))
+            --build-number=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/android-deploy-testers.yml
+++ b/.github/workflows/android-deploy-testers.yml
@@ -76,7 +76,7 @@ jobs:
             --dart-define=FLUTTER_ENV=development \
             --dart-define=GOOGLE_CLOUD_TTS_API_KEY=${{ secrets.GOOGLE_CLOUD_TTS_API_KEY }} \
             --build-name=1.0.${{ github.run_number }} \
-            --build-number=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
+            --build-number=$(( 10000 + ($(date +%s) - 1783814400) / 60 ))
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/android-deploy-testers.yml
+++ b/.github/workflows/android-deploy-testers.yml
@@ -76,7 +76,7 @@ jobs:
             --dart-define=FLUTTER_ENV=development \
             --dart-define=GOOGLE_CLOUD_TTS_API_KEY=${{ secrets.GOOGLE_CLOUD_TTS_API_KEY }} \
             --build-name=1.0.${{ github.run_number }} \
-            --build-number=${{ github.run_number }}
+            --build-number=$(( $(date +%s) / 60 ))
 
       - name: Upload to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1

--- a/.github/workflows/ios-deploy-appstore.yml
+++ b/.github/workflows/ios-deploy-appstore.yml
@@ -32,9 +32,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Minutes since epoch: one monotonic build-number source shared with
+          # 20000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
           # ios-deploy-testflight.yml (see comment there).
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/ios-deploy-appstore.yml
+++ b/.github/workflows/ios-deploy-appstore.yml
@@ -32,9 +32,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # 20000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
+          # 10000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
           # ios-deploy-testflight.yml (see comment there).
-          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
+          BUILD_NUMBER=$(( 10000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/ios-deploy-appstore.yml
+++ b/.github/workflows/ios-deploy-appstore.yml
@@ -32,9 +32,9 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Offset by 10000 so production build numbers always exceed TestFlight betas
-          # (which use the plain run number). The two tracks stay numerically distinct.
-          BUILD_NUMBER=$(( ${{ github.run_number }} + 10000 ))
+          # Minutes since epoch: one monotonic build-number source shared with
+          # ios-deploy-testflight.yml (see comment there).
+          BUILD_NUMBER=$(( $(date +%s) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/ios-deploy-testflight.yml
+++ b/.github/workflows/ios-deploy-testflight.yml
@@ -28,10 +28,10 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # 20000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
+          # 10000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
           # ios-deploy-appstore.yml, so App Store builds always exceed TestFlight
           # builds regardless of each workflow's independent run counter.
-          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
+          BUILD_NUMBER=$(( 10000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"

--- a/.github/workflows/ios-deploy-testflight.yml
+++ b/.github/workflows/ios-deploy-testflight.yml
@@ -28,12 +28,13 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # TestFlight betas use the plain run number (small: 1, 2, 3…).
-          # Production builds offset by 10000 (see ios-deploy-appstore.yml) so the
-          # two tracks stay numerically distinct; groups differentiate them in TestFlight.
+          # Minutes since epoch: one monotonic build-number source shared with
+          # ios-deploy-appstore.yml, so App Store builds always exceed TestFlight
+          # builds regardless of each workflow's independent run counter.
+          BUILD_NUMBER=$(( $(date +%s) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
-          echo "build_number=${{ github.run_number }}" >> $GITHUB_OUTPUT
-          echo "✅ Version: $VERSION+${{ github.run_number }}"
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
+          echo "✅ Version: $VERSION+$BUILD_NUMBER"
 
       # Apple requires the iOS 26 SDK (Xcode 26+) for App Store uploads.
       - name: 🛠️ Select Xcode 26

--- a/.github/workflows/ios-deploy-testflight.yml
+++ b/.github/workflows/ios-deploy-testflight.yml
@@ -28,10 +28,10 @@ jobs:
         id: version
         run: |
           VERSION=$(grep '^version:' frontend/pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          # Minutes since epoch: one monotonic build-number source shared with
+          # 20000 + minutes since 2026-07-11 UTC: one monotonic build-number source shared with
           # ios-deploy-appstore.yml, so App Store builds always exceed TestFlight
           # builds regardless of each workflow's independent run counter.
-          BUILD_NUMBER=$(( $(date +%s) / 60 ))
+          BUILD_NUMBER=$(( 20000 + ($(date +%s) - 1783814400) / 60 ))
           echo "version_name=$VERSION" >> $GITHUB_OUTPUT
           echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
           echo "✅ Version: $VERSION+$BUILD_NUMBER"


### PR DESCRIPTION
All 5 store deploy workflows now derive build number from minutes-since-epoch (~29,731,294) instead of per-workflow run counters.

**Why:** Production Android used `run_number + 10000` (existing users on versionCode 10001) while beta used bare `run_number` (small). Play Console rejected the beta rollout: 'doesn't allow any existing users to upgrade'. Same latent bug existed in the iOS pair.

**Fix:** single monotonic source shared by all workflows — any new build always upgrades over any older one, on every track. Well under Play's 2.1B versionCode cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile release versioning across Android and iOS deployments.
  * Build numbers are now generated consistently over time, reducing conflicts between releases and improving upgrade compatibility.
  * Release and distribution metadata now reflects the updated build numbering for beta, production, tester, and TestFlight builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->