### PR TITLE
fix: Discover tab infinite spinner + learning path navigation state loss

### DIFF
--- a/frontend/lib/features/community/presentation/screens/community_tab_screen.dart
+++ b/frontend/lib/features/community/presentation/screens/community_tab_screen.dart
@@ -261,24 +261,9 @@ class _CommunityTabContentState extends State<_CommunityTabContent> {
               onNext: _onNext,
               child: _PillTabs(
                 selected: _selectedTab,
-                onChanged: (i) {
-                  setState(() => _selectedTab = i);
-                  if (i == 1) {
-                    final discoverBloc = context.read<DiscoverBloc>();
-                    if (discoverBloc.state.status == DiscoverStatus.initial) {
-                      // Default the language filter to the user's current app
-                      // locale, bounded to the set of supported fellowship languages.
-                      final localeCode =
-                          AppLocalizations.of(context)!.locale.languageCode;
-                      final initialLang =
-                          ['en', 'hi', 'ml'].contains(localeCode)
-                              ? localeCode
-                              : null;
-                      discoverBloc
-                          .add(DiscoverLoadRequested(language: initialLang));
-                    }
-                  }
-                },
+                // _DiscoverTab loads itself on mount, so switching tabs from
+                // anywhere (pills or the empty-state CTA) always triggers a fetch.
+                onChanged: (i) => setState(() => _selectedTab = i),
                 tabs: [
                   Text(l10n.communityMyFellowships),
                   Row(
@@ -840,6 +825,24 @@ class _DiscoverTab extends StatefulWidget {
 class _DiscoverTabState extends State<_DiscoverTab> {
   final TextEditingController _searchController = TextEditingController();
   Timer? _debounce;
+
+  @override
+  void initState() {
+    super.initState();
+    // Load on mount so the tab is never stuck on the initial (spinner) state,
+    // regardless of how the user reached Discover.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final bloc = context.read<DiscoverBloc>();
+      if (bloc.state.status != DiscoverStatus.initial) return;
+      // Default the language filter to the user's current app locale, bounded
+      // to the set of supported fellowship languages.
+      final localeCode = AppLocalizations.of(context)!.locale.languageCode;
+      final initialLang =
+          ['en', 'hi', 'ml'].contains(localeCode) ? localeCode : null;
+      bloc.add(DiscoverLoadRequested(language: initialLang));
+    });
+  }
 
   @override
   void dispose() {

--- a/frontend/lib/features/home/presentation/pages/home_screen.dart
+++ b/frontend/lib/features/home/presentation/pages/home_screen.dart
@@ -1331,21 +1331,28 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
     });
   }
 
-  /// Navigate to learning path detail and refresh on return
-  void _navigateToLearningPath(String pathId) {
+  /// Navigate to learning path detail and refresh on return.
+  ///
+  /// Uses `push`, not `go`: the detail route is a sibling of the
+  /// `StatefulShellRoute` on the root navigator, so `go` unmatches the shell and
+  /// disposes every branch navigator — this screen would be rebuilt from
+  /// scratch on the way back. `push` keeps it mounted (URL still updates on
+  /// web), and the pop result says whether a refresh is actually needed.
+  Future<void> _navigateToLearningPath(String pathId) async {
     if (_isNavigating) return;
     _isNavigating = true;
 
     Logger.debug('[HOME] Navigating to learning path: $pathId');
 
-    // Use context.go() to properly update the browser URL
-    // Include source=home so back button returns to home screen
-    context.go('/learning-path/$pathId?source=home');
+    // Include source=home so a directly-opened deep link still has a sensible
+    // back target.
+    final progressChanged =
+        await context.push<bool>('/learning-path/$pathId?source=home');
 
-    // Reset navigation flag after navigation completes
-    Future.delayed(const Duration(milliseconds: 500), () {
-      _isNavigating = false;
-    });
+    _isNavigating = false;
+
+    if (!mounted || progressChanged != true) return;
+    sl<HomeBloc>().add(const LoadActiveLearningPath(forceRefresh: true));
   }
 
   Widget _buildTopicsErrorWidget(String error) {

--- a/frontend/lib/features/study_topics/presentation/pages/learning_path_detail_page.dart
+++ b/frontend/lib/features/study_topics/presentation/pages/learning_path_detail_page.dart
@@ -63,6 +63,12 @@ class _LearningPathDetailPageState extends State<LearningPathDetailPage> {
   LearningPathDownloadModel? _downloadModel;
   StreamSubscription<LearningPathDownloadModel>? _downloadSub;
 
+  /// Whether anything happened on this page that changed server-side progress
+  /// (enrollment, or a topic study session). Returned as the pop result so the
+  /// caller can refetch its own path list only when the data is actually stale
+  /// — an ordinary look-and-go-back leaves the caller's state untouched.
+  bool _progressChanged = false;
+
   @override
   void initState() {
     super.initState();
@@ -120,6 +126,7 @@ class _LearningPathDetailPageState extends State<LearningPathDetailPage> {
       context
           .read<LearningPathsBloc>()
           .add(EnrollInLearningPath(pathId: path.id));
+      _progressChanged = true;
     }
 
     // Get learning path study mode preference from Settings
@@ -339,6 +346,10 @@ class _LearningPathDetailPageState extends State<LearningPathDetailPage> {
     // Persist that this topic was accessed so future visits bypass the token check
     _markTopicAsAccessed(topic);
 
+    // A study session may have completed a topic, so the caller's cached path
+    // progress is now stale.
+    _progressChanged = true;
+
     // Refresh data when returning from the study guide - force refresh to bypass cache
     if (mounted) {
       Logger.debug(
@@ -371,8 +382,11 @@ class _LearningPathDetailPageState extends State<LearningPathDetailPage> {
   /// Handle back navigation - go to appropriate screen when can't pop
   void _handleBackNavigation() {
     if (context.canPop()) {
-      context.pop();
+      // Pop result tells the caller whether its path progress needs refetching.
+      context.pop(_progressChanged);
     } else {
+      // No stack below (deep link / shared URL opened this page directly), so
+      // there is no caller state to preserve — fall back to a full navigation.
       // Navigate based on source - default to home if source is 'home', otherwise study topics
       if (widget.source == 'home') {
         context.go(AppRoutes.home);
@@ -1041,6 +1055,7 @@ class _LearningPathDetailPageState extends State<LearningPathDetailPage> {
           context.read<LearningPathsBloc>().add(
                 EnrollInLearningPath(pathId: path.id),
               );
+          _progressChanged = true;
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: color,

--- a/frontend/lib/features/study_topics/presentation/pages/study_topics_screen.dart
+++ b/frontend/lib/features/study_topics/presentation/pages/study_topics_screen.dart
@@ -585,22 +585,37 @@ class _StudyTopicsScreenContentState extends State<_StudyTopicsScreenContent> {
     }
   }
 
-  /// Navigate to learning path detail page
-  void _navigateToLearningPath(LearningPath path) {
+  /// Navigate to learning path detail page.
+  ///
+  /// Uses `push`, not `go`: the detail route sits on the root navigator as a
+  /// sibling of the `StatefulShellRoute`, so `go` would unmatch the shell and
+  /// dispose every branch navigator — wiping this screen's scroll offset,
+  /// category pagination and loaded bloc state, forcing a full reload on the
+  /// way back. `push` keeps the shell mounted underneath (and still updates the
+  /// browser URL on web).
+  Future<void> _navigateToLearningPath(LearningPath path) async {
     if (_isNavigating) return;
     _isNavigating = true;
 
     Logger.debug(
         '[STUDY_TOPICS] Navigating to learning path: ${path.title} (ID: ${path.id})');
 
-    // Use context.go() to properly update the browser URL
-    // Include source=studyTopics so back button returns to study topics screen
-    context.go('/learning-path/${path.id}?source=studyTopics');
+    // Include source=studyTopics so a directly-opened deep link still has a
+    // sensible back target.
+    final progressChanged = await context
+        .push<bool>('/learning-path/${path.id}?source=studyTopics');
 
-    // Reset navigation flag after navigation completes
-    Future.delayed(const Duration(milliseconds: 500), () {
-      _isNavigating = false;
-    });
+    _isNavigating = false;
+
+    // Only refetch when the detail page reports progress actually changed;
+    // otherwise the preserved state stands and there is no visible reload.
+    if (!mounted || progressChanged != true) return;
+    context.read<LearningPathsBloc>()
+      ..add(LoadLearningPaths(
+        forceRefresh: true,
+        language: widget.currentLanguage,
+      ))
+      ..add(LoadPersonalizedPaths(language: widget.currentLanguage));
   }
 }
 


### PR DESCRIPTION
## Summary

- **Discover tab infinite loading** (Apple review rejection, Guideline 2.1(a)): `DiscoverLoadRequested` was dispatched only from the pill-tab `onChanged` callback. The My Fellowships empty-state "Discover" CTA switched tabs without dispatching, leaving the bloc at `DiscoverStatus.initial` — which renders as a spinner. Any account with zero fellowships hit this. `_DiscoverTab` now loads itself on mount.
- **Learning path navigation**: `context.go()` to the detail route unmatched the `StatefulShellRoute` and disposed every branch navigator, wiping scroll offset, pagination and bloc state. Switched to `context.push()`, with the detail page returning a `bool` pop result so callers refetch only when progress actually changed.

## Test plan

- `flutter analyze` passes (pre-commit hook).
- Manual: fresh account → Community → My Fellowships empty state → tap Discover CTA → list loads.
- Manual: Home / Study Topics → open a learning path → back → screen state preserved, no reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Discover content now loads automatically when opening the Discover tab using the app’s current language.
  - Learning-path details now report progress changes when returning to the previous screen.

- **Bug Fixes**
  - Returning from a learning path now refreshes progress only when enrollment or study completion changed.
  - Navigation between home, study topics, and learning-path details now preserves the previous screen’s state and avoids unnecessary resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->