### PR TITLE
fix(android): google-services 4.4.2 for Crashlytics Gradle plugin v3

### DIFF
--- a/frontend/android/build.gradle.kts
+++ b/frontend/android/build.gradle.kts
@@ -16,7 +16,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.google.gms:google-services:4.4.0")
+        // google-services must be >= 4.4.1 for the Crashlytics Gradle plugin v3.
+        classpath("com.google.gms:google-services:4.4.2")
         classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.2")
     }
 }


### PR DESCRIPTION
Hotfix for the failed **Deploy Android to Play Store (Beta)** run after the last merge.

## Problem
`bundleRelease` failed:
> The Crashlytics Gradle plugin 3 requires Google-Services 4.4.1 and above.

The Crashlytics plugin (added in the observability commit) is v3, but the project pinned `google-services:4.4.0`.

## Fix
Bump `com.google.gms:google-services` 4.4.0 → **4.4.2** in `frontend/android/build.gradle.kts`.