### PR TITLE
fix(backend): stop config push leaking USE_MOCK to production

### DIFF
--- a/backend/supabase/config.toml
+++ b/backend/supabase/config.toml
@@ -370,7 +370,10 @@ deno_version = 1
 [edge_runtime.secrets]
 OPENAI_API_KEY = "env(OPENAI_API_KEY)"
 ANTHROPIC_API_KEY = "env(ANTHROPIC_API_KEY)"
-USE_MOCK = "env(USE_MOCK)"
+# USE_MOCK is intentionally NOT declared here. Declaring it made `supabase config
+# push` leak the dev machine's USE_MOCK=true to production (env() resolves from the
+# local shell), flipping the prod IAP validator into mock mode. Local dev still gets
+# USE_MOCK via `supabase functions serve --env-file` (scripts/run_local_server.sh).
 # Firebase Admin SDK credentials for FCM
 FIREBASE_PROJECT_ID = "env(FIREBASE_PROJECT_ID)"
 FIREBASE_PRIVATE_KEY = "env(FIREBASE_PRIVATE_KEY)"


### PR DESCRIPTION
## What
Removes \`USE_MOCK\` from \`config.toml [edge_runtime.secrets]\` so it can no longer be pushed to the production Supabase project.

## Why
Prod Google Play IAP purchases failed with:
\`[GOOGLE_PLAY] USE_MOCK=true is not allowed in production\`

Root cause (verified): \`config.toml:373\` declared \`USE_MOCK = "env(USE_MOCK)"\`. Running \`supabase config push\` from a dev machine — where \`.env\`/\`.env.local\` export \`USE_MOCK=true\` — resolved \`env(USE_MOCK)\` to \`true\` and pushed it to prod, flipping the IAP validator into mock mode.

The GH deploy workflow was innocent: its deploy log proves \`supabase secrets set --env-file\` pushes \`USE_MOCK=false\` on every run. The leak only happened via manual \`config push\`.

## Fix
- Remove \`USE_MOCK\` from \`config.toml [edge_runtime.secrets]\` (this PR).
- Prod secret already reset to \`false\` out-of-band.
- Local dev unaffected — \`USE_MOCK\` still loads via \`supabase functions serve --env-file\` (\`run_local_server.sh\`).

## Note
Merging triggers the prod backend deploy (touches \`backend/**\`), which re-asserts \`USE_MOCK=false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented local development settings from being unintentionally propagated to production during configuration deployment.
  * Local testing continues to support the `USE_MOCK` environment setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->