### PR TITLE
feat(backend): default learning paths to non-sequential access

### DIFF
--- a/backend/supabase/migrations/20260724000001_default_non_sequential_access.sql
+++ b/backend/supabase/migrations/20260724000001_default_non_sequential_access.sql
@@ -1,0 +1,9 @@
+-- Make all learning paths non-sequential access by default
+-- New paths default to allow_non_sequential_access = true; existing paths updated to true
+
+ALTER TABLE learning_paths
+ALTER COLUMN allow_non_sequential_access SET DEFAULT true;
+
+UPDATE learning_paths
+SET allow_non_sequential_access = true
+WHERE allow_non_sequential_access = false;


### PR DESCRIPTION
## Summary
- Change `allow_non_sequential_access` column default from `false` to `true` on `learning_paths`
- Update all existing learning paths to allow non-sequential topic access

## Migration
`backend/supabase/migrations/20260724000001_default_non_sequential_access.sql`

Apply with `supabase db push --project-ref <ID>` after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New learning paths now allow learners to access content out of sequence by default.
  * Existing learning paths are updated to enable non-sequential access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->