### PR TITLE
fix: startup crash (Hive box closed) + iOS Crashlytics dSYM upload

### DIFF
--- a/frontend/ios/fastlane/Fastfile
+++ b/frontend/ios/fastlane/Fastfile
@@ -26,6 +26,7 @@ platform :ios do
     api_key = asc_api_key
     install_signing(api_key)
     build_ios
+    upload_crashlytics_symbols
     upload_to_testflight(
       api_key: api_key,
       skip_waiting_for_build_processing: true,
@@ -38,6 +39,7 @@ platform :ios do
     api_key = asc_api_key
     install_signing(api_key)
     build_ios
+    upload_crashlytics_symbols
     upload_to_app_store(
       api_key: api_key,
       submit_for_review: false,
@@ -47,6 +49,28 @@ platform :ios do
       skip_screenshots: true,
       precheck_include_in_app_purchases: false
     )
+  end
+
+  desc "Backfill Crashlytics dSYMs for already-shipped builds (fixes 'Missing dSYM')"
+  desc "Usage: fastlane refresh_dsyms version:1.0.1 build:18472  (omit both for all)"
+  lane :refresh_dsyms do |options|
+    api_key = asc_api_key
+    download_dsyms(
+      api_key: api_key,
+      app_identifier: APP_IDENTIFIER,
+      version: options[:version] || "latest",
+      build_number: options[:build]
+    )
+    paths = lane_context[SharedValues::DSYM_PATHS] || []
+    UI.user_error!("Apple has no dSYMs for this build (bitcode disabled — nothing to backfill)") if paths.empty?
+    paths.each do |dsym|
+      upload_symbols_to_crashlytics(
+        dsym_path: dsym,
+        gsp_path: "Runner/GoogleService-Info.plist",
+        binary_path: "./Pods/FirebaseCrashlytics/upload-symbols"
+      )
+    end
+    clean_build_artifacts
   end
 
   # --- helpers -------------------------------------------------------------
@@ -100,6 +124,25 @@ platform :ios do
         signingStyle: "manual",
         provisioningProfiles: { APP_IDENTIFIER => MATCH_PROFILE }
       }
+    )
+  end
+
+  # Upload the archive's dSYMs to Firebase Crashlytics so iOS crashes get
+  # symbolicated. Neither upload_to_testflight nor upload_to_app_store does this
+  # — without it Crashlytics reports "Missing dSYM". Bitcode is disabled, so the
+  # archive dSYM UUID matches the shipped binary and is the authoritative source.
+  # The upload-symbols binary ships inside the FirebaseCrashlytics pod, which
+  # `flutter build ios` (pod install) restores before this lane runs.
+  def upload_crashlytics_symbols
+    dsym = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+    unless dsym && File.exist?(dsym)
+      UI.important("No dSYM produced by gym — skipping Crashlytics upload")
+      return
+    end
+    upload_symbols_to_crashlytics(
+      dsym_path: dsym,
+      gsp_path: "Runner/GoogleService-Info.plist",
+      binary_path: "./Pods/FirebaseCrashlytics/upload-symbols"
     )
   end
 end

--- a/frontend/lib/features/walkthrough/data/walkthrough_repository_impl.dart
+++ b/frontend/lib/features/walkthrough/data/walkthrough_repository_impl.dart
@@ -13,8 +13,14 @@ class WalkthroughRepositoryImpl implements WalkthroughRepository {
   WalkthroughRepositoryImpl({required SupabaseClient supabase})
       : _supabase = supabase;
 
-  Future<Box>? _boxFuture;
-  Future<Box> get _box => _boxFuture ??= Hive.openBox(_boxName);
+  // Never cache the Box (or its open-future): a global Hive.close() during
+  // logout (LocalStoreRepositoryImpl.clearAll) closes every box, and a cached
+  // reference would then throw "Box has already been closed". Re-resolve each
+  // access, reopening if needed — matches the codebase-wide resilient pattern.
+  Future<Box> get _box async {
+    if (Hive.isBoxOpen(_boxName)) return Hive.box(_boxName);
+    return Hive.openBox(_boxName);
+  }
 
   // ── Anonymous user detection ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Fixes two crash/observability issues surfaced by Firebase Crashlytics.

### 1. Android startup crash — `HiveError: Box has already been closed`
`WalkthroughRepositoryImpl` cached the Hive box open-future forever. Logout (`LocalStoreRepositoryImpl.clearAll`) calls `Hive.close()`, which closes **every** box globally. The cached future then returned a dead box, so `hasSeen` threw on next startup (triggered from `_triggerWalkthroughIfNeeded`).

**Fix:** `_box` getter now re-resolves each access — returns the open box if open, else reopens. Matches the codebase-wide resilient pattern (`saved_guides_sync_service`). Survives any global `Hive.close()`.

### 2. iOS "Missing dSYM" — unsymbolicated crashes
Archive produced dSYMs but no step uploaded them to Crashlytics (`upload_to_testflight`/`upload_to_app_store` ship only the IPA).

**Fix (`ios/fastlane/Fastfile`):**
- `upload_crashlytics_symbols` helper runs after `build_app` in `beta` + `release` lanes, feeding gym's archive dSYM to `upload_symbols_to_crashlytics`.
- `refresh_dsyms` lane for manual backfill of already-shipped builds.

## Notes
- Build 1.0.1(18472) dSYM cannot be backfilled (ephemeral CI archive + bitcode disabled). Future builds fixed.
- Local `Podfile.lock` lacks `FirebaseCrashlytics` (stale); CI regenerates fresh. Recommend `pod install` + commit to sync.

## Test
- `flutter analyze` clean; pre-commit hooks passed.
- Fastfile `ruby -c` syntax OK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved walkthrough data access after logout or app state changes to prevent errors caused by closed local storage.
  * Ensured walkthrough information remains available by reopening storage when necessary.

* **Crash Reporting**
  * Crash reports from beta and release builds now include improved diagnostic symbol data.
  * Added support for refreshing symbol data for previously shipped iOS builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->