### PR TITLE
chore(release): bump version to 1.0.2

### DIFF
--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,6 +1,6 @@
 name: disciplefy_bible_study
 description: AI-powered Bible study guide application following  methodology
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Summary
Bump app version `1.0.1+2` → `1.0.2+3`. 1.0.1 is live on Play Store, so next release needs a higher version.

- `version_name` (1.0.2) derives from pubspec in all deploy workflows.
- Android `versionCode` stays date-based/monotonic in CI (unaffected by the `+3`).
- Shared pubspec → also bumps iOS marketing version to 1.0.2.